### PR TITLE
Implement isolating communities

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE communities ADD COLUMN is_hidden boolean NOT NULL DEFAULT FALSE;

--- a/www/explore/communities/index.spt
+++ b/www/explore/communities/index.spt
@@ -17,7 +17,8 @@ communities_top = query_cache.all("""
               LIMIT 1
            ) AS subtitle
       FROM communities c
-     WHERE nmembers > 1 OR nsubscribers > 1
+     WHERE (nmembers > 1 OR nsubscribers > 1)
+       AND NOT is_hidden
   ORDER BY nmembers DESC, random()
      LIMIT 15
 """, (' '.join(request.accept_langs),))
@@ -33,6 +34,7 @@ communities_loc = query_cache.all("""
            ) AS subtitle
       FROM communities c
      WHERE lang = %s
+       AND NOT is_hidden
   ORDER BY nmembers DESC, random()
      LIMIT 15
 """, (([l for l in request.accept_langs if l in communities_langs] + [''])[0],))


### PR DESCRIPTION
This PR implements a very basic blacklist mechanism to hide a community from the lists on <https://liberapay.com/explore/communities/>.