### PR TITLE
Fix handling of failed transfers in account history

### DIFF
--- a/liberapay/utils/history.py
+++ b/liberapay/utils/history.py
@@ -96,8 +96,8 @@ def iter_payday_events(db, participant, year=None):
     if transfers:
         yield dict(
             kind='totals',
-            given=sum(t['amount'] for t in transfers if t['tipper'] == id),
-            received=sum(t['amount'] for t in transfers if t['tippee'] == id),
+            given=sum(t['amount'] for t in transfers if t['tipper'] == id and t['status'] == 'succeeded'),
+            received=sum(t['amount'] for t in transfers if t['tippee'] == id and t['status'] == 'succeeded'),
         )
 
     payday_dates = db.all("""
@@ -139,7 +139,9 @@ def iter_payday_events(db, participant, year=None):
                     balance -= event['amount'] - event['fee']
         else:
             kind = 'transfer'
-            if event['tippee'] == id:
+            if event['status'] != 'succeeded':
+                pass
+            elif event['tippee'] == id:
                 balance -= event['amount']
             else:
                 balance += event['amount']

--- a/liberapay/utils/history.py
+++ b/liberapay/utils/history.py
@@ -77,17 +77,17 @@ def iter_payday_events(db, participant, year=None):
            AND extract(year from timestamp) = %(year)s
     """, locals(), back_as=dict)
     transfers = db.all("""
-        SELECT *, p.username, (SELECT username FROM participants WHERE id = team) AS team_name
-          FROM transfers
+        SELECT t.*, p.username, (SELECT username FROM participants WHERE id = team) AS team_name
+          FROM transfers t
           JOIN participants p ON p.id = tipper
-         WHERE tippee=%(id)s
-           AND extract(year from timestamp) = %(year)s
+         WHERE t.tippee=%(id)s
+           AND extract(year from t.timestamp) = %(year)s
         UNION ALL
-        SELECT *, p.username, (SELECT username FROM participants WHERE id = team) AS team_name
-          FROM transfers
+        SELECT t.*, p.username, (SELECT username FROM participants WHERE id = team) AS team_name
+          FROM transfers t
           JOIN participants p ON p.id = tippee
-         WHERE tipper=%(id)s
-           AND extract(year from timestamp) = %(year)s
+         WHERE t.tipper=%(id)s
+           AND extract(year from t.timestamp) = %(year)s
     """, locals(), back_as=dict)
 
     if not (exchanges or transfers):

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -143,7 +143,7 @@ else:
 
         <td class="balance">{{ event['balance'] }}</td>
 
-        <td class="status"></td>
+        <td class="status">{{ translated_status[event['status']] }}</td>
         <td class="notes">
         % set context = event['context']
         % if event['tippee'] == participant.id


### PR DESCRIPTION
Yesterday's payday created our first two transfers with `status = 'failed'`. This PR fixes the information displayed on the affected users' Wallet pages.