### PR TITLE
Add warning for bank SWIFT fee

### DIFF
--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -109,7 +109,7 @@ title = _("Withdraw money")
     % if show_form
     <p>{{ _(
         "Withdrawing money to a SEPA bank account is free, transfers to other "
-        "countries cost {0} per transfer.",
+        "countries cost {0} per transfer. Additional fee from your bank may apply.",
         Money(constants.FEE_PAYOUT_OUTSIDE_SEPA.fix * (constants.FEE_VAT + 1), 'EUR'),
     ) }}</p>
 

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -78,7 +78,7 @@ title = _("Frequently Asked Questions")
         constants.FEE_PAYIN_BANK_WIRE.var * (constants.FEE_VAT + 1) * 100,
     ) }}<br>{{ _(
         "Withdrawing money to a SEPA bank account is free, transfers to other "
-        "countries cost {0} per transfer.",
+        "countries cost {0} per transfer. Additional fee from your bank may apply.",
         Money(constants.FEE_PAYOUT_OUTSIDE_SEPA.fix * (constants.FEE_VAT + 1), 'EUR'),
     ) }}</dd>
 


### PR DESCRIPTION
When I was receiving funds from liberapay, I received a call from my bank's personnel saying "you have to pay a fee[1] but we'll waive the fee for this time". I think this is worth noting that your bank may have a fee on (even) receiving funds.

And well, I'm not sure about indentation or any other place that need same notice so review is really welcome.

[1]: fee was greater than the total receiving amount, fyi.