### PR TITLE
Fix cached amounts for some teams

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -323,15 +323,18 @@ class Payday(object):
                      WHERE t.tippee = team_id
                        AND p.new_balance >= t.amount;
             BEGIN
-                total_income := (
-                    SELECT sum(t.amount)
-                      FROM payday_tips t
-                      JOIN payday_participants p ON p.id = t.tipper
-                     WHERE t.tippee = team_id
-                       AND p.new_balance >= t.amount
-                );
+                WITH funded AS (
+                     UPDATE payday_tips
+                        SET is_funded = true
+                       FROM payday_participants p
+                      WHERE p.id = tipper
+                        AND tippee = team_id
+                        AND p.new_balance >= amount
+                  RETURNING amount
+                )
+                SELECT COALESCE(sum(amount), 0) FROM funded INTO total_income;
                 total_takes := (
-                    SELECT sum(t.amount)
+                    SELECT COALESCE(sum(t.amount), 0)
                       FROM payday_takes t
                      WHERE t.team = team_id
                 );
@@ -351,7 +354,6 @@ class Payday(object):
                             CONTINUE;
                         END IF;
                         transfer_amount := min(tip.amount, take.amount);
-                        UPDATE payday_tips SET is_funded = true WHERE id = tip.id;
                         EXECUTE transfer(tip.tipper, take.member, transfer_amount, 'take', team_id);
                         tip.amount := tip.amount - transfer_amount;
                         UPDATE our_takes t
@@ -371,7 +373,7 @@ class Payday(object):
     def transfer_virtually(cursor):
         cursor.run("""
             SELECT settle_tip_graph();
-            SELECT resolve_takes(team) FROM payday_takes GROUP BY team ORDER BY team;
+            SELECT resolve_takes(id) FROM payday_participants WHERE kind = 'group';
             SELECT settle_tip_graph();
             UPDATE payday_tips SET is_funded = false WHERE is_funded IS NULL;
         """)

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -514,13 +514,28 @@ class Payday(object):
               FROM ( SELECT p2.id
                           , ( SELECT count(*)
                                 FROM payday_transfers t
-                               WHERE t.tippee = p2.id OR t.team = p2.id
+                               WHERE t.tippee = p2.id
                             ) AS npatrons
                        FROM participants p2
                    ) p2
              WHERE p.id = p2.id
                AND p.npatrons <> p2.npatrons
-               AND p.status <> 'stub';
+               AND p.status <> 'stub'
+               AND p.kind IN ('individual', 'organization');
+
+            UPDATE participants p
+               SET npatrons = p2.npatrons
+              FROM ( SELECT p2.id
+                          , ( SELECT count(*)
+                                FROM payday_tips t
+                               WHERE t.tippee = p2.id
+                                 AND t.is_funded
+                            ) AS npatrons
+                       FROM participants p2
+                   ) p2
+             WHERE p.id = p2.id
+               AND p.npatrons <> p2.npatrons
+               AND p.kind = 'group';
 
             """)
         self.clean_up()

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -41,10 +41,13 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         carl = self.make_participant('carl', balance=1.56)
         dana = self.make_participant('dana')
         emma = Participant.make_stub(username='emma')
+        team2 = self.make_participant('team2', kind='group')
+        team2.add_member(dana)
         alice.set_tip_to(dana, '3.00')
         alice.set_tip_to(bob, '6.00')
         alice.set_tip_to(emma, '0.50')
         alice.set_tip_to(team, '1.20')
+        alice.set_tip_to(team2, '0.49')
         bob.set_tip_to(alice, '5.00')
         team.add_member(bob)
         team.set_take_for(bob, D('1.00'), bob)
@@ -58,7 +61,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             carl = Participant.from_username('carl')
             dana = Participant.from_username('dana')
             emma = Participant.from_username('emma')
-            assert alice.giving == D('10.20')
+            assert alice.giving == D('10.69')
             assert alice.receiving == D('5.00')
             assert bob.giving == D('7.00')
             assert bob.receiving == D('7.00')
@@ -70,11 +73,15 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             assert emma.receiving == D('0.50')
             assert emma.npatrons == 1
             funded_tips = self.db.all("SELECT amount FROM tips WHERE is_funded ORDER BY id")
-            assert funded_tips == [3, 6, 0.5, D('1.20'), 5, 2]
+            assert funded_tips == [3, 6, 0.5, D('1.20'), D('0.49'), 5, 2]
 
             team = Participant.from_username('team')
             assert team.receiving == D('1.20')
             assert team.npatrons == 1
+
+            team2 = Participant.from_username('team2')
+            assert team2.receiving == D('0.49')
+            assert team2.npatrons == 1
 
             janet = self.janet.refetch()
             assert janet.giving == 0


### PR DESCRIPTION
Fixes https://github.com/liberapay/liberapay.com/pull/257#issuecomment-207953159:

> `receiving` is still broken: it's `0.00` for teams that don't distribute their income.