### PR TITLE
Fix team invites

### DIFF
--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -35,6 +35,34 @@ class Tests(Harness):
         self.a_team.remove_all_members()
         assert len(self.a_team.get_current_takes()) == 0
 
+    def test_invite_accept_leave(self):
+        r = self.client.PxST(
+            '/A-Team/membership/invite', {'username': 'bob'}, auth_as=self.alice,
+        )
+        assert r.code == 302
+
+        r = self.client.PxST('/A-Team/membership/accept', auth_as=self.bob)
+        assert r.code == 302
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is True
+
+        r = self.client.PxST('/A-Team/membership/leave', auth_as=self.alice)
+        assert r.code == 200
+        assert 'confirm' in r.text
+
+        r = self.client.PxST(
+            '/A-Team/membership/leave', {'confirmed': 'true'}, auth_as=self.alice,
+        )
+        is_member = self.alice.member_of(self.a_team)
+        assert is_member is False
+
+    def test_refuse_invite(self):
+        self.a_team.invite(self.bob, self.alice)
+        r = self.client.PxST('/A-Team/membership/refuse', auth_as=self.bob)
+        assert r.code == 302
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is False
+
 
 class Tests2(Harness):
 

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -9,39 +9,34 @@ class Tests(Harness):
 
     def setUp(self):
         Harness.setUp(self)
-        self.team = self.make_participant('A-Team', kind='group')
+        self.a_team = self.make_participant('A-Team', kind='group')
+        self.alice = self.make_participant('alice')
+        self.a_team.add_member(self.alice)
+        self.bob = self.make_participant('bob', email='bob@example.net')
 
-    def test_can_add_members(self):
-        alice = self.make_participant('alice')
-        expected = True
-        self.team.add_member(alice)
-        actual = alice.member_of(self.team)
-        assert actual == expected
+    def test_member_of(self):
+        actual = self.alice.member_of(self.a_team)
+        assert actual is True
 
     def test_get_teams_for_member(self):
-        alice = self.make_participant('alice')
-        bob = self.make_participant('bob')
-        team = self.make_participant('B-Team', kind='group')
-        self.team.add_member(alice)
-        team.add_member(bob)
-        expected = 1
-        actual = alice.get_teams().pop().nmembers
-        assert actual == expected
+        b_team = self.make_participant('B-Team', kind='group')
+        b_team.add_member(self.bob)
+        actual = self.alice.get_teams().pop().nmembers
+        assert actual == 1
 
     def test_preclude_adding_stub_participant(self):
         stub_participant = self.make_stub()
         with self.assertRaises(InactiveParticipantAdded):
-            self.team.add_member(stub_participant)
+            self.a_team.add_member(stub_participant)
 
     def test_remove_all_members(self):
-        alice = self.make_participant('alice')
-        self.team.add_member(alice)
-        bob = self.make_participant('bob')
-        self.team.add_member(bob)
+        self.a_team.add_member(self.bob)
+        assert len(self.a_team.get_current_takes()) == 2  # sanity check
+        self.a_team.remove_all_members()
+        assert len(self.a_team.get_current_takes()) == 0
 
-        assert len(self.team.get_current_takes()) == 2  # sanity check
-        self.team.remove_all_members()
-        assert len(self.team.get_current_takes()) == 0
+
+class Tests2(Harness):
 
     def test_create_close_and_reopen_team(self):
         alice = self.make_participant('alice')

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -63,6 +63,17 @@ class Tests(Harness):
         is_member = self.bob.member_of(self.a_team)
         assert is_member is False
 
+    def test_invite_is_scoped_to_specific_team(self):
+        b_team = self.make_participant('B-Team', kind='group')
+        self.a_team.invite(self.bob, self.alice)
+
+        # Chech that bob can't use the invite from A-Team to join B-Team
+        r = self.client.PxST('/B-Team/membership/accept', auth_as=self.bob)
+        assert r.code == 400
+        assert 'not invited' in r.text
+        is_member = self.bob.member_of(b_team)
+        assert is_member is False
+
 
 class Tests2(Harness):
 

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -11,15 +11,16 @@ from liberapay.utils import b64encode_s, get_participant, utcnow
 
 ONE_WEEK = timedelta(days=7)
 
-def get_invite(p):
+def get_invite(team, p):
     return website.db.one("""
         SELECT *
           FROM events
-         WHERE type LIKE 'invite%%'
+         WHERE participant = %s
+           AND type LIKE 'invite%%'
            AND payload->>'invitee' = %s::text
       ORDER BY ts DESC
          LIMIT 1
-    """, (p.id,))
+    """, (team.id, p.id,))
 
 [---]
 
@@ -36,7 +37,7 @@ msg = None
 confirm = None
 
 if action in ('accept', 'refuse'):
-    invite = get_invite(user)
+    invite = get_invite(team, user)
     if not invite:
         raise Response(400, _("You are not invited to join this team."))
     if invite.type == 'invite_accept':
@@ -54,7 +55,7 @@ if action == 'invite':
         raise Response(400, _("A team can't join a team"))
     if invitee.status != 'active':
         raise Response(400, _("You can't invite an inactive user to join a team."))
-    invite = get_invite(invitee)
+    invite = get_invite(team, invitee)
     if invite:
         invite_age = utcnow() - invite.ts
         if invite.type == 'invite' and invite_age < ONE_WEEK:


### PR DESCRIPTION
While working on #262 I stumbled on a big bug in team invites: you can use an invite from a team to join any team, not just the one you were invited to. This PR fixes that and has already been deployed to production.