### PR TITLE
Improve fee computation

### DIFF
--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -49,13 +49,17 @@ def upcharge(amount, fees, min_amount):
     # a = c - vf * c - ff  =>  c = (a + ff) / (1 - vf)
     # a = amount ; c = charge amount ; ff = fixed fee ; vf = variable fee
     charge_amount = (amount + fees.fix) / (1 - fees.var)
-    charge_amount = charge_amount.quantize(D_CENT, rounding=ROUND_UP)
     fee = charge_amount - amount
 
     # + VAT
-    vat = (fee * FEE_VAT).quantize(D_CENT, rounding=ROUND_UP)
+    vat = fee * FEE_VAT
     charge_amount += vat
     fee += vat
+
+    # Round
+    charge_amount = charge_amount.quantize(D_CENT, rounding=ROUND_UP)
+    fee = fee.quantize(D_CENT, rounding=ROUND_UP)
+    vat = vat.quantize(D_CENT, rounding=ROUND_UP)
 
     return charge_amount, fee, vat
 


### PR DESCRIPTION
This PR modifies how we compute fees to try to get closer to the actual amounts.

Modifying the fee formula is dangerous, so I ran a simulation to validate the soundness of the change, and it suggests that this would have reduced this month's surplus from €0.39 to €0.26, and last month's from €0.04 to €0.01. (I announce the surplus every month in https://github.com/liberapay/liberapay.org/issues/10.)