### PR TITLE
Prevent github's API rate limiting from causing test failures

### DIFF
--- a/liberapay/elsewhere/__init__.py
+++ b/liberapay/elsewhere/__init__.py
@@ -112,10 +112,13 @@ class Platform(object):
         The response is returned, after checking its status code and ratelimit
         headers.
         """
+        url = self.api_url+path
         is_user_session = bool(sess)
         if not sess:
             sess = self.get_auth_session()
-        response = sess.get(self.api_url+path, **kw)
+            if self.name == 'github':
+                url += '?client_id=%s&client_secret=%s' % (self.api_key, self.api_secret)
+        response = sess.get(url, **kw)
 
         limit, remaining, reset = self.get_ratelimit_headers(response)
         if not is_user_session:

--- a/tests/py/fixtures/TestElsewhere.yml
+++ b/tests/py/fixtures/TestElsewhere.yml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/liberapay
+    uri: https://api.github.com:443/users/liberapay?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -36,7 +36,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/orgs/liberapay/public_members
+    uri: https://api.github.com:443/orgs/liberapay/public_members?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -90,7 +90,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/adhsjakdjsdkjsajdhksda
+    uri: https://api.github.com:443/users/adhsjakdjsdkjsajdhksda?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |

--- a/tests/py/fixtures/TestFriendFinder.yml
+++ b/tests/py/fixtures/TestFriendFinder.yml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/whit537/following
+    uri: https://api.github.com:443/users/whit537/following?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |

--- a/tests/py/fixtures/TestPages.yml
+++ b/tests/py/fixtures/TestPages.yml
@@ -73,7 +73,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/liberapay
+    uri: https://api.github.com:443/users/liberapay?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -106,7 +106,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/orgs/liberapay/public_members
+    uri: https://api.github.com:443/orgs/liberapay/public_members?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -136,7 +136,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/liberapay
+    uri: https://api.github.com:443/users/liberapay?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -169,7 +169,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/orgs/liberapay/public_members
+    uri: https://api.github.com:443/orgs/liberapay/public_members?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -269,7 +269,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/users/liberapay
+    uri: https://api.github.com:443/users/liberapay?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |
@@ -302,7 +302,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.github.com:443/orgs/liberapay/public_members
+    uri: https://api.github.com:443/orgs/liberapay/public_members?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
https://travis-ci.org/liberapay/liberapay.com/builds/78410058
https://github.com/gratipay/gratipay.com/issues/3266
https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications