### PR TITLE
Handle negative exchange fees

### DIFF
--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -310,7 +310,7 @@ def record_exchange_result(db, exchange_id, status, error, participant):
 
         amount = e.amount
         if amount < 0:
-            amount = -amount + e.fee if status == 'failed' else 0
+            amount = -amount + max(e.fee, 0) if status == 'failed' else 0
         else:
             amount = amount if status == 'succeeded' else 0
         propagate_exchange(cursor, participant, e, e.route, error, amount)

--- a/liberapay/models/__init__.py
+++ b/liberapay/models/__init__.py
@@ -79,7 +79,7 @@ def _check_balances(cursor):
 
                        union all
 
-                      select participant as id, sum(amount-fee) as a
+                      select participant as id, sum(amount - (CASE WHEN (fee > 0) THEN fee ELSE 0 END)) as a
                         from exchanges
                        where amount < 0
                          and status <> 'failed'

--- a/liberapay/utils/history.py
+++ b/liberapay/utils/history.py
@@ -31,7 +31,7 @@ def get_end_of_year_balance(db, participant, year, current_year):
                      AND amount > 0
                      AND status = 'succeeded'
                ) + (
-                  SELECT COALESCE(sum(amount-fee), 0) AS a
+                  SELECT COALESCE(sum(amount - (CASE WHEN (fee > 0) THEN fee ELSE 0 END)), 0) AS a
                     FROM exchanges
                    WHERE participant = %(id)s
                      AND extract(year from timestamp) = %(year)s
@@ -136,7 +136,7 @@ def iter_payday_events(db, participant, year=None):
             else:
                 kind = 'credit'
                 if event['status'] != 'failed':
-                    balance -= event['amount'] - event['fee']
+                    balance -= event['amount'] - max(event['fee'], 0)
         else:
             kind = 'transfer'
             if event['status'] != 'succeeded':

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -94,10 +94,10 @@ else:
     </tr>
     % elif event['kind'] == 'credit'
     <tr>
-        <td class="bank">{{ -event['amount'] }}</td>
+        <td class="bank">{{ -event['amount'] - min(event['fee'], 0) }}</td>
         <td class="fees">{{ event['fee'] }}</td>
         <td class="credits"></td>
-        <td class="debits">{{ -event['amount'] + event['fee'] }}</td>
+        <td class="debits">{{ -event['amount'] + max(event['fee'], 0) }}</td>
         <td class="balance">{{ event['balance'] }}</td>
         <td class="status">{{ translated_status[event['status']] }}</td>
         <td class="notes">


### PR DESCRIPTION
We've started using negative fees for the first time as part of https://github.com/liberapay/salon/issues/52 to provide total refunds to donors.