### PR TITLE
Increase salt size to 32 bytes

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -279,7 +279,7 @@ class Participant(Model, MixinTeam):
         if l < PASSWORD_MIN_SIZE or l > PASSWORD_MAX_SIZE:
             raise BadPasswordSize
         algo = 'sha256'
-        salt = urandom(21)
+        salt = urandom(32)
         rounds = website.app_conf.password_rounds
         hashed = cls._hash_password(password, algo, salt, rounds)
         hashed = '$'.join((

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -285,6 +285,7 @@ class Participant(Model, MixinTeam):
             raise BadPasswordSize
         # Using SHA-256 as the HMAC algorithm (PBKDF2 + HMAC-SHA-256)
         algo = 'sha256'
+        # Generate 32 random bytes for the salt
         salt = urandom(32)
         rounds = website.app_conf.password_rounds
         hashed = cls._hash_password(password, algo, salt, rounds)

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -232,6 +232,11 @@ class Participant(Model, MixinTeam):
             salt, hashed = b64decode(salt), b64decode(hashed)
             if constant_time_compare(cls._hash_password(v2, algo, salt, rounds), hashed):
                 p.authenticated = True
+                if len(salt) < 32:
+                    # Update the password hash in the DB
+                    hashed = cls.hash_password(v2)
+                    cls.db.run("UPDATE participants SET password = %s WHERE id = %s",
+                               (hashed, p.id))
                 return p
 
     @classmethod

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -283,6 +283,7 @@ class Participant(Model, MixinTeam):
         l = len(password)
         if l < PASSWORD_MIN_SIZE or l > PASSWORD_MAX_SIZE:
             raise BadPasswordSize
+        # Using SHA-256 as the HMAC algorithm (PBKDF2 + HMAC-SHA-256)
         algo = 'sha256'
         salt = urandom(32)
         rounds = website.app_conf.password_rounds


### PR DESCRIPTION
Since we are using PBKDF2-SHA-256, the salt should be 32 bytes long.

For more inforamtion please refer to my recommendations here:
https://github.com/EdOverflow/hunter/blob/master/docs/password-storage.md

On a side note, how many rounds did you set?