### PR TITLE
Fill `Tag` field of MangoPay Users with Liberapay profile URL

### DIFF
--- a/www/%username/identity.spt
+++ b/www/%username/identity.spt
@@ -34,6 +34,9 @@ if request.method == 'POST':
         p = 'LegalRepresentative'
         keys = KEYS_LEGAL
 
+    if not account.Tag:
+        account.Tag = website.canonical_url + '/~%i/' % participant.id
+
     account.Email = participant.email
     for k in keys:
         v = body.get(k)


### PR DESCRIPTION
MangoPay requested this in order to "verify the conformity" of our users.