### PR TITLE
Add Content Security Policy (CSP)

### DIFF
--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -15,7 +15,7 @@ from liberapay import utils, wireup
 from liberapay.cron import Cron
 from liberapay.models.community import Community
 from liberapay.models.participant import Participant
-from liberapay.security import authentication, csrf, allow_cors_for_assets, x_frame_options
+from liberapay.security import authentication, csrf, set_default_security_headers
 from liberapay.utils import b64decode_s, b64encode_s, erase_cookie, http_caching, i18n, set_cookie
 from liberapay.utils.state_chain import (
     create_response_object, canonize, insert_constants,
@@ -117,8 +117,7 @@ algorithm.functions = [
     authentication.add_auth_to_response,
     csrf.add_token_to_response,
     http_caching.add_caching_to_response,
-    x_frame_options,
-    allow_cors_for_assets,
+    set_default_security_headers,
 
     algorithm['delegate_error_to_simplate'],
     tell_sentry,

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -26,6 +26,8 @@ def set_default_security_headers(response, request=None):
 
         del response.headers[b'X-Frame-Options']
 
+    # CSP is a client-side protection against code injection (XSS)
+    # https://scotthelme.co.uk/content-security-policy-an-introduction/
     if b'content-security-policy' not in response.headers:
         response.headers[b'content-security-policy'] = (
             b"default-src 'self';"

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -1,21 +1,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 
-def allow_cors_for_assets(response, request=None):
-    """The subdomains need this to access the assets on the main domain.
-    """
+def set_default_security_headers(response, request=None):
+    # Allow CORS for assets
+    # The subdomains need this to access the assets on the main domain.
     if request is not None and request.path.raw.startswith('/assets/'):
         if b'Access-Control-Allow-Origin' not in response.headers:
             response.headers[b'Access-Control-Allow-Origin'] = b'*'
 
-
-def x_frame_options(response):
-    """X-Frame-Origin
-
-    This is a security measure to prevent clickjacking:
-    http://en.wikipedia.org/wiki/Clickjacking
-
-    """
+    # X-Frame-Options is a security measure to prevent clickjacking
+    # See http://en.wikipedia.org/wiki/Clickjacking
     if b'X-Frame-Options' not in response.headers:
         response.headers[b'X-Frame-Options'] = b'SAMEORIGIN'
     elif response.headers[b'X-Frame-Options'] == b'ALLOWALL':

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -40,3 +40,7 @@ def set_default_security_headers(website, response, request=None):
         if website.canonical_scheme == 'https':
             csp += b"upgrade-insecure-requests;block-all-mixed-content;"
         response.headers[b'content-security-policy-report-only'] = csp
+
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+    if b'X-XSS-Protection' not in response.headers:
+        response.headers[b'X-XSS-Protection'] = b'1; mode=block'

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -31,3 +31,14 @@ def x_frame_options(response):
         #   http://ipsec.pl/node/1094
 
         del response.headers[b'X-Frame-Options']
+
+    if b'content-security-policy' not in response.headers:
+        response.headers[b'content-security-policy'] = (
+            b"default-src 'self';"
+            b"script-src 'self' 'unsafe-inline';"
+            b"style-src 'self' 'unsafe-inline';"
+            b"img-src *;"
+            b"upgrade-insecure-requests;"
+            b"block-all-mixed-content;"
+            b"reflected-xss block;"
+        )

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 
-def set_default_security_headers(response, request=None):
+def set_default_security_headers(website, response, request=None):
     # Allow CORS for assets
     # The subdomains need this to access the assets on the main domain.
     if request is not None and request.path.raw.startswith('/assets/'):
@@ -29,12 +29,14 @@ def set_default_security_headers(response, request=None):
     # CSP is a client-side protection against code injection (XSS)
     # https://scotthelme.co.uk/content-security-policy-an-introduction/
     if b'content-security-policy' not in response.headers:
-        response.headers[b'content-security-policy'] = (
+        csp = (
             b"default-src 'self';"
             b"script-src 'self' 'unsafe-inline';"
             b"style-src 'self' 'unsafe-inline';"
+            b"connect-src *;"  # for credit card data
             b"img-src *;"
-            b"upgrade-insecure-requests;"
-            b"block-all-mixed-content;"
             b"reflected-xss block;"
         )
+        if website.canonical_scheme == 'https':
+            csp += b"upgrade-insecure-requests;block-all-mixed-content;"
+        response.headers[b'content-security-policy'] = csp

--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -36,7 +36,7 @@ def set_default_security_headers(website, response, request=None):
             b"connect-src *;"  # for credit card data
             b"img-src *;"
             b"reflected-xss block;"
-        )
+        ) + website.app_conf.csp_extra.encode()
         if website.canonical_scheme == 'https':
             csp += b"upgrade-insecure-requests;block-all-mixed-content;"
-        response.headers[b'content-security-policy'] = csp
+        response.headers[b'content-security-policy-report-only'] = csp

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -91,6 +91,7 @@ class AppConf(object):
         bountysource_secret=str,
         check_db_every=int,
         compress_assets=bool,
+        csp_extra=str,
         dequeue_emails_every=int,
         facebook_callback=str,
         facebook_id=str,

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+-- For production
+-- INSERT INTO app_conf (key, value) VALUES ('csp_extra', '"report-uri https://liberapay.report-uri.io/r/default/csp/reportOnly;"'::jsonb);
+-- For local
+INSERT INTO app_conf (key, value) VALUES ('csp_extra', '""'::jsonb);


### PR DESCRIPTION
Content Security Policy (CSP) is a security mechanism that allows web sites control how browsers process their pages. In essence, sites can restrict what types of resources are loaded and from where. CSP policies can be used to defend against cross-site scripting, prevent mixed content issues, as well as report violations for investigation.