### PR TITLE
Prevent timing attacks

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -194,7 +194,7 @@ class Participant(Model, MixinTeam):
             algo, rounds, salt, hashed = p.password.split('$', 3)
             rounds = int(rounds)
             salt, hashed = b64decode(salt), b64decode(hashed)
-            if cls._hash_password(v2, algo, salt, rounds) == hashed:
+            if constant_time_compare(cls._hash_password(v2, algo, salt, rounds), hashed):
                 p.authenticated = True
                 return p
 

--- a/liberapay/security/crypto.py
+++ b/liberapay/security/crypto.py
@@ -55,6 +55,10 @@ def constant_time_compare(val1, val2):
     if len(val1) != len(val2):
         return False
     result = 0
-    for x, y in zip(val1, val2):
-        result |= ord(x) ^ ord(y)
+    if isinstance(val1, bytes) and bytes != str:
+        for x, y in zip(val1, val2):
+            result |= x ^ y
+    else:
+        for x, y in zip(val1, val2):
+            result |= ord(x) ^ ord(y)
     return result == 0


### PR DESCRIPTION
Liberapay is vulnerable to timing attacks, because the `==` operation does a byte-by-byte comparison of two values and as soon as the two differentiate it terminates.

For more on timing attacks please refer to: https://github.com/EdOverflow/hunter/blob/master/docs/timing-attacks.md