### PR TITLE
Team takes as maximums

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -301,7 +301,7 @@ class Payday(object):
                      WHERE t.team = team_id
                 );
                 IF (total_income = 0 OR total_takes = 0) THEN RETURN; END IF;
-                ratio := total_income / total_takes;
+                ratio := min(total_income / total_takes, 1::numeric);
 
                 OPEN our_takes;
                 FETCH our_takes INTO take;

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -90,12 +90,13 @@ class MixinTeam(object):
                            )
 
     def compute_max_this_week(self, member_id, last_week):
-        """2x the member's take last week, but at least 1 unit or a minimum
-        based on last week's median take.
+        """2x the member's take last week, or a minimum based on last week's
+        median take, or current income divided by the number of members if takes
+        were zero last week, or 1.
         """
         return max(
             last_week.get(member_id, 0) * 2,
-            last_week['_relative_min'],
+            last_week['_relative_min'] or self.receiving / self.nmembers,
             UNIT
         )
 

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -105,7 +105,7 @@ class MixinTeam(object):
         """
         assert self.kind == 'group'
 
-        if take and check_max:
+        if take and check_max and take > 1:
             last_week = self.get_takes_last_week()
             max_this_week = self.compute_max_this_week(member.id, last_week)
             if take > max_this_week:

--- a/www/about/teams.spt
+++ b/www/about/teams.spt
@@ -79,7 +79,9 @@ title = _("Teams")
     "The nominal takes are the raw numbers that the members input themselves, "
     "the actual takes are computed by the system: first it sums up the nominal "
     "takes, then it computes the percentage that each take represents, and "
-    "finally it applies those percentages to the available income."
+    "finally it applies those percentages to the available income. Nominal "
+    "takes also act as maximums: the actual takes are never higher than the "
+    "nominal ones, even if additional income is available."
 ) }}</p>
 
 <p>{{ _(

--- a/www/about/teams.spt
+++ b/www/about/teams.spt
@@ -87,9 +87,10 @@ title = _("Teams")
 <p>{{ _(
     "Nominal takes are throttled, they can't be raised higher than a maximum "
     "computed based on the nominal takes at the time of the previous payday. "
-    "The exact limit is the maximum of these three values: two times the "
-    "member's take in the previous payday, 70% of the median take in the "
-    "previous payday, and the number 1."
+    "The exact limit is the maximum of these three values: the number 1, two "
+    "times the member's take in the previous payday, 70% of the median take in "
+    "the previous payday, or if that number is zero, the current income "
+    "divided by the number of members."
 ) }}</p>
 
 <h3>{{ _("Removing team membership") }}</h3>


### PR DESCRIPTION
I didn't include this in #33 because I wasn't sure about it and I wanted to keep moving forward, but after further consideration I think it's a good idea: it stabilizes the income of team members, and allows us to see which teams have funding but lack contributors, and vice versa.