### PR TITLE
Tweak default gunicorn options

### DIFF
--- a/defaults.env
+++ b/defaults.env
@@ -19,4 +19,4 @@ ASPEN_WWW_ROOT=www/
 
 # The timeout is for pdb, see https://github.com/benoitc/gunicorn/issues/186
 # If you like to use pdb you may also want to disable the autoreload
-GUNICORN_OPTS="workers=1 reload=True timeout=99999999"
+GUNICORN_OPTS="workers=2 reload=True timeout=99999999"

--- a/defaults.env
+++ b/defaults.env
@@ -17,5 +17,6 @@ ASPEN_PROJECT_ROOT=.
 ASPEN_SHOW_TRACEBACKS=yes
 ASPEN_WWW_ROOT=www/
 
-# https://github.com/benoitc/gunicorn/issues/186
-GUNICORN_OPTS="workers=1 timeout=99999999"
+# The timeout is for pdb, see https://github.com/benoitc/gunicorn/issues/186
+# If you like to use pdb you may also want to disable the autoreload
+GUNICORN_OPTS="workers=1 reload=True timeout=99999999"


### PR DESCRIPTION
This PR is meant to improve DevX and early detection of concurrency bugs. I've been using these settings for a while in my `local.env`.