### PR TITLE
Fix `is_funded` in `payday_tips`

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -373,6 +373,7 @@ class Payday(object):
             SELECT settle_tip_graph();
             SELECT resolve_takes(team) FROM payday_takes GROUP BY team ORDER BY team;
             SELECT settle_tip_graph();
+            UPDATE payday_tips SET is_funded = false WHERE is_funded IS NULL;
         """)
 
     @staticmethod

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -92,7 +92,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         # Check that update_cached_amounts actually updates amounts
         self.db.run("""
             UPDATE tips t
-               SET is_funded = false
+               SET is_funded = true
               FROM participants p
              WHERE p.id = t.tippee
                AND p.mangopay_user_id IS NOT NULL;

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -108,6 +108,12 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         Payday.start().update_cached_amounts()
         check()
 
+        # Check that the update methods of Participant concur
+        for p in self.db.all("SELECT p.*::participants FROM participants p"):
+            p.update_receiving()
+            p.update_giving()
+        check()
+
     def test_update_cached_amounts_depth(self):
         alice = self.make_participant('alice', balance=100)
         usernames = ('bob', 'carl', 'dana', 'emma', 'fred', 'greg')

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -245,6 +245,8 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             assert new_balances[self.david.id] == D('0.49')
             assert new_balances[self.janet.id] == D('0.51')
             assert new_balances[self.homer.id] == 0
+            nulls = cursor.all("SELECT * FROM payday_tips WHERE is_funded IS NULL")
+            assert not nulls
 
     def test_transfer_tips_whole_graph(self):
         alice = self.make_participant('alice', balance=50)


### PR DESCRIPTION
We currently have cases when `is_funded` is `NULL` in `payday_tips`, that confuses `update_cached_amounts`, we should use `false` instead.