### PR TITLE
Fix computation of payment processing fees

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -37,8 +37,8 @@ BALANCE_MAX = Decimal("1000")
 
 BIRTHDAY = date(2015, 5, 22)
 
-CHARGE_MIN = Decimal("15.00")  # fee ≈ 3%
-CHARGE_TARGET = Decimal("92.00")  # fee ≈ 2%
+CHARGE_MIN = Decimal("15.00")  # fee ≈ 3.5%
+CHARGE_TARGET = Decimal("92.00")  # fee ≈ 2.33%
 
 ELSEWHERE_ACTIONS = {'connect', 'lock', 'unlock'}
 
@@ -52,6 +52,7 @@ FEE_CHARGE_FIX = Decimal('0.18')  # 0.18 euros
 FEE_CHARGE_VAR = Decimal('0.018')  # 1.8%
 FEE_CREDIT = 0
 FEE_CREDIT_OUTSIDE_SEPA = Decimal("2.5")
+FEE_VAT = Decimal('0.17')  # 17% (Luxembourg rate)
 
 JINJA_ENV_COMMON = dict(
     trim_blocks=True, lstrip_blocks=True,

--- a/liberapay/testing/__init__.py
+++ b/liberapay/testing/__init__.py
@@ -217,7 +217,7 @@ class Harness(unittest.TestCase):
         return self.db.one("SELECT * FROM paydays", back_as=dict)
 
 
-    def make_exchange(self, route, amount, fee, participant, status='succeeded', error=''):
+    def make_exchange(self, route, amount, fee, participant, status='succeeded', error='', vat=0):
         if not isinstance(route, ExchangeRoute):
             network = route
             route = ExchangeRoute.from_network(participant, network)
@@ -225,7 +225,7 @@ class Harness(unittest.TestCase):
                 from .mangopay import MangopayHarness
                 route = ExchangeRoute.insert(participant, network, MangopayHarness.card_id)
                 assert route
-        e_id = record_exchange(self.db, route, amount, fee, participant, 'pre')
+        e_id = record_exchange(self.db, route, amount, fee, vat, participant, 'pre')
         record_exchange_result(self.db, e_id, status, error, participant)
         return e_id
 

--- a/liberapay/utils/fake_data.py
+++ b/liberapay/utils/fake_data.py
@@ -130,7 +130,7 @@ def fake_transfer(db, tipper, tippee, amount, timestamp):
     return t
 
 
-def fake_exchange(db, participant, amount, fee, timestamp):
+def fake_exchange(db, participant, amount, fee, vat, timestamp):
     route = ExchangeRoute.from_network(participant, 'mango-cc')
     if not route:
         route = _fake_thing(
@@ -149,6 +149,7 @@ def fake_exchange(db, participant, amount, fee, timestamp):
         participant=participant.id,
         amount=amount,
         fee=fee,
+        vat=vat,
         status='pre',
         route=route.id,
     )
@@ -211,7 +212,7 @@ def populate_db(website, num_participants=100, num_tips=200, num_teams=5, num_tr
         sys.stdout.flush()
         amount = fake_tip_amount()
         ts = faker.date_time_this_year()
-        fake_exchange(db, tipper, amount, 0, (ts - datetime.timedelta(days=1)))
+        fake_exchange(db, tipper, amount, 0, 0, (ts - datetime.timedelta(days=1)))
         transfers.append(fake_transfer(db, tipper, tippee, amount, ts))
     print("")
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+BEGIN;
+    ALTER TABLE exchanges ADD COLUMN vat numeric(35,2) NOT NULL DEFAULT 0;
+    ALTER TABLE exchanges ALTER COLUMN vat DROP DEFAULT;
+END;

--- a/tests/py/test_callbacks.py
+++ b/tests/py/test_callbacks.py
@@ -22,7 +22,7 @@ class TestMangopayCallbacks(EmailHarness, MangopayHarness):
             status_up = status.upper()
             error = 'FOO' if status == 'failed' else None
             self.make_exchange('mango-cc', 10, 0, homer)
-            e_id = record_exchange(self.db, ba, -10, 0, homer, 'pre')
+            e_id = record_exchange(self.db, ba, -10, 0, 0, homer, 'pre')
             assert homer.balance == 0
             homer.close(None)
             assert homer.status == 'closed'

--- a/www/%username/wallet/payin/%back_to.spt
+++ b/www/%username/wallet/payin/%back_to.spt
@@ -118,8 +118,8 @@ title = _("Add money")
     <p>{{ _(
         "Adding money to Liberapay via credit/debit card (currently the only "
         "supported payment method) incurs a fee of {0}% + {1}.",
-        constants.FEE_CHARGE_VAR * 100,
-        Money(constants.FEE_CHARGE_FIX, 'EUR'),
+        constants.FEE_CHARGE_VAR * (constants.FEE_VAT + 1) * 100,
+        Money(constants.FEE_CHARGE_FIX * (constants.FEE_VAT + 1), 'EUR'),
     ) }}</p>
 
     <h3>{{ _("Amount") }}</h3>
@@ -129,7 +129,7 @@ title = _("Add money")
         <select class="form-control" name="amount">
         % for weeks in weeks_list
             % set amount = weekly * weeks
-            % set charge_amount, fees = upcharge(amount)
+            % set charge_amount, fees, vat = upcharge(amount)
             <option value="{{ amount }}">{{ _(
                 "{0} ({2}% fee included)",
                 Money(charge_amount, 'EUR'),

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -91,7 +91,7 @@ title = _("Withdraw money")
     <p>{{ _(
         "Withdrawing money to a SEPA bank account is free, transfers to other "
         "countries cost {0} per transfer.",
-        Money(constants.FEE_CREDIT_OUTSIDE_SEPA, 'EUR'),
+        Money(constants.FEE_CREDIT_OUTSIDE_SEPA * (constants.FEE_VAT + 1), 'EUR'),
     ) }}</p>
 
     <h3>{{ _("Amount") }}</h3>

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -62,12 +62,12 @@ title = _("Frequently Asked Questions")
     <dd>{{ _(
         "Adding money to Liberapay via credit/debit card (currently the only "
         "supported payment method) incurs a fee of {0}% + {1}.",
-        constants.FEE_CHARGE_VAR * 100,
-        Money(constants.FEE_CHARGE_FIX, 'EUR'),
+        constants.FEE_CHARGE_VAR * (constants.FEE_VAT + 1) * 100,
+        Money(constants.FEE_CHARGE_FIX * (constants.FEE_VAT + 1), 'EUR'),
     ) + " " + _(
         "Withdrawing money to a SEPA bank account is free, transfers to other "
         "countries cost {0} per transfer.",
-        Money(constants.FEE_CREDIT_OUTSIDE_SEPA, 'EUR'),
+        Money(constants.FEE_CREDIT_OUTSIDE_SEPA * (constants.FEE_VAT + 1), 'EUR'),
     ) }}</dd>
 
 

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -83,7 +83,7 @@ title = _("Frequently Asked Questions")
         "The minimum you can give any user is {0}. To minimize processing fees, "
         "we charge your credit card at least {1} at a time (the money is stored "
         "in your Liberapay wallet and transferred to others during Payday)."
-        , Money(constants.MIN_TIP, 'EUR'), Money(10, 'EUR')
+        , Money(constants.MIN_TIP, 'EUR'), Money(constants.CHARGE_MIN, 'EUR')
     ) }}</dd>
 
     <dd>{{ _(


### PR DESCRIPTION
We just received our first invoice from Mangopay, and it was a bad surprise: we owe them €0.75. Obviously the amount isn't a problem, the real issue is the revelation that we need to upcharge users to pay 17% VAT on Mangopay's fee (they never told us about that).

That means our actual credit card fees are 2.11% + €0.21, not 1.8% + €0.18. :-(

Undercharging users is a big deal, so I've already deployed this in production. This PR is to inform everyone following this repo of the problem, and to give an opportunity to review the changes.