### PR TITLE
Fix handling of payment failures

### DIFF
--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -190,7 +190,7 @@ def charge(db, participant, amount, return_url):
     if payin.ExecutionDetails.SecureModeRedirectURL:
         raise Response(302, headers={'Location': payin.ExecutionDetails.SecureModeRedirectURL})
 
-    return record_exchange_result(db, e_id, 'succeeded', None, participant)
+    return record_exchange_result(db, e_id, payin.Status.lower(), repr_error(payin), participant)
 
 
 def record_exchange(db, route, amount, fee, vat, participant, status, error=None):

--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -144,8 +144,8 @@ def payout(db, participant, amount, ignore_high_fee=False):
     payout.Tag = str(e_id)
     try:
         test_hook()
-        mangoapi.payOuts.Create(payout)
-        return record_exchange_result(db, e_id, 'created', None, participant)
+        payout = mangoapi.payOuts.Create(payout)
+        return record_exchange_result(db, e_id, payout.Status.lower(), repr_error(payout), participant)
     except Exception as e:
         error = repr_exception(e)
         return record_exchange_result(db, e_id, 'failed', error, participant)

--- a/tests/py/fixtures/TestPayouts.yml
+++ b/tests/py/fixtures/TestPayouts.yml
@@ -1,5 +1,38 @@
 interactions:
 - request:
+    body: '{"AuthorId": "11763370", "Tag": "658989071", "CreditedWalletId": "11763371",
+      "CardId": "11763373", "SecureModeReturnURL": "http://localhost/", "Fees": {"Currency":
+      "EUR", "Amount": 121}, "CardType": "CB_VISA_MASTERCARD", "DebitedFunds": {"Currency":
+      "EUR", "Amount": 4721}}'
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/payins/card/direct/
+  response:
+    body: {string: !!python/unicode '{"Id":"11763433","Tag":"658989071","CreationDate":1459978297,"AuthorId":"11763370","CreditedUserId":"11763370","DebitedFunds":{"Currency":"EUR","Amount":4721},"CreditedFunds":{"Currency":"EUR","Amount":4600},"Fees":{"Currency":"EUR","Amount":121},"Status":"SUCCEEDED","ResultCode":"000000","ResultMessage":"Success","ExecutionDate":1459978298,"Type":"PAYIN","Nature":"REGULAR","CreditedWalletId":"11763371","DebitedWalletId":null,"PaymentType":"CARD","ExecutionType":"DIRECT","SecureMode":"DEFAULT","CardId":"11763373","SecureModeReturnURL":null,"SecureModeRedirectURL":null,"SecureModeNeeded":false}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['600']
+      content-type: [application/json; charset=utf-8]
+      expires: ['-1']
+      pragma: [no-cache]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"CreditedWalletID": "11763375", "CreditedUserId": "8301775", "DebitedFunds":
+      {"Currency": "EUR", "Amount": 4600}, "AuthorId": "11763370", "Tag": "658989071",
+      "Fees": {"Currency": "EUR", "Amount": 0}, "DebitedWalletID": "11763371"}'
+    headers: {}
+    method: POST
+    uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/transfers
+  response:
+    body: {string: !!python/unicode '{"Id":"11763435","Tag":"658989071","CreationDate":1459978299,"AuthorId":"11763370","CreditedUserId":"8301775","DebitedFunds":{"Currency":"EUR","Amount":4600},"CreditedFunds":{"Currency":"EUR","Amount":4600},"Fees":{"Currency":"EUR","Amount":0},"Status":"SUCCEEDED","ResultCode":"000000","ResultMessage":"Success","ExecutionDate":1459978300,"Type":"TRANSFER","Nature":"REGULAR","DebitedWalletId":"11763371","CreditedWalletId":"11763375"}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['437']
+      content-type: [application/json; charset=utf-8]
+      expires: ['-1']
+      pragma: [no-cache]
+    status: {code: 200, message: OK}
+- request:
     body: null
     headers: {}
     method: GET
@@ -7,27 +40,26 @@ interactions:
   response:
     body: {string: !!python/unicode '{"OwnerAddress":{"AddressLine1":"Somewhere","AddressLine2":null,"City":"The
         City of Light","Region":null,"PostalCode":"75001","Country":"FR"},"IBAN":"FR1420041010050500013M02606","BIC":"PSSTFRPPLIL","UserId":"8301775","OwnerName":"Homer
-        Jay","Type":"IBAN","Id":"8301777","Tag":null,"CreationDate":1440851680}'}
+        Jay","Type":"IBAN","Id":"8301777","Tag":null,"CreationDate":1459977889}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['308']
+      content-length: ['310']
       content-type: [application/json; charset=utf-8]
       expires: ['-1']
       pragma: [no-cache]
     status: {code: 200, message: OK}
 - request:
     body: '{"BankWireRef": "658989072", "DebitedFunds": {"Currency": "EUR", "Amount":
-      100}, "BankAccountId": "8301777", "AuthorId": "8301775", "Tag": "658989072",
-      "Fees": {"Currency": "EUR", "Amount": 0}, "DebitedWalletId": "8301776"}'
+      3000}, "BankAccountId": "8301777", "AuthorId": "8301775", "Tag": "658989072",
+      "Fees": {"Currency": "EUR", "Amount": 0}, "DebitedWalletId": "11763375"}'
     headers: {}
     method: POST
     uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/payouts/bankwire/
   response:
-    body: {string: !!python/unicode '{"Id":"8301778","Tag":"658989072","CreationDate":1440851686,"AuthorId":"8301775","CreditedUserId":null,"DebitedFunds":{"Currency":"EUR","Amount":100},"CreditedFunds":{"Currency":"EUR","Amount":100},"Fees":{"Currency":"EUR","Amount":0},"Status":"FAILED","ResultCode":"001001","ResultMessage":"Unsufficient
-        wallet balance","ExecutionDate":null,"Type":"PAYOUT","Nature":"REGULAR","CreditedWalletId":null,"DebitedWalletId":"8301776","PaymentType":"BANK_WIRE","BankAccountId":"8301777","BankWireRef":"658989072"}'}
+    body: {string: !!python/unicode '{"Id":"11763437","Tag":"658989072","CreationDate":1459978301,"AuthorId":"8301775","CreditedUserId":null,"DebitedFunds":{"Currency":"EUR","Amount":3000},"CreditedFunds":{"Currency":"EUR","Amount":3000},"Fees":{"Currency":"EUR","Amount":0},"Status":"CREATED","ResultCode":null,"ResultMessage":null,"ExecutionDate":null,"Type":"PAYOUT","Nature":"REGULAR","CreditedWalletId":null,"DebitedWalletId":"11763375","PaymentType":"BANK_WIRE","BankAccountId":"8301777","BankWireRef":"658989072"}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['507']
+      content-length: ['485']
       content-type: [application/json; charset=utf-8]
       expires: ['-1']
       pragma: [no-cache]
@@ -40,10 +72,10 @@ interactions:
   response:
     body: {string: !!python/unicode '{"OwnerAddress":{"AddressLine1":"Somewhere","AddressLine2":null,"City":"The
         City of Light","Region":null,"PostalCode":"75001","Country":"FR"},"IBAN":"FR1420041010050500013M02606","BIC":"PSSTFRPPLIL","UserId":"8301775","OwnerName":"Homer
-        Jay","Type":"IBAN","Id":"8301777","Tag":null,"CreationDate":1440851680}'}
+        Jay","Type":"IBAN","Id":"8301777","Tag":null,"CreationDate":1459977889}'}
     headers:
       cache-control: [no-cache]
-      content-length: ['308']
+      content-length: ['310']
       content-type: [application/json; charset=utf-8]
       expires: ['-1']
       pragma: [no-cache]

--- a/tests/py/test_billing_exchanges.py
+++ b/tests/py/test_billing_exchanges.py
@@ -31,8 +31,12 @@ from liberapay.testing.mangopay import MangopayHarness
 class TestPayouts(MangopayHarness):
 
     def test_payout(self):
-        self.make_exchange('mango-cc', 27, 0, self.homer)
-        self.make_exchange('mango-cc', 19, 0, self.homer)
+        e = charge(self.db, self.janet, D('46.00'), 'http://localhost/')
+        assert e.status == 'succeeded', e.note
+        self.janet.set_tip_to(self.homer, '42.00')
+        self.janet.close('downstream')
+        self.homer = self.homer.refetch()
+        assert self.homer.balance == 46
         exchange = payout(self.db, self.homer, D('30.00'))
         assert exchange.note is None
         assert exchange.status == 'created'


### PR DESCRIPTION
I think I've found the cause of #249: we assume the transaction has succeeded if an exception isn't raised, when in fact it looks like the mangopay library doesn't raise an exception for simple payin failures.