### PR TITLE
Fix balances in notifications

### DIFF
--- a/emails/income.spt
+++ b/emails/income.spt
@@ -24,7 +24,7 @@
     </ul>
 % endif
 
-<p>{{ _("You now have {0} in your wallet.", Money(participant.balance, 'EUR')) }}</p>
+<p>{{ _("You now have {0} in your wallet.", Money(new_balance, 'EUR')) }}</p>
 
 <a href="{{ participant.url('wallet/') }}">{{ _("See your account's transaction logs") }}</a>
 
@@ -50,6 +50,6 @@
     % endfor
 % endif
 
-{{ _("You now have {0} in your wallet.", Money(participant.balance, 'EUR')) }}
+{{ _("You now have {0} in your wallet.", Money(new_balance, 'EUR')) }}
 
 {{ _("See your account's transaction logs") }}: {{ participant.url('wallet/') }}

--- a/emails/low_balance.spt
+++ b/emails/low_balance.spt
@@ -2,13 +2,13 @@
 
 [---] text/html
 {{ _("You have {0} left in your Liberapay wallet, but you need at least {1} to cover your donations next week.",
-     Money(participant.balance, 'EUR'), Money(participant.get_giving_for_profile()[1], 'EUR')) }}
+     Money(low_balance, 'EUR'), Money(participant.get_giving_for_profile()[1], 'EUR')) }}
 
 <a href="{{ participant.url('wallet/payin/') }}" style="{{ button_style }}"
     >{{ _("Add money") }}</a>
 
 [---] text/plain
 {{ _("You have {0} left in your Liberapay wallet, but you need at least {1} to cover your donations next week.",
-     Money(participant.balance, 'EUR'), Money(participant.get_giving_for_profile()[1], 'EUR')) }}
+     Money(low_balance, 'EUR'), Money(participant.get_giving_for_profile()[1], 'EUR')) }}
 
 {{ _("Add money") }}: {{ participant.url('wallet/payin/') }}

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -587,11 +587,13 @@ class Payday(object):
                        for k, v in group_by(successes, 'team').items()}
             personal = by_team.pop(None, 0)
             by_team = {Participant.from_id(k).username: v for k, v in by_team.items()}
-            Participant.from_id(tippee_id).notify(
+            p = Participant.from_id(tippee_id)
+            p.notify(
                 'income',
                 total=sum(t['amount'] for t in successes),
                 personal=personal,
                 by_team=by_team,
+                new_balance=p.balance,
             )
 
         # Identity-required notifications
@@ -636,7 +638,7 @@ class Payday(object):
                    )
         """, (previous_ts_end, self.ts_end))
         for p in participants:
-            p.notify('low_balance')
+            p.notify('low_balance', low_balance=p.balance)
 
 
 def main(override_payday_checks=False):

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+DELETE FROM notification_queue WHERE event IN ('income', 'low_balance');


### PR DESCRIPTION
Closes #409. Fixing the old notifications isn't straightforward, so this PR deletes them, because we have more important things to work on.