### PR TITLE
Tweak cookie domain to allow local dev with Chromium

### DIFF
--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -229,8 +229,8 @@ def set_cookie(cookies, key, value, expires=None, httponly=True, path='/'):
         cookie[str('httponly')] = True
     if path:
         cookie[str('path')] = ensure_str(path)
-    if website.canonical_domain:
-        cookie[str('domain')] = ensure_str(website.canonical_domain)
+    if website.cookie_domain:
+        cookie[str('domain')] = ensure_str(website.cookie_domain)
     if website.canonical_scheme == 'https':
         cookie[str('secure')] = True
 

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -43,11 +43,12 @@ from liberapay.utils.i18n import (
 def canonical(env):
     canonical_scheme = env.canonical_scheme
     canonical_host = env.canonical_host
+    cookie_domain = None
     if canonical_host:
-        canonical_domain = ('.' + canonical_host.split(':')[0]).encode('ascii')
         canonical_url = '%s://%s' % (canonical_scheme, canonical_host)
+        if ':' not in canonical_host:
+            cookie_domain = ('.' + canonical_host).encode('ascii')
     else:
-        canonical_domain = None
         canonical_url = ''
     asset_url = canonical_url+'/assets/'
     return locals()

--- a/tests/py/test_state_chain.py
+++ b/tests/py/test_state_chain.py
@@ -20,15 +20,15 @@ class Tests(Harness):
         Harness.setUp(self)
         self.client.website.canonical_scheme = 'https'
         self.client.website.canonical_host = 'example.com'
-        self._canonical_domain = self.client.website.canonical_domain
-        self.client.website.canonical_domain = b'.example.com'
+        self._cookie_domain = self.client.website.cookie_domain
+        self.client.website.cookie_domain = b'.example.com'
 
     def tearDown(self):
         Harness.tearDown(self)
         website = self.client.website
         website.canonical_scheme = website.env.canonical_scheme
         website.canonical_host = website.env.canonical_host
-        website.canonical_domain = self._canonical_domain
+        website.cookie_domain = self._cookie_domain
 
     def test_canonize_canonizes(self):
         response = self.client.GxT("/",


### PR DESCRIPTION
When I tried to replicate #508 locally in Chromium I couldn't log into an account, I got a "bad CSRF cookie" error. It was because the domain of cookies was `.localhost`, which Chromium apparently considers not to match `localhost:8339`.