### PR TITLE
Fix language of first email

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -118,7 +118,7 @@ class Participant(Model, MixinTeam):
             p.change_username(username, c)
         return p
 
-    def make_team(self, name, email=None):
+    def make_team(self, name, email=None, email_lang=None):
         with self.db.get_cursor() as c:
             t = c.one("""
                 INSERT INTO participants
@@ -129,6 +129,7 @@ class Participant(Model, MixinTeam):
             t.change_username(name, c)
             t.add_member(self, c)
         if email:
+            t.set_email_lang(email_lang)
             t.add_email(email)
         return t
 
@@ -737,13 +738,15 @@ class Participant(Model, MixinTeam):
                     delete(msg)
                 sleep(1)
 
-    def set_email_lang(self, accept_lang):
+    def set_email_lang(self, accept_lang, cursor=None):
         if not accept_lang:
             return
         if isinstance(accept_lang, bytes):
             accept_lang = accept_lang.decode('ascii', 'replace')
-        self.db.run("UPDATE participants SET email_lang=%s WHERE id=%s",
-                    (accept_lang, self.id))
+        (cursor or self.db).run(
+            "UPDATE participants SET email_lang=%s WHERE id=%s",
+            (accept_lang, self.id)
+        )
         self.set_attributes(email_lang=accept_lang)
 
 

--- a/liberapay/security/authentication.py
+++ b/liberapay/security/authentication.py
@@ -60,6 +60,7 @@ def sign_in_with_form_data(body, state):
                 body.pop('sign-in.username'), kind, body.pop('sign-in.password'),
                 cursor=c
             )
+            p.set_email_lang(state['request'].headers.get(b'Accept-Language'), cursor=c)
             p.add_email(body.pop('sign-in.email'), cursor=c)
         p.authenticated = True
 

--- a/tests/py/test_sign_in.py
+++ b/tests/py/test_sign_in.py
@@ -234,3 +234,9 @@ class TestSignIn(EmailHarness):
     def test_sign_in_terms_not_checked(self):
         r = self.sign_in(dict(terms=None))
         assert r.code == 400
+
+    def test_sign_in_without_csrf_cookie(self):
+        r = self.sign_in(csrf_token=None)
+        assert r.code == 403
+        assert "Bad CSRF cookie" in r.text
+        assert SESSION not in r.headers.cookie

--- a/tests/py/test_sign_in.py
+++ b/tests/py/test_sign_in.py
@@ -199,6 +199,12 @@ class TestSignIn(EmailHarness):
         p = Participant.from_username(username)
         assert p.avatar_url
 
+    def test_sign_in_form_repost(self):
+        extra = {'name': 'python', 'lang': 'mul', 'form.repost': 'true'}
+        r = self.sign_in(url='/for/new', extra=extra)
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/for/python/edit'
+
     def test_sign_in_non_ascii_username(self):
         r = self.sign_in(dict(username='mélodie'.encode('utf8')))
         assert r.code == 400

--- a/www/about/teams.spt
+++ b/www/about/teams.spt
@@ -20,7 +20,8 @@ if request.method == 'POST':
         else:
             raise UsernameAlreadyTaken(name)
     else:
-        t = user.make_team(name, request.body.get('email'))
+        email_lang = request.headers.get(b'Accept-Language')
+        t = user.make_team(name, request.body.get('email'), email_lang)
     response.redirect('/'+t.username+'/edit')
 
 title = _("Teams")


### PR DESCRIPTION
We currently set `email_lang` too late, so the first email we send is always in English. This PR will fix that, and take care of #93 too.