### PR TITLE
Help users pay lower card fees

### DIFF
--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -15,8 +15,8 @@ from mangopaysdk.types.money import Money
 
 from liberapay.billing import mangoapi, PayInExecutionDetailsDirect, PayInPaymentDetailsCard, PayOutPaymentDetailsBankWire
 from liberapay.constants import (
-    FEE_CHARGE_FIX, FEE_CHARGE_VAR, FEE_CREDIT, FEE_CREDIT_OUTSIDE_SEPA,
-    MINIMUM_CHARGE, QUARANTINE, SEPA_ZONE,
+    CHARGE_MIN, CHARGE_TARGET, FEE_CHARGE_FIX, FEE_CHARGE_VAR,
+    FEE_CREDIT, FEE_CREDIT_OUTSIDE_SEPA, QUARANTINE, SEPA_ZONE,
 )
 from liberapay.exceptions import (
     LazyResponse, NegativeBalance, NotEnoughWithdrawableMoney,
@@ -35,8 +35,8 @@ def upcharge(amount):
     """
     typecheck(amount, Decimal)
 
-    if amount < MINIMUM_CHARGE:
-        amount = MINIMUM_CHARGE
+    if amount < CHARGE_MIN:
+        amount = CHARGE_MIN
 
     # a = c - vf * c - ff  =>  c = (a + ff) / (1 - vf)
     # a = amount ; c = charge amount ; ff = fixed fee ; vf = variable fee
@@ -47,9 +47,12 @@ def upcharge(amount):
     return charge_amount, fee
 
 
-t = upcharge(MINIMUM_CHARGE)
-assert t == (Decimal('15.46'), Decimal('0.46')), upcharge(MINIMUM_CHARGE)
+t = upcharge(CHARGE_MIN)
+assert t == (Decimal('15.46'), Decimal('0.46')), t
 assert t[1] / t[0] < Decimal('0.03')  # less than 3% fee
+t = upcharge(CHARGE_TARGET)
+assert t == (Decimal('93.87'), Decimal('1.87')), t
+assert t[1] / t[0] < Decimal('0.02')  # less than 2% fee
 del t
 
 

--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -46,7 +46,11 @@ def upcharge(amount):
 
     return charge_amount, fee
 
-assert upcharge(MINIMUM_CHARGE) == (Decimal('10.37'), Decimal('0.37')), upcharge(MINIMUM_CHARGE)
+
+t = upcharge(MINIMUM_CHARGE)
+assert t == (Decimal('15.46'), Decimal('0.46')), upcharge(MINIMUM_CHARGE)
+assert t[1] / t[0] < Decimal('0.03')  # less than 3% fee
+del t
 
 
 def skim_credit(amount, ba):

--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -15,7 +15,7 @@ from mangopaysdk.types.money import Money
 
 from liberapay.billing import mangoapi, PayInExecutionDetailsDirect, PayInPaymentDetailsCard, PayOutPaymentDetailsBankWire
 from liberapay.constants import (
-    CHARGE_MIN, CHARGE_TARGET, FEE_CHARGE_FIX, FEE_CHARGE_VAR,
+    CHARGE_MIN, FEE_CHARGE_FIX, FEE_CHARGE_VAR,
     FEE_CREDIT, FEE_CREDIT_OUTSIDE_SEPA, QUARANTINE, SEPA_ZONE,
 )
 from liberapay.exceptions import (
@@ -45,15 +45,6 @@ def upcharge(amount):
     fee = charge_amount - amount
 
     return charge_amount, fee
-
-
-t = upcharge(CHARGE_MIN)
-assert t == (Decimal('15.46'), Decimal('0.46')), t
-assert t[1] / t[0] < Decimal('0.03')  # less than 3% fee
-t = upcharge(CHARGE_TARGET)
-assert t == (Decimal('93.87'), Decimal('1.87')), t
-assert t[1] / t[0] < Decimal('0.02')  # less than 2% fee
-del t
 
 
 def skim_credit(amount, ba):

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -1,3 +1,4 @@
+# coding: utf8
 from __future__ import print_function, unicode_literals
 
 from aspen.utils import utc
@@ -55,7 +56,7 @@ LAUNCH_TIME = datetime(2016, 2, 3, 12, 50, 0, 0, utc)
 MAX_TIP = Decimal('100.00')
 MIN_TIP = Decimal('0.01')
 
-MINIMUM_CHARGE = Decimal("10.00")
+MINIMUM_CHARGE = Decimal("15.00")  # fee ≈ 3%
 
 QUARANTINE = timedelta(weeks=4)
 

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -32,7 +32,12 @@ ASCII_ALLOWED_IN_USERNAME = set("0123456789"
 
 AVATAR_QUERY = '?s=160&default=retro'
 
+BALANCE_MAX = Decimal("1000")
+
 BIRTHDAY = date(2015, 5, 22)
+
+CHARGE_MIN = Decimal("15.00")  # fee ≈ 3%
+CHARGE_TARGET = Decimal("92.00")  # fee ≈ 2%
 
 EMAIL_VERIFICATION_TIMEOUT = timedelta(hours=24)
 EMAIL_RE = re.compile(r'^[^@]+@[^@]+\.[^@]+$')
@@ -55,8 +60,6 @@ LAUNCH_TIME = datetime(2016, 2, 3, 12, 50, 0, 0, utc)
 
 MAX_TIP = Decimal('100.00')
 MIN_TIP = Decimal('0.01')
-
-MINIMUM_CHARGE = Decimal("15.00")  # fee ≈ 3%
 
 QUARANTINE = timedelta(weeks=4)
 

--- a/www/%username/wallet/payin/%back_to.spt
+++ b/www/%username/wallet/payin/%back_to.spt
@@ -43,10 +43,16 @@ donations = participant.get_giving_for_profile()[1]
 weekly = donations - participant.receiving
 if weekly > 0:
     funded = participant.balance // weekly
-    min_weeks = max(constants.MINIMUM_CHARGE // weekly, 1)
+    min_weeks = max(constants.CHARGE_MIN // weekly, 1)
+    max_weeks = min(
+        max(constants.CHARGE_TARGET // weekly, 52),
+        constants.BALANCE_MAX // weekly
+    )
+    weeks_list = sorted(set((min_weeks, 4, 13, 26, 39, max_weeks)))
+    weeks_list = [w for w in weeks_list if w >= min_weeks and w <= max_weeks]
 
 if request.method == 'POST':
-    if weekly <= 0 or funded >= 52 or participant.balance > 1500:
+    if weekly <= 0 or funded >= 52 or participant.balance > constants.BALANCE_MAX:
         raise Response(403, _(
             "Why are you trying to put more money into your wallet? "
             "Please contact support@liberapay.com if you have a legitimate reason."
@@ -121,10 +127,15 @@ title = _("Add money")
     <fieldset id="amount" class="form-inline">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <select class="form-control" name="amount">
-        % for weeks in sorted(set((min_weeks, 4, 13, 26, 39, 52)))
-            % if weeks >= min_weeks
-            <option value="{{ weekly * weeks }}">{{ ngettext("{0} ({n} week)", "{0} ({n} weeks)", weeks, Money(upcharge(weekly * weeks)[0], 'EUR')) }}</option>
-            % endif
+        % for weeks in weeks_list
+            % set amount = weekly * weeks
+            % set charge_amount, fees = upcharge(amount)
+            <option value="{{ amount }}">{{ _(
+                "{0} ({2}% fee included)",
+                Money(charge_amount, 'EUR'),
+                Money(amount, 'EUR'),
+                (fees / charge_amount * 100).quantize(constants.CHARGE_MIN),
+            ) }}</option>
         % endfor
         </select>
     </fieldset>


### PR DESCRIPTION
We've recently started saying on the homepage that Liberapay is "economical", but we've been doing a bad job at helping users pay less in credit card fees. This PR improves the situation a little, by raising the minimum charge from €10 to €15 (which lowers the fee to just below 3%), and by proposing to users who don't give much yet to add more money from the start so that they'll pay less than 2% in fees.

The next steps in lowering fees are #45 (flat 0.5% fee) and #54 (if we know the total amount the user wants to give instead of only the amount they're currently giving, then we can propose higher charge amounts that result in lower fees).