### PR TITLE
Tweak "recent activity" section of homepage

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -508,10 +508,6 @@ section.community-sidebar {
 
 p.event {
     margin-bottom: 0.5em;
-    .avatar {
-        height: 20px;
-        margin: -4px 2px -2px 0;
-    }
 }
 
 .buttons .btn {

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -33,6 +33,7 @@ recent_events = query_cache.all("""
                  , json_build_object() AS args
               FROM communities c
               JOIN participants p ON p.id = c.creator
+             WHERE c.nmembers > 0
 
             UNION ALL
 

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -35,6 +35,15 @@ recent_events = query_cache.all("""
                  , json_build_object('community_name', c.name) AS args
               FROM communities c
               JOIN participants p ON p.id = c.creator
+
+            UNION ALL
+
+            SELECT 'payday' AS event
+                 , NULL AS avatar_url
+                 , NULL AS username
+                 , p.ts_end AS ts
+                 , json_build_object('transfer_volume', p.transfer_volume) AS args
+              FROM paydays p
            ) foo
   ORDER BY ts DESC
      LIMIT 20
@@ -229,6 +238,13 @@ recent_events = query_cache.all("""
                         ('<a href="/for/{0}/">{0}</a>'|safe).format(e.args.community_name),
                         to_age(e.ts),
                     ) }}
+                % elif e.event == 'payday'
+                    {{ glyphicon('refresh') }}
+                    <span>{{ _(
+                        'Payday was run {0} ago and transferred {1}.',
+                        to_age(e.ts),
+                        Money(e.args.transfer_volume, 'EUR'),
+                    ) }}</span>
                 % endif
             </p>
         % endfor

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -18,8 +18,6 @@ recent_events = query_cache.all("""
     SELECT *
       FROM (
             SELECT 'new_user' AS event
-                 , avatar_url
-                 , username
                  , join_time AS ts
                  , json_build_object() AS args
               FROM participants
@@ -29,18 +27,14 @@ recent_events = query_cache.all("""
             UNION ALL
 
             SELECT 'new_community' AS event
-                 , p.avatar_url
-                 , p.username
                  , c.ctime AS ts
-                 , json_build_object('community_name', c.name) AS args
+                 , json_build_object() AS args
               FROM communities c
               JOIN participants p ON p.id = c.creator
 
             UNION ALL
 
             SELECT 'payday' AS event
-                 , NULL AS avatar_url
-                 , NULL AS username
                  , p.ts_end AS ts
                  , json_build_object('transfer_volume', p.transfer_volume) AS args
               FROM paydays p
@@ -222,22 +216,19 @@ recent_events = query_cache.all("""
             % if loop.index == 11
                 </div><div class="col-md-6">
             % endif
-            % set user_link
-                <a href="/{{ e.username }}/">
-                    {{ avatar_img(e) }}
-                    {{ e.username }}
-                </a>
-            % endset
             <p class="event">
                 % if e.event == 'new_user'
-                    {{ _('{0} joined Liberapay {1} ago.', user_link|safe, to_age(e.ts)) }}
+                    {{ glyphicon('user') }}
+                    <span>{{ _(
+                        'Someone joined Liberapay {0} ago.',
+                        to_age(e.ts)
+                    ) }}</span>
                 % elif e.event == 'new_community'
-                    {{ _(
-                        '{0} created the {1} community {2} ago.',
-                        user_link|safe,
-                        ('<a href="/for/{0}/">{0}</a>'|safe).format(e.args.community_name),
+                    {{ glyphicon('plus') }}
+                    <span>{{ _(
+                        'Someone created a new community {0} ago.',
                         to_age(e.ts),
-                    ) }}
+                    ) }}</span>
                 % elif e.event == 'payday'
                     {{ glyphicon('refresh') }}
                     <span>{{ _(

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -1,5 +1,7 @@
 # coding: utf8
 
+from math import ceil
+
 from liberapay.models.participant import Participant
 from liberapay.utils.query_cache import QueryCache
 
@@ -40,7 +42,7 @@ recent_events = query_cache.all("""
               FROM paydays p
            ) foo
   ORDER BY ts DESC
-     LIMIT 20
+     LIMIT 16
 """)
 
 [---]
@@ -213,7 +215,7 @@ recent_events = query_cache.all("""
     </div>
     <div class="col-md-6">
         % for e in recent_events
-            % if loop.index == 11
+            % if loop.index == ceil(len(recent_events) / 2.0) + 1
                 </div><div class="col-md-6">
             % endif
             <p class="event">

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -21,7 +21,7 @@ recent_events = query_cache.all("""
       FROM (
             SELECT 'new_user' AS event
                  , join_time AS ts
-                 , json_build_object() AS args
+                 , json_build_object('kind', kind) AS args
               FROM participants
              WHERE status = 'active'
                AND kind <> 'community'
@@ -221,13 +221,21 @@ recent_events = query_cache.all("""
             % endif
             <p class="event">
                 % if e.event == 'new_user'
+                    % if e.args.kind == 'group'
+                    {{ glyphicon('plus') }}
+                    <span>{{ _(
+                        'Someone created a new team {0} ago.',
+                        to_age(e.ts)
+                    ) }}</span>
+                    % else
                     {{ glyphicon('user') }}
                     <span>{{ _(
                         'Someone joined Liberapay {0} ago.',
                         to_age(e.ts)
                     ) }}</span>
+                    % endif
                 % elif e.event == 'new_community'
-                    {{ glyphicon('plus') }}
+                    {{ glyphicon('asterisk') }}
                     <span>{{ _(
                         'Someone created a new community {0} ago.',
                         to_age(e.ts),

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -216,7 +216,7 @@ recent_events = query_cache.all("""
     <div class="col-md-6">
         % for e in recent_events
             % if loop.index == ceil(len(recent_events) / 2.0) + 1
-                </div><div class="col-md-6">
+                </div><div class="col-md-6 visible-md-block visible-lg-block">
             % endif
             <p class="event">
                 % if e.event == 'new_user'


### PR DESCRIPTION
That section isn't meant to be a discovery mechanism, it's just to show that the site is alive. New users and empty communities aren't what we want to showcase on the homepage, especially now that provocateurs have started to use Liberapay. So, this PR anonymizes the data in that section.

I'm not saying it's perfect, in fact we should probably drop the linear format and show aggregates instead, like "X users have signed up in the last 7 days", but we can do that later.