### PR TITLE
Stop requiring a `.html` suffix in receipt URLs

### DIFF
--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -51,7 +51,7 @@ class TestPages(MangopayHarness):
 
     def browse(self, **kw):
         for url in self.urls:
-            url = url.replace('/%exchange_id.int', '/%s' % self.exchange_id)
+            url = url.replace('/%exchange_id', '/%s' % self.exchange_id)
             assert '/%' not in url
             try:
                 r = self.client.GET(url, **kw)

--- a/www/%username/receipts/%exchange_id.spt
+++ b/www/%username/receipts/%exchange_id.spt
@@ -11,9 +11,15 @@ PAYMENT_METHODS = {
 }
 del _
 
-[-------------------]
+[---]
 
 participant = get_participant(state, restrict=True)
+
+e_id = request.path['exchange_id'].split('.html')[0]
+try:
+    int(e_id)
+except ValueError:
+    raise Response(404)
 
 exchange = website.db.one("""
     SELECT *
@@ -21,7 +27,7 @@ exchange = website.db.one("""
      WHERE id = %s
        AND participant = %s
        AND amount > 0
-""", (request.path['exchange_id'], participant.id))
+""", (e_id, participant.id))
 if exchange is None or exchange.status != 'succeeded':
     raise Response(404)
 
@@ -32,7 +38,7 @@ if route.network == 'mango-cc':
 
 account = participant.get_mangopay_account()
 
-[-------------------]
+[---] text/html
 <style>
     body {
         margin: 0;

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -121,7 +121,7 @@ else:
             &mdash; <a href="/~{{ event['recorder'] }}/">{{ event['recorder'] }}</a>
         % endif
         % if event['status'] == 'succeeded'
-            (<a href="../receipts/{{ event['id'] }}.html">{{ _("Receipt").lower() }}</a>)
+            (<a href="../receipts/{{ event['id'] }}">{{ _("Receipt").lower() }}</a>)
         % endif
         </td>
     </tr>

--- a/www/%username/wallet/payin/bankwire/%back_to.spt
+++ b/www/%username/wallet/payin/bankwire/%back_to.spt
@@ -75,7 +75,7 @@ if request.method == 'POST':
 elif 'exchange_id' in request.qs:
     exchange, payin = get_exchange_payin(participant, request)
     if exchange.status == 'succeeded':
-        response.redirect(participant.path('receipts/%s.html' % exchange.id))
+        response.redirect(participant.path('receipts/%s' % exchange.id))
 
 back_to = b64decode_s(request.path['back_to'], default=None)
 show_form = weekly > 0 and funded < 52 and not payin

--- a/www/%username/wallet/payin/card/%back_to.spt
+++ b/www/%username/wallet/payin/card/%back_to.spt
@@ -95,7 +95,7 @@ title = _("Add money")
             _("The attempt to take {0} from your credit card has failed. Error message: {1}", Money(exchange.amount + exchange.fee, 'EUR'), exchange.note)
         }}</div>
         % if success
-        <a href="{{ participant.path('receipts/%s.html' % exchange.id) }}">{{ _("View Receipt") }}</a>
+        <a href="{{ participant.path('receipts/%s' % exchange.id) }}">{{ _("View Receipt") }}</a>
         % endif
     % endif
 


### PR DESCRIPTION
Fixes https://github.com/liberapay/liberapay.com/issues/45#issuecomment-219996749.