### PR TITLE
Don't redirect widget requests to canonical URL

### DIFF
--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -29,7 +29,7 @@ BEGINNING_OF_EPOCH = to_rfc822(datetime(1970, 1, 1)).encode('ascii')
 
 
 def get_participant(state, restrict=True, redirect_stub=True, allow_member=False,
-                    block_suspended_user=False):
+                    block_suspended_user=False, redirect_canon=True):
     """Given a Request, raise Response or return Participant.
 
     If restrict is True then we'll restrict access to owners and admins.
@@ -59,7 +59,7 @@ def get_participant(state, restrict=True, redirect_stub=True, allow_member=False
         if participant is None or participant.kind == 'community':
             raise response.error(404)
 
-    if request.method in ('GET', 'HEAD'):
+    if redirect_canon and request.method in ('GET', 'HEAD'):
         if slug != participant.username:
             canon = '/' + participant.username + request.line.uri[len(slug)+1:]
             raise response.redirect(canon)

--- a/www/%username/widgets/%type.spt
+++ b/www/%username/widgets/%type.spt
@@ -10,7 +10,7 @@ t = request.path['type']
 if t not in ('giving.js', 'receiving.js'):
     raise response.error(400)
 
-participant = get_participant(state, restrict=False)
+participant = get_participant(state, restrict=False, redirect_canon=False)
 
 if participant.hide_giving and t != 'receiving.js' or \
    participant.hide_receiving and t != 'giving.js':

--- a/www/%username/widgets/button.js.spt
+++ b/www/%username/widgets/button.js.spt
@@ -6,7 +6,7 @@ ICON = include_svg(ICON, 16, 16)
 
 [---]
 
-participant = get_participant(state, restrict=False)
+participant = get_participant(state, restrict=False, redirect_canon=False)
 
 response.headers[b'Cache-Control'] = b'public, max-age=86400'
 response.headers[b'Vary'] = b'Accept-Language'


### PR DESCRIPTION
Because it's more efficient that way, obviously.