### PR TITLE
Don't send "identity required" emails to teams

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -586,6 +586,7 @@ class Payday(object):
             SELECT p.*::participants
               FROM participants p
              WHERE mangopay_user_id IS NULL
+               AND kind IN ('individual', 'organization')
                AND (p.goal IS NULL OR p.goal >= 0)
                AND EXISTS (
                      SELECT 1

--- a/tests/py/test_billing_payday.py
+++ b/tests/py/test_billing_payday.py
@@ -403,7 +403,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         self.make_exchange('mango-cc', 10, 0, self.janet)
         self.janet.set_tip_to(self.david, '4.50')
         self.janet.set_tip_to(self.homer, '3.50')
-        team = self.make_participant('team', kind='group')
+        team = self.make_participant('team', kind='group', email='team@example.com')
         self.janet.set_tip_to(team, '0.25')
         team.add_member(self.david)
         team.set_take_for(self.david, D('0.23'), team)


### PR DESCRIPTION
A user has reported that he received such an email, that's a bug.