### PR TITLE
Stop using aspen's log function

### DIFF
--- a/liberapay/elsewhere/_base.py
+++ b/liberapay/elsewhere/_base.py
@@ -10,13 +10,16 @@ except ImportError:
     from urllib import quote
 import xml.etree.ElementTree as ET
 
-from aspen import log, Response
+from aspen import Response
 from aspen.utils import to_age, utc
 from oauthlib.oauth2 import TokenExpiredError
 from requests_oauthlib import OAuth1Session, OAuth2Session
 
 from liberapay.elsewhere._extractors import not_available
 from liberapay.exceptions import LazyResponse
+
+
+logger = logging.getLogger('liberapay.elsewhere')
 
 
 class UserInfo(object):
@@ -128,8 +131,7 @@ class Platform(object):
                     return _("You're making requests too fast, please try again later.")
             raise LazyResponse(status, msg)
         if status != 200:
-            log('{} api responded with {}:\n{}'.format(self.name, status, response.text),
-                level=logging.ERROR)
+            logger.error('{} api responded with {}:\n{}'.format(self.name, status, response.text))
             msg = lambda _: _("{0} returned an error, please try again later.",
                               self.display_name)
             raise LazyResponse(502, msg)
@@ -147,7 +149,7 @@ class Platform(object):
                 reset = datetime.fromtimestamp(reset, tz=utc)
             except (TypeError, ValueError):
                 d = dict(limit=limit, remaining=remaining, reset=reset)
-                log('Got weird rate headers from %s: %s' % (self.name, d))
+                logger.warning('Got weird rate headers from %s: %s' % (self.name, d))
                 limit, remaining, reset = None, None, None
 
         return limit, remaining, reset
@@ -168,7 +170,7 @@ class Platform(object):
                 log_lvl = logging.ERROR
             elif percent_remaining < 0.05:
                 log_lvl = logging.CRITICAL
-            log(log_msg, log_lvl)
+            logger.log(log_lvl, log_msg)
 
     def extract_user_info(self, info):
         """

--- a/liberapay/elsewhere/_extractors.py
+++ b/liberapay/elsewhere/_extractors.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 
 from functools import reduce
 import json
+import logging
 from operator import getitem
 import xml.etree.ElementTree as ET
 
-from aspen import log
+
+logger = logging.getLogger('liberapay.elsewhere')
 
 
 def _getitemchain(o, *keys):
@@ -45,7 +47,7 @@ def any_key(*keys, **kw):
             return default[0]
         msg = 'Unable to find any of the keys %s in %s API response:\n%s'
         msg %= keys, self.name, json.dumps(info, indent=4)
-        log(msg)
+        logger.error(msg)
         raise KeyError(msg)
     return f
 
@@ -56,14 +58,14 @@ def key(k, clean=lambda a: a):
             v = info.pop(k, *default)
         except KeyError:
             msg = 'Unable to find key "%s" in %s API response:\n%s'
-            log(msg % (k, self.name, json.dumps(info, indent=4)))
+            logger.error(msg % (k, self.name, json.dumps(info, indent=4)))
             raise
         if v:
             v = clean(v)
         if not v and not default:
             msg = 'Key "%s" has an empty value in %s API response:\n%s'
             msg %= (k, self.name, json.dumps(info, indent=4))
-            log(msg)
+            logger.error(msg)
             raise ValueError(msg)
         return v
     return f
@@ -80,7 +82,7 @@ def xpath(path, attr=None, clean=lambda a: a):
             if len(l) > 1:
                 msg = 'The xpath "%s" matches more than one element in %s API response:\n%s'
                 msg %= (path, self.name, ET.tostring(info))
-                log(msg)
+                logger.error(msg)
                 raise ValueError(msg)
             v = l[0].get(attr) if attr else l[0]
         except IndexError:
@@ -88,21 +90,21 @@ def xpath(path, attr=None, clean=lambda a: a):
                 return default[0]
             msg = 'Unable to find xpath "%s" in %s API response:\n%s'
             msg %= (path, self.name, ET.tostring(info))
-            log(msg)
+            logger.error(msg)
             raise IndexError(msg)
         except KeyError:
             if default:
                 return default[0]
             msg = 'The element has no "%s" attribute in %s API response:\n%s'
             msg %= (attr, self.name, ET.tostring(info))
-            log(msg)
+            logger.error(msg)
             raise KeyError(msg)
         if v:
             v = clean(v)
         if not v and not default:
             msg = 'The xpath "%s" points to an empty value in %s API response:\n%s'
             msg %= (path, self.name, ET.tostring(info))
-            log(msg)
+            logger.error(msg)
             raise ValueError(msg)
         return v
     return f

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -144,7 +144,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         Payday.start().update_cached_amounts()
         check()
 
-    @mock.patch('liberapay.billing.payday.log')
+    @mock.patch('liberapay.billing.payday.logger.info')
     def test_start_prepare(self, log):
         self.clear_tables()
         self.make_participant('carl', balance=10)

--- a/www/on/%platform/associate.spt
+++ b/www/on/%platform/associate.spt
@@ -1,6 +1,6 @@
 import json
 
-from aspen import log, resources, Response
+from aspen import resources, Response
 from oauthlib.oauth2 import OAuth2Error
 from requests_oauthlib.oauth1_session import TokenRequestDenied
 
@@ -74,8 +74,6 @@ if action_user_id and account.user_id != action_user_id:
         then = '/on/%s/%s/failure.html?team=true'
         response.redirect(then % (platform.name, claimed_account.liberapay_slug))
     account = claimed_account
-
-log('%s user "%s" wants to %s' % (platform.name, account.user_id, action))
 
 if action == 'connect':
     connect_to = Participant.from_id(p_id) if p_id else user


### PR DESCRIPTION
Because it sucks, and because we don't want the `elsewhere` and `payday` modules to depend on the web framework.