### PR TITLE
Improve payday tests

### DIFF
--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -105,6 +105,9 @@ class MixinTeam(object):
         """
         assert self.kind == 'group'
 
+        if not isinstance(take, (None.__class__, Decimal)):
+            take = Decimal(take)
+
         if take and check_max and take > 1:
             last_week = self.get_takes_last_week()
             max_this_week = self.compute_max_this_week(member.id, last_week)

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -284,7 +284,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         team = self.make_participant('team', kind='group')
         self.janet.set_tip_to(team, '0.25')
         team.add_member(self.david)
-        team.set_take_for(self.david, '0.23', team)
+        team.set_take_for(self.david, D('0.23'), team)
         self.client.POST('/homer/emails/notifications.json', auth_as=self.homer,
                          data={'fields': 'income', 'income': ''}, xhr=True)
         Payday.start().run()

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -288,9 +288,15 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         self.client.POST('/homer/emails/notifications.json', auth_as=self.homer,
                          data={'fields': 'income', 'income': ''}, xhr=True)
         Payday.start().run()
+        david = self.david.refetch()
+        assert david.balance == D('4.73')
+        janet = self.janet.refetch()
+        assert janet.balance == D('1.77')
+        assert janet.giving == D('0.23')
         emails = self.get_emails()
         assert len(emails) == 2
         assert emails[0]['to'][0]['email'] == self.david.email
-        assert 'received' in emails[0]['subject']
+        assert '4.73' in emails[0]['subject']
         assert emails[1]['to'][0]['email'] == self.janet.email
         assert 'top up' in emails[1]['subject']
+        assert '1.77' in emails[1]['text']


### PR DESCRIPTION
In https://github.com/liberapay/salon/issues/10#issuecomment-182395318 I noted that payday#1 transferred less money than expected, so I started looking for possible bugs, and it seemed like team takes weren't working perfectly, but in fact it was the test that was broken. This PR fixes it and adds an additional test for team takes.