### PR TITLE
Prepare to refund payins

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transfers ADD COLUMN refund_ref bigint REFERENCES transfers;
+ALTER TABLE exchanges ADD COLUMN refund_ref bigint REFERENCES exchanges;


### PR DESCRIPTION
This PR adds an `exchanges.refund_ref` column so we can link refunds to the original payins. It also adds a similar column to the `transfers` table (I'll backfill it later).