### PR TITLE
Stop requiring verifying email to add money

### DIFF
--- a/www/%username/identity.spt
+++ b/www/%username/identity.spt
@@ -37,7 +37,7 @@ if request.method == 'POST':
     if not account.Tag:
         account.Tag = website.canonical_url + '/~%i/' % participant.id
 
-    account.Email = participant.email
+    account.Email = participant.email or participant.get_any_email()
     for k in keys:
         v = body.get(k)
         if v:
@@ -96,12 +96,6 @@ else:
 
 % block content
 <div class="paragraph">
-% if not participant.email
-<p class="alert alert-warning">{{
-    _("Please {0}verify your email address{1} then reload this page.",
-      '<a href="./emails/" target="_blank">'|safe, '</a>'|safe)
-}}</p>
-% else
 <form action="" method="POST" class="js-submit">
 
     % if error
@@ -115,6 +109,5 @@ else:
     <button class="btn btn-primary" type="submit">{{ _("Save") }}</button>
 
 </form>
-% endif
 </div>
 % endblock

--- a/www/%username/wallet/payin/%back_to.spt
+++ b/www/%username/wallet/payin/%back_to.spt
@@ -34,21 +34,6 @@ title = _("Add money")
 
 % block panel_body
 
-    % if can_payin and not participant.email
-        % if participant.join_time > utcnow() - constants.SESSION_TIMEOUT
-            <p class="alert alert-success">{{ _(
-                "We've sent you an email, please open it now and click the confirmation "
-                "link inside, then come back to this page and carry on."
-            ) }}</p>
-        % else
-            <p class="alert alert-warning">{{ _(
-                "Please {0}verify your email address{1}, then come back to this page and carry on.",
-                '<a href="%s" target="_blank">'|safe % participant.path('emails/'),
-                '</a>'|safe
-            ) }}</p>
-        % endif
-    % endif
-
     <p>
         % if donations == 0
             {{ _(

--- a/www/%username/wallet/payin/bankwire/%back_to.spt
+++ b/www/%username/wallet/payin/bankwire/%back_to.spt
@@ -168,7 +168,6 @@ title = _("Add money")
         % endif
 
     % elif show_form
-    % if participant.email
     <form id="payin" action="javascript:" method="POST"
           data-msg-loading="{{ _('Request in progress, please wait…') }}">
 
@@ -216,14 +215,6 @@ title = _("Add money")
     % endif
 
     </form>
-
-    % else
-    <p class="alert alert-warning">{{
-        _("Please {0}verify your email address{1} then reload this page.",
-          '<a href="%s" target="_blank">'|safe % participant.path('emails/'),
-          '</a>'|safe)
-    }}</p>
-    % endif
     % endif
 
 % endblock

--- a/www/%username/wallet/payin/card/%back_to.spt
+++ b/www/%username/wallet/payin/card/%back_to.spt
@@ -123,7 +123,6 @@ title = _("Add money")
     % endif
 
     % if show_form
-    % if participant.email
     <p>{{ _(
         "Adding money to Liberapay via credit/debit card incurs a fee of {0}% + {1}.",
         constants.FEE_PAYIN_CARD.var * (constants.FEE_VAT + 1) * 100,
@@ -197,14 +196,6 @@ title = _("Add money")
 
     % if back_to
         <a href="{{ back_to }}" class="btn btn-warning pull-right">{{ _("Cancel") }}</a>
-    % endif
-
-    % else
-    <p class="alert alert-warning">{{
-        _("Please {0}verify your email address{1} then reload this page.",
-          '<a href="%s" target="_blank">'|safe % participant.path('emails/'),
-          '</a>'|safe)
-    }}</p>
     % endif
     % endif
 


### PR DESCRIPTION
This makes donating for the first time easier. The next step is #247.

MangoPay said it's okay to send them email addresses we haven't verified.