### PR TITLE
Use html2text

### DIFF
--- a/emails/base.spt
+++ b/emails/base.spt
@@ -24,8 +24,9 @@ $body
 
 $body
 
-{{ _("Something not right? Reply to this email for help.") }}
 
-----
+---
+
+{{ _("Something not right? Reply to this email for help.") }}
 
 {{ _("Change your email settings") }}: https://liberapay.com/about/me/emails/

--- a/emails/withdrawal_created.spt
+++ b/emails/withdrawal_created.spt
@@ -4,8 +4,3 @@
 {{ _("We have initiated a transfer of {0} from your Liberapay wallet to your bank account. "
      "Please note that it can take several business days for the transaction to complete.",
      Money(-exchange.amount + exchange.fee, 'EUR')) }}
-
-[---] text/plain
-{{ _("We have initiated a transfer of {0} from your Liberapay wallet to your bank account. "
-     "Please note that it can take several business days for the transaction to complete.",
-     Money(-exchange.amount + exchange.fee, 'EUR')) }}


### PR DESCRIPTION
[html2text](https://github.com/Alir3z4/html2text/) was pulled into our dependencies by MailShake (#272), and now that we have it we might as well use it to lighten our email templates. This PR is only a first step in that direction.