### PR TITLE
Modify i18n extraction to flag messages properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ pytest-re: env
 
 _i18n_extract: env
 	@PYTHONPATH=. $(env_bin)/pybabel extract -F .babel_extract --no-wrap -o i18n/core.pot emails liberapay templates www
+	@PYTHONPATH=. $(env_bin)/python liberapay/utils/i18n.py po-reflag i18n/core.pot
 	@for f in i18n/*/*.po; do \
 		$(env_bin)/pybabel update -i i18n/core.pot -l $$(basename -s '.po' "$$f") -o "$$f" --ignore-obsolete --no-fuzzy-matching --no-wrap; \
 	done
@@ -85,6 +86,7 @@ _i18n_clean:
 	    sed -E -e '/^"(POT?-[^-]+-Date|Last-Translator|X-Generator|Language): /d' \
 	           -e 's/^("[^:]+: ) +/\1/' \
 	           -e 's/^("Language-Team: .+? )<(.+)>\\n/\1"\n"<\2>\\n/' \
+	           -e 's/^#(, .+)?, python-format(, .+)?$$/#\1\2/' \
 	           -e '/^#: /d' "$$f" >"$$f.new"; \
 	    mv "$$f.new" "$$f"; \
 	done

--- a/liberapay/utils/i18n.py
+++ b/liberapay/utils/i18n.py
@@ -318,3 +318,34 @@ def extract_spt(fileobj, *args, **kw):
         if extractor:
             for match in extractor(f, *args, **kw):
                 yield match
+
+
+if __name__ == '__main__':
+    import sys
+
+    from babel.messages.pofile import read_po, write_po
+
+    if sys.argv[1] == 'po-reflag':
+        # This adds the `python-brace-format` flag to messages that contain braces
+        # https://github.com/python-babel/babel/issues/333
+        pot_path = sys.argv[2]
+        print('rewriting PO template file', pot_path)
+        # read PO file
+        with open(pot_path, 'rb') as pot:
+            catalog = read_po(pot)
+        # tweak message flags
+        for m in catalog:
+            msg = m.id
+            contains_brace = any(
+                '{' in s for s in (msg if isinstance(msg, tuple) else (msg,))
+            )
+            if contains_brace:
+                m.flags.add('python-brace-format')
+            m.flags.discard('python-format')
+        # write back
+        with open(pot_path, 'wb') as pot:
+            write_po(pot, catalog, width=0)
+
+    else:
+        print("unknown command")
+        raise SystemExit(1)


### PR DESCRIPTION
This is a workaround for <https://github.com/python-babel/babel/issues/333>. It will add ~2200 lines to our PO files, so I hope Weblate will eventually give us a better solution (<https://github.com/nijel/weblate/issues/1210>).