### PR TITLE
Switch Content Security Policy from report-only to enforceable

### DIFF
--- a/liberapay/security/__init__.py
+++ b/liberapay/security/__init__.py
@@ -30,17 +30,17 @@ def set_default_security_headers(website, response, request=None):
     # https://scotthelme.co.uk/content-security-policy-an-introduction/
     if b'content-security-policy' not in response.headers:
         csp = (
-            b"default-src %(main_domain)s;"
-            b"script-src %(main_domain)s 'unsafe-inline';"
-            b"style-src %(main_domain)s 'unsafe-inline';"
+            b"default-src 'self' %(main_domain)s;"
+            b"script-src 'self' %(main_domain)s 'unsafe-inline';"
+            b"style-src 'self' %(main_domain)s 'unsafe-inline';"
             b"connect-src *;"  # for credit card data
             b"img-src *;"
             b"reflected-xss block;"
         ) % {b'main_domain': website.canonical_host.encode('ascii')}
         csp += website.env.csp_extra.encode()
         if website.canonical_scheme == 'https':
-            csp += b"upgrade-insecure-requests;block-all-mixed-content;"
-        response.headers[b'content-security-policy-report-only'] = csp
+            csp += b"upgrade-insecure-requests;"
+        response.headers[b'content-security-policy'] = csp
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
     if b'X-XSS-Protection' not in response.headers:


### PR DESCRIPTION
In #468 we opted to start with a report-only policy. This PR is so we don't forget to switch to enforcement mode. I want to wait a little while longer and analyze the reports before merging this.