### PR TITLE
Fix permission to take money from a team

### DIFF
--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -79,14 +79,12 @@ class MixinTeam(object):
         return takes
 
     def get_take_for(self, member):
-        """Return a Decimal representation of the take for this member, or 0.
+        """Return the nominal take for this member, or None.
         """
-        assert self.kind == 'group'
-        return self.db.one( "SELECT amount FROM current_takes "
-                            "WHERE member=%s AND team=%s"
-                          , (member.id, self.id)
-                          , default=D_ZERO
-                           )
+        return self.db.one(
+            "SELECT amount FROM current_takes WHERE member = %s AND team = %s",
+            (member.id, self.id)
+        )
 
     def compute_max_this_week(self, member_id, last_week):
         """2x the member's take last week, or a minimum based on last week's
@@ -103,6 +101,11 @@ class MixinTeam(object):
         """Sets member's take from the team pool.
         """
         assert self.kind == 'group'
+
+        if recorder.id != self.id:
+            cur_take = self.get_take_for(member)
+            if cur_take is None:
+                return None
 
         if not isinstance(take, (None.__class__, Decimal)):
             take = Decimal(take)

--- a/tests/py/test_history.py
+++ b/tests/py/test_history.py
@@ -54,7 +54,7 @@ class TestHistory(FakeTransfersHarness):
         david = self.make_participant('david')
         self.make_exchange('mango-cc', 10000, 0, david)
         david.set_tip_to(team, Decimal('1.00'))
-        team.set_take_for(bob, Decimal('1.00'), bob)
+        team.set_take_for(bob, Decimal('1.00'), team)
         alice.set_tip_to(bob, Decimal('5.00'))
 
         assert bob.balance == 0

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -50,7 +50,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         alice.set_tip_to(team2, '0.49')
         bob.set_tip_to(alice, '5.00')
         team.add_member(bob)
-        team.set_take_for(bob, D('1.00'), bob)
+        team.set_take_for(bob, D('1.00'), team)
         bob.set_tip_to(dana, '2.00')  # funded by bob's take
         bob.set_tip_to(emma, '7.00')  # not funded, insufficient receiving
         carl.set_tip_to(dana, '2.08')  # not funded, insufficient balance
@@ -281,16 +281,16 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
     def test_transfer_takes(self):
         a_team = self.make_participant('a_team', kind='group')
         alice = self.make_participant('alice')
-        a_team.set_take_for(alice, D('1.00'), alice)
+        a_team.set_take_for(alice, D('1.00'), a_team)
         bob = self.make_participant('bob')
-        a_team.set_take_for(bob, D('0.01'), bob)
+        a_team.set_take_for(bob, D('0.01'), a_team)
         charlie = self.make_participant('charlie', balance=1000)
         charlie.set_tip_to(a_team, D('1.01'))
 
         payday = Payday.start()
 
         # Test that payday ignores takes set after it started
-        a_team.set_take_for(alice, D('2.00'), alice)
+        a_team.set_take_for(alice, D('2.00'), a_team)
 
         # Run the transfer multiple times to make sure we ignore takes that
         # have already been processed
@@ -315,9 +315,9 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         self.clear_tables()
         team = self.make_participant('team', kind='group')
         alice = self.make_participant('alice')
-        team.set_take_for(alice, D('1.00'), alice)
+        team.set_take_for(alice, D('1.00'), team)
         bob = self.make_participant('bob')
-        team.set_take_for(bob, D('1.00'), bob)
+        team.set_take_for(bob, D('1.00'), team)
         charlie = self.make_participant('charlie', balance=1000)
         charlie.set_tip_to(team, D('0.26'))
 
@@ -341,9 +341,9 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         self.clear_tables()
         team = self.make_participant('team', kind='group')
         alice = self.make_participant('alice')
-        team.set_take_for(alice, D('0.79'), alice)
+        team.set_take_for(alice, D('0.79'), team)
         bob = self.make_participant('bob')
-        team.set_take_for(bob, D('0.21'), bob)
+        team.set_take_for(bob, D('0.21'), team)
         charlie = self.make_participant('charlie', balance=10)
         charlie.set_tip_to(team, D('5.00'))
         dan = self.make_participant('dan', balance=10)
@@ -366,10 +366,10 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         team = self.make_participant('team', kind='group')
         alice = self.make_participant('alice', balance=8)
         alice.set_tip_to(team, D('2.00'))
-        team.set_take_for(alice, D('0.25'), alice)
+        team.set_take_for(alice, D('0.25'), team)
         bob = self.make_participant('bob', balance=10)
         bob.set_tip_to(team, D('2.00'))
-        team.set_take_for(bob, D('0.75'), bob)
+        team.set_take_for(bob, D('0.75'), team)
 
         Payday.start().run()
 
@@ -387,7 +387,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         alice = self.make_participant('alice')
         alice.set_tip_to(team, D('1.00'))  # unfunded tip
         bob = self.make_participant('bob')
-        team.set_take_for(bob, D('1.00'), bob)
+        team.set_take_for(bob, D('1.00'), team)
 
         Payday.start().run()
 

--- a/tests/py/test_take.py
+++ b/tests/py/test_take.py
@@ -21,7 +21,7 @@ class Tests(Harness):
         return team
 
     def take_last_week(self, team, member, amount, actual_amount=None):
-        team.set_take_for(member, amount, member, check_max=False)
+        team.set_take_for(member, amount, team, check_max=False)
         self.db.run("INSERT INTO paydays DEFAULT VALUES")
         actual_amount = amount if actual_amount is None else actual_amount
         self.db.run("""

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -74,6 +74,18 @@ class Tests(Harness):
         is_member = self.bob.member_of(b_team)
         assert is_member is False
 
+    def test_members_can_take_from_team(self):
+        r = self.client.PxST('/A-Team/income/take', {'take': '1'}, auth_as=self.alice)
+        assert r.code == 302
+        take = self.a_team.get_take_for(self.alice)
+        assert take == 1
+
+    def test_non_members_cant_take_from_team(self):
+        r = self.client.PxST('/A-Team/income/take', {'take': '2'}, auth_as=self.bob)
+        assert r.code == 403
+        take = self.a_team.get_take_for(self.bob)
+        assert take is None
+
 
 class Tests2(Harness):
 

--- a/www/%username/income/take.spt
+++ b/www/%username/income/take.spt
@@ -21,6 +21,8 @@ if not user.mangopay_user_id:
 
 take = parse_decimal(request.body['take'])
 new_take = team.set_take_for(user, take, user)
+if new_take is None:
+    raise Response(403, _("You are not a member of the {0} team.", team.username))
 if new_take < take:
     msg = _("Your take is now {0} (you can't go higher this week).",
             Money(new_take, 'EUR'))


### PR DESCRIPTION
I stumbled on a big permission fail: the HTTP endpoint that allows users to change their takes wasn't checking that the user is a member of the team! That means you could take money from any team. :flushed: 

This PR fixes that bug and has already been deployed to production.