### PR TITLE
Fix charge test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ requests-oauthlib==0.4.2
 xmltodict==0.8.4
 
 lockfile==0.10.2
-mangopaysdk==1.8
+mangopaysdk==1.9
 
 raven==3.1.4
 

--- a/tests/py/fixtures/TestCharge.yml
+++ b/tests/py/fixtures/TestCharge.yml
@@ -1,22 +1,5 @@
 interactions:
 - request:
-    body: '{"AuthorId": "8301771", "Tag": "141066466", "CreditedWalletId": "8301772",
-      "CardId": "8301774", "SecureModeReturnURL": "http://localhost/", "Fees": {"Currency":
-      "EUR", "Amount": 202}, "CardType": "CB_VISA_MASTERCARD", "DebitedFunds": {"Currency":
-      "EUR", "Amount": 10202}}'
-    headers: {}
-    method: POST
-    uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/payins/card/direct/
-  response:
-    body: {string: !!python/unicode '{"Id":"8301780","Tag":"141066466","CreationDate":1440851689,"AuthorId":"8301771","CreditedUserId":"8301771","DebitedFunds":{"Currency":"EUR","Amount":10202},"CreditedFunds":{"Currency":"EUR","Amount":10000},"Fees":{"Currency":"EUR","Amount":202},"Status":"CREATED","ResultCode":null,"ResultMessage":null,"ExecutionDate":null,"Type":"PAYIN","Nature":"REGULAR","CreditedWalletId":"8301772","DebitedWalletId":null,"PaymentType":"CARD","ExecutionType":"DIRECT","SecureMode":"DEFAULT","CardId":"8301774","SecureModeReturnURL":"http://localhost/?transactionId=8301780","SecureModeRedirectURL":"https://api.sandbox.mangopay.com:443/Redirect/ACSWithValidation?token=265e083986ab4f4c8c120d3ff8b4525f","SecureModeNeeded":true}'}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['716']
-      content-type: [application/json; charset=utf-8]
-      expires: ['-1']
-      pragma: [no-cache]
-    status: {code: 200, message: OK}
-- request:
     body: '{"AuthorId": "8301771", "Tag": "141066467", "CreditedWalletId": "8301772",
       "CardId": "-1", "SecureModeReturnURL": "http://localhost/", "Fees": {"Currency":
       "EUR", "Amount": 37}, "CardType": "CB_VISA_MASTERCARD", "DebitedFunds": {"Currency":

--- a/tests/py/test_billing_exchanges.py
+++ b/tests/py/test_billing_exchanges.py
@@ -102,7 +102,12 @@ class TestCharge(MangopayHarness):
             assert janet.withdrawable_balance == 0
             self.db.self_check()
 
-    def test_charge_100(self):
+    @mock.patch('mangopaysdk.tools.apipayins.ApiPayIns.Create')
+    def test_charge_100(self, Create):
+        def add_redirect_url_to_payin(payin):
+            payin.ExecutionDetails.SecureModeRedirectURL = 'some url'
+            return payin
+        Create.side_effect = add_redirect_url_to_payin
         with self.assertRaises(Response) as cm:
             charge(self.db, self.janet, D('100'), 'http://localhost/')
         r = cm.exception


### PR DESCRIPTION
That test has been failing randomly for a while because the Mangopay API doesn't always return what we expect. This PR solves the problem by removing the call to Mangopay.

While I was at it I also upgraded the mangopaysdk library to the latest version.