### PR TITLE
Add support for montly and yearly donation amounts

### DIFF
--- a/js/10-base.js
+++ b/js/10-base.js
@@ -52,12 +52,18 @@ Liberapay.init = function() {
         }
     });
 
-    var amount_re = /\?(.*&)*amount=(.+?)(&|$)/;
+    var amount_re = /\?(.*&)*amount=(.*?)(&|$)/;
+    var period_re = /\?(.*&)*period=(.*?)(&|$)/;
     $('a.amount-btn').each(function() {
         $(this).data('href', this.getAttribute('href')).attr('href', null);
     }).click(function(e) {
         var href = $(this).data('href');
         $('#amount').val(amount_re.exec(href)[2]);
+        var period = period_re.exec(href);
+        period = (period ? period[2] : 'weekly') || 'weekly';
+        $('select[name=period] > option').filter(
+            function () { return this.getAttribute('value') === period }
+        ).prop('selected', true);
         history.pushState(null, null, location.pathname + href + location.hash);
     });
 

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -3,7 +3,7 @@ from __future__ import print_function, unicode_literals
 
 from collections import namedtuple, OrderedDict
 from datetime import date, datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, ROUND_UP
 import re
 
 from jinja2 import StrictUndefined
@@ -50,6 +50,16 @@ D_INF = Decimal('inf')
 D_UNIT = Decimal('1.00')
 D_ZERO = Decimal('0.00')
 
+DONATION_LIMITS_WEEKLY = (Decimal('0.01'), Decimal('100.00'))
+DONATION_LIMITS = {
+    'weekly': DONATION_LIMITS_WEEKLY,
+    'monthly': tuple((x * Decimal(52) / Decimal(12)).quantize(D_CENT, rounding=ROUND_UP)
+                     for x in DONATION_LIMITS_WEEKLY),
+    'yearly': tuple((x * Decimal(52)).quantize(D_CENT)
+                    for x in DONATION_LIMITS_WEEKLY),
+}
+DONATION_WEEKLY_MIN, DONATION_WEEKLY_MAX = DONATION_LIMITS_WEEKLY
+
 ELSEWHERE_ACTIONS = {'connect', 'lock', 'unlock'}
 
 EMAIL_VERIFICATION_TIMEOUT = timedelta(hours=24)
@@ -91,15 +101,18 @@ KYC_PAYOUT_YEARLY_THRESHOLD = Decimal('1000')
 
 LAUNCH_TIME = datetime(2016, 2, 3, 12, 50, 0, 0, utc)
 
-MAX_TIP = Decimal('100.00')
-MIN_TIP = Decimal('0.01')
-
 PASSWORD_MIN_SIZE = 8
 PASSWORD_MAX_SIZE = 150
 
 PAYIN_BANK_WIRE_MIN = Decimal('2.00')
 PAYIN_CARD_MIN = Decimal("15.00")  # fee ≈ 3.5%
 PAYIN_CARD_TARGET = Decimal("92.00")  # fee ≈ 2.33%
+
+PERIOD_CONVERSION_RATES = {
+    'weekly': Decimal(1),
+    'monthly': Decimal(12) / Decimal(52),
+    'yearly': Decimal(1) / Decimal(52),
+}
 
 PRIVACY_FIELDS = OrderedDict([
     ('hide_giving', _("Hide total giving from others.")),
@@ -129,7 +142,7 @@ STANDARD_TIPS = (
     (_("Small ({0})"), Decimal('0.25')),
     (_("Medium ({0})"), Decimal('1.00')),
     (_("Large ({0})"), Decimal('5.00')),
-    (_("Maximum ({0})"), MAX_TIP),
+    (_("Maximum ({0})"), DONATION_WEEKLY_MAX),
 )
 
 USERNAME_MAX_SIZE = 32

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -138,11 +138,11 @@ SESSION_REFRESH = timedelta(hours=1)
 SESSION_TIMEOUT = timedelta(hours=6)
 
 STANDARD_TIPS = (
-    (_("Symbolic ({0})"), Decimal('0.01')),
-    (_("Small ({0})"), Decimal('0.25')),
-    (_("Medium ({0})"), Decimal('1.00')),
-    (_("Large ({0})"), Decimal('5.00')),
-    (_("Maximum ({0})"), DONATION_WEEKLY_MAX),
+    (_("Symbolic ({0} per week)"), Decimal('0.01')),
+    (_("Small ({0} per week)"), Decimal('0.25')),
+    (_("Medium ({0} per week)"), Decimal('1.00')),
+    (_("Large ({0} per week)"), Decimal('5.00')),
+    (_("Maximum ({0} per week)"), DONATION_WEEKLY_MAX),
 )
 
 USERNAME_MAX_SIZE = 32

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -3,7 +3,7 @@ from __future__ import print_function, unicode_literals
 from dependency_injection import resolve_dependencies
 from pando import Response
 
-from .constants import MAX_TIP, MIN_TIP, PASSWORD_MIN_SIZE, PASSWORD_MAX_SIZE
+from .constants import DONATION_LIMITS, PASSWORD_MIN_SIZE, PASSWORD_MAX_SIZE
 
 
 class Redirect(Exception):
@@ -117,10 +117,18 @@ class NoTippee(LazyResponse400):
     def msg(self, _):
         return _("There is no user named {0}.", *self.args)
 
+_ = lambda a: a
+BAD_AMOUNT_MESSAGES = {
+    'weekly': _("'{0}' is not a valid weekly donation amount (min={1}, max={2})"),
+    'monthly': _("'{0}' is not a valid monthly donation amount (min={1}, max={2})"),
+    'yearly': _("'{0}' is not a valid yearly donation amount (min={1}, max={2})"),
+}
+del _
+
 class BadAmount(LazyResponse400):
     def msg(self, _):
-        return _("'{0}' is not a valid donation amount (min={1}, max={2})",
-                 self.args[0], MIN_TIP, MAX_TIP)
+        period = self.args[1]
+        return _(BAD_AMOUNT_MESSAGES[period], self.args[0], *DONATION_LIMITS[period])
 
 class UserDoesntAcceptTips(LazyResponse400):
     def msg(self, _):

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -12,4 +12,9 @@ BEGIN;
         ALTER COLUMN period SET NOT NULL,
         ALTER COLUMN periodic_amount SET NOT NULL;
 
+    CREATE OR REPLACE VIEW current_tips AS
+        SELECT DISTINCT ON (tipper, tippee) *
+          FROM tips
+      ORDER BY tipper, tippee, mtime DESC;
+
 END;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+    CREATE TYPE donation_period AS ENUM ('weekly', 'monthly', 'yearly');
+
+    ALTER TABLE tips
+        ADD COLUMN period donation_period,
+        ADD COLUMN periodic_amount numeric(35,2);
+
+    UPDATE tips SET period = 'weekly', periodic_amount = amount;
+
+    ALTER TABLE tips
+        ALTER COLUMN period SET NOT NULL,
+        ALTER COLUMN periodic_amount SET NOT NULL;
+
+END;

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -82,6 +82,10 @@ input.amount {
     width: auto !important;
 }
 
+.input-group select.form-control {
+    width: auto;
+}
+
 .input-group-addon:not(:first-child) {
     border-left: none;
 }

--- a/templates/your-tip.html
+++ b/templates/your-tip.html
@@ -31,7 +31,11 @@
                class="amount form-control {{ 'input-sm' if small else '' }}"
                value="{{ request.qs.get('amount') or format_decimal(tip.amount) }}"
                {{ disabled }} />
-        <div class="input-group-addon">{{ _("per week") }}</div>
+        <select name="period" class="form-control {{ 'input-sm' if small else '' }}">
+            <option value="weekly">{{ _("per week") }}</option>
+            <option value="monthly">{{ _("per month") }}</option>
+            <option value="yearly">{{ _("per year") }}</option>
+        </select>
         <div class="input-group-btn">
             <button class="btn btn-{{ 'primary' if tip.amount > 0 else 'donate' }}
                            {{ 'btn-sm' if small else '' }}" {{ disabled }}>{{

--- a/templates/your-tip.html
+++ b/templates/your-tip.html
@@ -29,12 +29,13 @@
         <div class="input-group-addon">€</div>
         <input type="text" name="amount" id="amount"
                class="amount form-control {{ 'input-sm' if small else '' }}"
-               value="{{ request.qs.get('amount') or format_decimal(tip.amount) }}"
+               value="{{ request.qs.get('amount') or format_decimal(tip.periodic_amount) }}"
                {{ disabled }} />
+        % set period = request.qs.get('period') or tip.period
         <select name="period" class="form-control {{ 'input-sm' if small else '' }}">
             <option value="weekly">{{ _("per week") }}</option>
-            <option value="monthly">{{ _("per month") }}</option>
-            <option value="yearly">{{ _("per year") }}</option>
+            <option value="monthly" {{ 'selected' if period == 'monthly' }}>{{ _("per month") }}</option>
+            <option value="yearly" {{ 'selected' if period == 'yearly' }}>{{ _("per year") }}</option>
         </select>
         <div class="input-group-btn">
             <button class="btn btn-{{ 'primary' if tip.amount > 0 else 'donate' }}

--- a/templates/your-tip.html
+++ b/templates/your-tip.html
@@ -16,7 +16,7 @@
             % for msg, amount in constants.STANDARD_TIPS
                 % set amount_str = format_decimal(amount, '#,##0.00')
                 <a class="btn btn-default amount-btn" href="?amount={{ amount_str }}"
-                   rel="nofollow">{{ _(msg, amount_str) }}</a>
+                   rel="nofollow">{{ _(msg, Money(amount, 'EUR')) }}</a>
             % endfor
             </div>
             <br>

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -82,7 +82,7 @@ class TestTakeOver(Harness):
         bob.take_over(carl, have_confirmation=True)
         tips = self.db.all("select * from tips where amount > 0 order by id asc")
         assert len(tips) == 3
-        assert tips[-1].amount == 6
+        assert tips[-1].amount == 5
         assert tips[-1].is_funded is False
         self.db.self_check()
 

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -286,6 +286,18 @@ class Tests(Harness):
         assert t['is_pledge'] is False
         assert t['first_time_tipper'] is True
 
+    def test_stt_works_for_monthly_donations(self):
+        alice = self.make_participant('alice', balance=100)
+        bob = self.make_participant('bob')
+        t = alice.set_tip_to(bob, '4.33', 'monthly')
+        assert t['amount'] == 1
+
+    def test_stt_works_for_yearly_donations(self):
+        alice = self.make_participant('alice', balance=100)
+        bob = self.make_participant('bob')
+        t = alice.set_tip_to(bob, '104', 'yearly')
+        assert t['amount'] == 2
+
     def test_stt_returns_False_for_second_time_tipper(self):
         alice = self.make_participant('alice', balance=100)
         bob = self.make_participant('bob')

--- a/tests/py/test_tip_json.py
+++ b/tests/py/test_tip_json.py
@@ -42,11 +42,11 @@ class TestTipJson(Harness):
         bob = self.make_participant("bob")
 
         response = self.tip(bob, "alice", "110.00", raise_immediately=False)
-        assert "not a valid donation amount" in response.text
+        assert "not a valid weekly donation amount" in response.text
         assert response.code == 400
 
         response = self.tip(bob, "alice", "-1.00", raise_immediately=False)
-        assert "not a valid donation amount" in response.text
+        assert "not a valid weekly donation amount" in response.text
         assert response.code == 400
 
     def test_set_tip_to_patron(self):

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -118,7 +118,12 @@ weekly = total - participant.receiving
         <tfoot>
             <tr>
                 <th></th>
-                <th class="total">{{ total }}</th>
+                <th class="total">{{ _(
+                    "{0} per week ~ {1} per month ~ {2} per year",
+                    Money(total, 'EUR'),
+                    Money(total / constants.PERIOD_CONVERSION_RATES['monthly'], 'EUR'),
+                    Money(total / constants.PERIOD_CONVERSION_RATES['yearly'], 'EUR'),
+                ) }}</th>
                 <th></th>
                 <th></th>
                 <th></th>
@@ -164,7 +169,12 @@ weekly = total - participant.receiving
         <tfoot>
             <tr>
                 <th></th>
-                <th class="total">{{ pledges_total }}</th>
+                <th class="total">{{ _(
+                    "{0} per week ~ {1} per month ~ {2} per year",
+                    Money(pledges_total, 'EUR'),
+                    Money(pledges_total / constants.PERIOD_CONVERSION_RATES['monthly'], 'EUR'),
+                    Money(pledges_total / constants.PERIOD_CONVERSION_RATES['yearly'], 'EUR'),
+                ) }}</th>
                 <th></th>
                 <th></th>
             </tr>

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -103,7 +103,7 @@ weekly = total - participant.receiving
 <div class="giving row valign-middle">
 
 % if ntips
-<div class="col-md-8">
+<div class="col-lg-12">
     <h3>{{ _("Donations") }} (N={{ ntips }})</h3>
     <table class="table">
         <thead>
@@ -150,7 +150,7 @@ weekly = total - participant.receiving
 % endif
 
 % if npledges
-<div class="col-md-8">
+<div class="col-lg-8">
     <h3>{{ _("Pledges") }} (N={{ len(pledges) }})</h3>
     <table class="table">
         <thead>
@@ -187,7 +187,7 @@ weekly = total - participant.receiving
 % endif
 
 % if ncancelled_tips
-<div class="col-md-8">
+<div class="col-lg-7">
     <h3>{{ _("Recently Cancelled") }} (N={{ ncancelled_tips }})
         <small>{{ _("within the last 30 days") }}</small></h3>
     <table class="table">

--- a/www/%username/tip.spt
+++ b/www/%username/tip.spt
@@ -5,6 +5,14 @@ from base64 import b64encode
 from liberapay.exceptions import AuthRequired
 from liberapay.utils import b64encode_s, get_participant
 
+_ = lambda a: a
+MESSAGES = {
+    'weekly': _("You are now donating {0} per week to {1}. Thank you!"),
+    'monthly': _("You are now donating {0} per month to {1}. Thank you!"),
+    'yearly': _("You are now donating {0} per year to {1}. Thank you!"),
+}
+del _
+
 [-----------------------------------------------------------------------------]
 
 if user.ANON:
@@ -32,10 +40,10 @@ if request.method == 'POST':
         raise Response(400, "bad 'period' value '%s'" % period)
     out = tipper.set_tip_to(tippee, parse_decimal(request.body['amount']), period)
     if out['amount'] == 0:
-        out["msg"] = _("Your weekly donation to {0} has been stopped.", tippee_name)
+        out["msg"] = _("Your donation to {0} has been stopped.", tippee_name)
     else:
-        out["msg"] = _("You are now donating {0} per week to {1}. Thank you!",
-                       Money(out['amount'], 'EUR'), tippee_name)
+        out["msg"] = _(MESSAGES[out['period']],
+                       Money(out['periodic_amount'], 'EUR'), tippee_name)
     if request.headers.get(b'X-Requested-With') != b'XMLHttpRequest':
         back_to = request.body.get('back_to') or tipper.path('giving/')
         back_to += '&' if '?' in back_to else '?'

--- a/www/%username/tip.spt
+++ b/www/%username/tip.spt
@@ -27,7 +27,10 @@ if tippee.status == 'stub':
 # =========================
 
 if request.method == 'POST':
-    out = tipper.set_tip_to(tippee, parse_decimal(request.body['amount']))
+    period = request.body.get('period', 'weekly')
+    if period not in constants.PERIOD_CONVERSION_RATES:
+        raise Response(400, "bad 'period' value '%s'" % period)
+    out = tipper.set_tip_to(tippee, parse_decimal(request.body['amount']), period)
     if out['amount'] == 0:
         out["msg"] = _("Your weekly donation to {0} has been stopped.", tippee_name)
     else:

--- a/www/%username/tips.json.spt
+++ b/www/%username/tips.json.spt
@@ -15,9 +15,10 @@ if request.method == 'POST':
         seen.add(tip['username'])
         one = {"username": tip['username']}
         try:
-            amount = participant.set_tip_to( tip['username']
-                                           , parse_decimal(tip['amount'])
-                                            )['amount']
+            amount = participant.set_tip_to(
+                tip['username'], parse_decimal(tip['amount']),
+                tip.get('period', 'weekly'),
+            )['amount']
         except Exception as exc:
             amount = "error"
             one['error'] = exc.__class__.__name__
@@ -28,7 +29,7 @@ if request.method == 'POST':
         old_tips = participant.get_current_tips()
         for tip in old_tips:
             if tip['username'] not in seen:
-                participant.set_tip_to(tip['username'], '0.00')
+                participant.set_tip_to(tip['username'], '0.00', tip['period'])
 
 else:
     tips, total, pledges, pledges_total = participant.get_giving_for_profile()

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -97,12 +97,13 @@ title = _("Frequently Asked Questions")
         "The minimum you can give any user is {0}. To minimize processing fees, "
         "we charge your credit card at least {1} at a time (the money is stored "
         "in your Liberapay wallet and transferred to others during Payday)."
-        , Money(constants.MIN_TIP, 'EUR'), Money(constants.PAYIN_CARD_MIN, 'EUR')
+        , Money(constants.DONATION_WEEKLY_MIN, 'EUR')
+        , Money(constants.PAYIN_CARD_MIN, 'EUR')
     ) }}<br>
     {{ _(
         "The maximum you can give any one user is {0} per week. This helps to "
         "stabilize income by reducing how dependent it is on a few large patrons."
-        , Money(constants.MAX_TIP, 'EUR')
+        , Money(constants.DONATION_WEEKLY_MAX, 'EUR')
     ) }}
     </dd>
 

--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -15,7 +15,7 @@ title = _("Introduction")
         "Payments come with no strings attached. You don't know exactly who is "
         "giving to you, and donations are capped at {0} per week per donor to "
         "dampen undue influence."
-        , Money(constants.MAX_TIP, 'EUR')
+        , Money(constants.DONATION_WEEKLY_MAX, 'EUR')
     ) }}</p>
 
     <p>{{ _(


### PR DESCRIPTION
This PR closes #85.

In reality donations are always processed weekly (payday isn't modified), but now users can input a monthly or yearly donation amount and the server automatically computes the weekly equivalent (see `PERIOD_CONVERSION_RATES`) which is then used during payday.

Each donation has its own period, so you can have any combination of weekly, monthly, and yearly donations. This may be unnecessary complexity, perhaps one period per user would have been simpler, I'm not sure.