### PR TITLE
fixed #294: Added link to user profile under avatar on pledge detail

### DIFF
--- a/www/on/%platform/%user_name/index.html.spt
+++ b/www/on/%platform/%user_name/index.html.spt
@@ -66,6 +66,10 @@ if is_team:
 
             <div class="avatar col-xs-3">
                 <a href="{{ account.html_url}}">{{ avatar_img(account) }}</a>
+                <hr />
+                <p><a href="{{ account.html_url}}">
+                    <span class="fa fa-external-link" aria-hidden="true"></span> {{ _("Profile on {0}", platform.display_name) }}</a>
+                </p>
             </div>
 
             <div class="col-xs-9">


### PR DESCRIPTION
This is a real pull request this time, fixing an actual issue. As explained in #294, the pledge detail page was missing an explicit link. My implementation adds a link with an `external-link` icon from font-awesome, and with the text `Profile on {platform}`, as shown below:

![screenshot from 2016-11-30 23-09-19](https://cloud.githubusercontent.com/assets/1970915/20773492/60b14b92-b752-11e6-970a-483dd152bf08.png)

I'm not sure how to handle i18n though. Should I run a command to compile the new translation ?

