### PR TITLE
Don't redirect callbacks

### DIFF
--- a/liberapay/__init__.py
+++ b/liberapay/__init__.py
@@ -14,6 +14,9 @@ from . import constants
 def canonize(request, website):
     """Enforce a certain scheme and hostname.
     """
+    if request.path.raw.startswith('/callbacks/'):
+        # Don't redirect callbacks
+        return
     scheme = request.headers.get('X-Forwarded-Proto', 'http')
     host = request.headers['Host']
     canonical_host = website.canonical_host

--- a/liberapay/__init__.py
+++ b/liberapay/__init__.py
@@ -2,6 +2,10 @@ from __future__ import print_function, unicode_literals
 
 from mimetypes import guess_type
 
+from six.moves.urllib.parse import urlsplit, urlunsplit
+
+from aspen.http.request import Line
+
 from . import constants
 
 
@@ -16,6 +20,14 @@ def canonize(request, website):
     """
     if request.path.raw.startswith('/callbacks/'):
         # Don't redirect callbacks
+        if request.path.raw[-1] == '/':
+            # Remove trailing slash
+            l = request.line
+            scheme, netloc, path, query, fragment = urlsplit(l.uri)
+            assert path[-1] == '/'  # sanity check
+            path = path[:-1]
+            new_uri = urlunsplit((scheme, netloc, path, query, fragment))
+            request.line = Line(l.method.raw, new_uri, l.version.raw)
         return
     scheme = request.headers.get('X-Forwarded-Proto', 'http')
     host = request.headers['Host']

--- a/www/callbacks/mangopay.spt
+++ b/www/callbacks/mangopay.spt
@@ -21,6 +21,10 @@ try:
 except ValueError:
     raise Response(400, "bad EventType")
 RessourceId = request.qs['RessourceId']
+try:
+    int(RessourceId)
+except ValueError:
+    raise Response(400, "bad RessourceId")
 
 cls = EVENT_TYPES.get(event)
 


### PR DESCRIPTION
MangoPay callbacks were failing because they apparently don't like our TLS certificate, but they're okay with plain unprotected HTTP requests (!), so I've switched to that. There's no risk since callbacks don't transmit sensitive information. This is already deployed in production.