### PR TITLE
Fix python3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ aspen-jinja2==0.4
 psycopg2==2.6.1
 postgres==2.2.1
 
+simplejson==3.8.1
+
 certifi==0.0.8
 pyasn1==0.1.3
 chardet==1.0.1


### PR DESCRIPTION
Fixes #87. Aspen uses `simplejson`, so bring it back and update it. I've removed the caches on Travis, that should prevent it from not detecting problems.