### PR TITLE
Cache stable redirects

### DIFF
--- a/liberapay/utils/state_chain.py
+++ b/liberapay/utils/state_chain.py
@@ -58,7 +58,9 @@ def canonize(request, website):
         else:
             # For non-idempotent methods, redirect to homepage.
             url += '/'
-        website.redirect(url)
+        response = Response()
+        response.headers[b'Cache-Control'] = b'public, max-age=86400'
+        response.redirect(url)
 
 
 def insert_constants():

--- a/tests/py/test_hooks.py
+++ b/tests/py/test_hooks.py
@@ -37,6 +37,7 @@ class Tests(Harness):
                                    )
         assert response.code == 302
         assert response.headers[b'Location'] == b'https://example.com/'
+        assert response.headers[b'Cache-Control'] == b'public, max-age=86400'
 
     def test_no_cookies_over_http(self):
         """


### PR DESCRIPTION
The protocol and domain redirects are pretty stable, caching them for 24 hours shouldn't pose any problem. The goal is of course to shift the load from the app server to the reverse proxies (we currently use CloudFlare).