### PR TITLE
Fix #448: added Docker configuration for easier development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:8
+
+RUN apt-get update && apt-get install build-essential wget libpq-dev python-dev postgresql-client -y
+
+RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && python /tmp/get-pip.py
+
+ADD ./requirements.txt /requirements/pip/base.txt
+RUN pip install -r /requirements/pip/base.txt
+
+ADD ./requirements_dev.txt /requirements/pip/dev.txt
+RUN pip install -r /requirements/pip/dev.txt
+
+ADD ./requirements_tests.txt /requirements/pip/tests.txt
+RUN pip install -r /requirements/pip/tests.txt
+
+ADD . /app
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ To deploy the app simply run `release.sh`, it'll guide you through it. Of course
 
 [OS-dev]: https://developers.openshift.com/
 
+### Setting up a development environment using Docker
+
+If you don't want to install directly dependencies on your machine, you can spin up a development environment easily, assuming you have [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed:
+
+    # build the local container
+    docker-compose build
+
+    # initialize the database
+    docker-compose run web bash recreate-schema.sh
+
+    # populate the database with fake data
+    docker-compose run web python -m liberapay.utils.fake_data
+
+    # launch the database and the web server
+    # the application should be available on http://localhost:8339
+    docker-compose up
+
+You can also run tests in the DOcker environment:
+
+    docker-compose -f docker/tests.yml run tests
+
+All arguments are passed to the underlying `py.test` command, so you can use `-x` for failing fast or `--ff` to retry failed tests first:
+
+    docker-compose -f docker/tests.yml run tests -x --ff
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+services:
+    web:
+        extends:
+            file: docker/common.yml
+            service: web
+        command: python app.py
+        entrypoint: honcho run -e defaults.env,docker/defaults.env,local.env
+        links:
+            - db
+        ports:
+            - "8339:8339"
+
+    db:
+        image: postgres:9.4
+        volumes:
+            - /var/lib/postgresql/data

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+    web:
+        build: ..
+        volumes:
+            - ..:/app

--- a/docker/defaults.env
+++ b/docker/defaults.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres@db/postgres
+GUNICORN_OPTS=bind=0.0.0.0:8339 workers=2 reload=True timeout=99999999

--- a/docker/runtests
+++ b/docker/runtests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./recreate-schema.sh test && py.test ./tests/ "$@"

--- a/docker/tests.env
+++ b/docker/tests.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres@test_db/postgres
+PYTHONPATH=.

--- a/docker/tests.yml
+++ b/docker/tests.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+    tests:
+        extends:
+            file: common.yml
+            service: web
+        entrypoint: honcho run -e defaults.env,tests/test.env,docker/tests.env,tests/local.env ./docker/runtests
+        links:
+            - test_db
+    test_db:
+        image: postgres:9.4


### PR DESCRIPTION
This is a basic PoC of a development setup using Docker. **I've put the usage instructions in the README, but if you'd rather not have it here, we can easily move it somewhere else** (maybe there is a wiki or documentation you use internally).

Basically, if you want to start on the project and have Docker / docker-compose installed, you can now set up the whole thing in 3 commands:

    docker-compose build                        
    docker-compose run web bash recreate-schema.sh
    docker-compose run web python -m liberapay.utils.fake_data

Then run the application with:

    docker-compose up

The first one is the real Docker one, that spins up the application container (based on Debian 8, but this can be changed to reflect the production environment). The other ones are simple calls to existing setup scripts (database creation and population).

Tests with py.test are working in this setup, you can run the whole test suite with:

    docker-compose -f docker/tests.yml run tests

Note this accept all py.test arguments such as --ff (failed tests first) or -x (fail fast):

    docker-compose -f docker/tests.yml run tests --ff -x