### PR TITLE
Fix overestimation of team takes

### DIFF
--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -186,7 +186,7 @@ class MixinTeam(object):
         nominal_takes = self.get_current_takes(cursor=cursor)
         balance = self.receiving
         total_takes = sum(t['amount'] for t in nominal_takes)
-        ratio = balance / total_takes if total_takes else 0
+        ratio = min(balance / total_takes, 1) if total_takes else 0
         for take in nominal_takes:
             nominal = take['nominal_take'] = take.pop('amount')
             actual = take['actual_amount'] = (nominal * ratio).quantize(CENT, rounding=ROUND_UP)

--- a/tests/py/test_take.py
+++ b/tests/py/test_take.py
@@ -84,6 +84,7 @@ class Tests(Harness):
         assert len(members) == 1
         assert members[alice.id]['username'] == 'alice'
         assert members[alice.id]['nominal_take'] == 42
+        assert members[alice.id]['actual_amount'] == 42
 
     def test_taking_and_receiving_are_updated_correctly(self):
         team = self.make_team()


### PR DESCRIPTION
This fixes half of #107, only the overestimate, not the rounding error (I don't see the latter as a high priority issue).