### PR TITLE
Fix #132: Added explicit button to update nominal take in team table

### DIFF
--- a/templates/team-members.html
+++ b/templates/team-members.html
@@ -40,7 +40,10 @@
                     <form action="/~{{ team.id }}/income/take?back_to={{ urlquote(request.line.uri) }}"
                           method="POST">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
-                        <input class="form-control" name="take" value="{{ format_decimal(member.nominal_take, '#,##0.00') }}" />
+                        <div class="input-group">
+                            <input class="form-control" name="take" value="{{ format_decimal(member.nominal_take, '#,##0.00') }}" />
+                            <span class="input-group-btn"><button class="btn btn-default" title="{{ _("Update my nominal take") }}" type="submit"><i class="fa fa-edit"></i></button></span>
+                        </div>
                     </form>
                 </td>
             % else


### PR DESCRIPTION
This was a simple one (as promised):

![screenshot from 2016-12-01 17-41-14](https://cloud.githubusercontent.com/assets/1970915/20802874/bd101710-b7ed-11e6-8a32-c366e110664d.png)

However, on the long term, I think the UX would be better if the line relavent to the current user was put somewhere in a deterministic way, for example at the top, or to move the form outside the table. I imagine if you have a team with 10s of members, it will become painful to find yourself in that. Also, if you're not familiar with the UI, it can be easy to miss the input.

Also, because of how bootstrap handles input groups, the line holding the input will be taller than other ones. 