### PR TITLE
Improve payout form

### DIFF
--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -80,19 +80,23 @@ def skim_amount(amount, fees):
 skim_bank_wire = lambda amount: skim_amount(amount, FEE_PAYIN_BANK_WIRE)
 
 
+def get_bank_account_country(ba):
+    if ba.Type == 'IBAN':
+        return ba.IBAN[:2].upper()
+    elif ba.Type in ('US', 'GB', 'CA'):
+        return ba.Type
+    else:
+        assert ba.Type == 'OTHER', ba.Type
+        return ba.Country.upper()
+
+
 def skim_credit(amount, ba):
     """Given a payout amount, return a lower amount, the fee, and taxes.
 
     The returned amount can be negative, look out for that.
     """
     typecheck(amount, Decimal)
-    if ba.Type == 'IBAN':
-        country = ba.IBAN[:2].upper()
-    elif ba.Type in ('US', 'GB', 'CA'):
-        country = ba.Type
-    else:
-        assert ba.Type == 'OTHER', ba.Type
-        country = ba.Country.upper()
+    country = get_bank_account_country(ba)
     if country in SEPA:
         fee = FEE_PAYOUT
     else:

--- a/liberapay/billing/exchanges.py
+++ b/liberapay/billing/exchanges.py
@@ -16,7 +16,7 @@ from liberapay.constants import (
     D_CENT, D_ZERO,
     PAYIN_CARD_MIN, FEE_PAYIN_CARD,
     FEE_PAYIN_BANK_WIRE,
-    FEE_PAYOUT, FEE_PAYOUT_OUTSIDE_SEPA, FEE_PAYOUT_WARN, QUARANTINE, SEPA_ZONE,
+    FEE_PAYOUT, FEE_PAYOUT_OUTSIDE_SEPA, FEE_PAYOUT_WARN, QUARANTINE, SEPA,
     FEE_VAT,
 )
 from liberapay.exceptions import (
@@ -93,7 +93,7 @@ def skim_credit(amount, ba):
     else:
         assert ba.Type == 'OTHER', ba.Type
         country = ba.Country.upper()
-    if country in SEPA_ZONE:
+    if country in SEPA:
         fee = FEE_PAYOUT
     else:
         fee = FEE_PAYOUT_OUTSIDE_SEPA

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -158,7 +158,7 @@ check_bits(list(PRIVILEGES.values()))
 
 QUARANTINE = timedelta(weeks=4)
 
-SEPA_ZONE = set("""
+SEPA = set("""
     AT BE BG CH CY CZ DE DK EE ES ES FI FR GB GI GR HR HU IE IS IT LI LT LU LV
     MC MT NL NO PL PT RO SE SI SK
 """.split())

--- a/templates/postal-addresses.html
+++ b/templates/postal-addresses.html
@@ -1,4 +1,4 @@
-% macro postal_address_form(prefix='', saved=None)
+% macro postal_address_form(prefix='', saved=None, country=None)
 
     <label>
         <span>{{ _("Address") }}</span>
@@ -35,8 +35,9 @@
         <span>{{ _("Country") }}</span>
         <select name="{{ prefix }}Address.Country" class="form-control" required>
             <option></option>
-            % for each in locale.countries.items()
-                <option value="{{ each[0] }}" {{ 'selected' if each[0] == saved.Country }}>{{ each[1] }}</option>
+            % set country = country or saved.Country
+            % for code, name in locale.countries.items()
+                <option value="{{ code }}" {{ 'selected' if code == country }}>{{ name }}</option>
             % endfor
         </select>
     </label><br>

--- a/tests/py/fixtures/TestPages.yml
+++ b/tests/py/fixtures/TestPages.yml
@@ -59,6 +59,20 @@ interactions:
     body: null
     headers: {}
     method: GET
+    uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/users/20717489
+  response:
+    body: {string: !!python/unicode '{"Address":{"AddressLine1":null,"AddressLine2":null,"City":null,"Region":null,"PostalCode":null,"Country":null},"FirstName":"David","LastName":"Foobar","Birthday":0,"Nationality":"BE","CountryOfResidence":"BE","Occupation":null,"IncomeRange":null,"ProofOfIdentity":null,"ProofOfAddress":null,"PersonType":"NATURAL","Email":"nobody@example.net","KYCLevel":"LIGHT","Id":"20717489","Tag":null,"CreationDate":1491402287}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['416']
+      content-type: [application/json; charset=utf-8]
+      expires: ['-1']
+      pragma: [no-cache]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
     uri: https://api.github.com:443/users/liberapay?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
   response:
     body:
@@ -343,6 +357,20 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['290']
+      content-type: [application/json; charset=utf-8]
+      expires: ['-1']
+      pragma: [no-cache]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.mangopay.com:443/v2.01/liberapay-dev/users/20717489
+  response:
+    body: {string: !!python/unicode '{"Address":{"AddressLine1":null,"AddressLine2":null,"City":null,"Region":null,"PostalCode":null,"Country":null},"FirstName":"David","LastName":"Foobar","Birthday":0,"Nationality":"BE","CountryOfResidence":"BE","Occupation":null,"IncomeRange":null,"ProofOfIdentity":null,"ProofOfAddress":null,"PersonType":"NATURAL","Email":"nobody@example.net","KYCLevel":"LIGHT","Id":"20717489","Tag":null,"CreationDate":1491402287}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['416']
       content-type: [application/json; charset=utf-8]
       expires: ['-1']
       pragma: [no-cache]

--- a/tests/py/test_pages.py
+++ b/tests/py/test_pages.py
@@ -41,7 +41,7 @@ class BrowseTestHarness(MangopayHarness):
                      .replace('/%platform', '/github') \
                      .replace('/%user_name/', '/liberapay/') \
                      .replace('/%redirect_to', '/giving') \
-                     .replace('/%back_to', '/Li4=') \
+                     .replace('/%back_to', '/') \
                      .replace('/payday/%id', '/payday/') \
                      .replace('/%type', '/receiving.js') \
                      .replace('/%endpoint', '/public')

--- a/www/%username/receiving/index.html.spt
+++ b/www/%username/receiving/index.html.spt
@@ -33,7 +33,7 @@ teams = website.db.all("""
     <p>{{ _("We need to know who you are before we can legally start to collect money for you.") }}</p>
     <p><a class="btn btn-primary" href="{{ participant.path('identity') }}">{{ _("Fill identity form") }}</a></p>
 % elif participant.balance > 0
-    <p><a class="btn btn-default" href="{{ participant.path('wallet/payout/Li4=') }}"
+    <p><a class="btn btn-default" href="{{ participant.path('wallet/payout/' + b64encode_s(request.path.raw)) }}"
           >{{ _("Withdraw money") }}</a></p>
 % endif
 

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -69,7 +69,7 @@ else:
 <p>{{ BALANCE }}</p>
 
 % if participant.balance > 0
-    <p><a class="btn btn-default" href="{{ participant.path('wallet/payout/Li4=') }}"
+    <p><a class="btn btn-default" href="{{ participant.path('wallet/payout/' + b64encode_s(request.path.raw)) }}"
           >{{ _("Withdraw money") }}</a></p>
 % endif
 

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -7,9 +7,12 @@ from decimal import Decimal as D
 from mangopay.resources import BankAccount
 
 from liberapay.billing.exchanges import payout
+from liberapay.constants import SEPA
 from liberapay.exceptions import TransactionFeeTooHigh
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.utils import b64decode_s, get_participant
+
+NOT_OTHER = set('US CA GB'.split()).union(SEPA)
 
 def obfuscate(n, x, y):
     return n[:x] + 'x'*len(n[x:y]) + n[y:]
@@ -259,8 +262,10 @@ title = _("Withdraw money")
                     <span>{{ _("Country") }}</span>
                     <select name="Country" class="form-control" required>
                     <option></option>
-                    % for each in locale.countries.items()
-                        <option value="{{ each[0] }}">{{ each[1] }}</option>
+                    % for code, name in locale.countries.items()
+                        % set disable = code in NOT_OTHER
+                        <option value="{{ code }}" {{ 'disabled' if disable }}
+                                >{{ name }}</option>
                     % endfor
                     </select>
                 </label><br>

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -163,7 +163,7 @@ title = _("Withdraw money")
 
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="{{ 'active' if ba_type == 'IBAN' else '' }}">
-                <a href="#iban" aria-controls="iban" role="tab" data-toggle="tab">{{ _("International") }}</a></li>
+                <a href="#iban" aria-controls="iban" role="tab" data-toggle="tab">{{ _("SEPA / IBAN") }}</a></li>
             <li role="presentation" class="{{ 'active' if ba_type == 'US' else '' }}">
                 <a href="#usa" aria-controls="usa" role="tab" data-toggle="tab">{{ _("USA") }}</a></li>
             <li role="presentation" class="{{ 'active' if ba_type == 'CA' else '' }}">

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -62,6 +62,18 @@ if show_form:
             route.address, user_id=participant.mangopay_user_id
         )
         ba_type = bank_account.Type
+    else:
+        mp_account = participant.get_mangopay_account()
+        country = (
+            getattr(mp_account, 'LegalRepresentativeCountryOfResidence', None) or
+            getattr(mp_account, 'CountryOfResidence', None)
+        )
+        if country in ('US', 'GB', 'CA'):
+            ba_type = country
+        elif country in constants.SEPA:
+            ba_type = 'IBAN'
+        else:
+            ba_type = 'OTHER'
     donations = participant.get_giving_for_profile()[1]
     recommended_withdrawal = min(
         withdrawable,

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -14,6 +14,23 @@ from liberapay.utils import b64decode_s, get_participant
 
 NOT_OTHER = set('US CA GB'.split()).union(SEPA)
 
+def get_owner_name(account):
+    if account.PersonType == 'NATURAL':
+        return account.FirstName + ' ' + account.LastName
+    else:
+        return account.Name
+
+def get_owner_address(bank_account, mp_account):
+    if bank_account:
+        addr = bank_account.OwnerAddress
+    elif mp_account.PersonType == 'NATURAL':
+        addr = mp_account.Address
+    else:
+        addr = mp_account.HeadquartersAddress
+    if not addr.Country:
+        return None
+    return addr
+
 def obfuscate(n, x, y):
     return n[:x] + 'x'*len(n[x:y]) + n[y:]
 
@@ -304,11 +321,12 @@ title = _("Withdraw money")
 
         <label>
             <span>{{ _("Name") }}</span>
-            <input name="OwnerName" class="form-control" required />
+            <input name="OwnerName" class="form-control" required
+                   value="{{ get_owner_name(mp_account) }}" />
         </label><br>
 
         % from "templates/postal-addresses.html" import postal_address_form with context
-        {{ postal_address_form(prefix='Owner') }}
+        {{ postal_address_form(prefix='Owner', saved=get_owner_address(bank_account, mp_account), country=country) }}
 
     </fieldset>
 

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -6,7 +6,7 @@ from decimal import Decimal as D
 
 from mangopay.resources import BankAccount
 
-from liberapay.billing.exchanges import payout
+from liberapay.billing.exchanges import get_bank_account_country, payout
 from liberapay.constants import SEPA
 from liberapay.exceptions import TransactionFeeTooHigh
 from liberapay.models.exchange_route import ExchangeRoute
@@ -21,7 +21,7 @@ def obfuscate(n, x, y):
 
 participant = get_participant(state, restrict=True, block_suspended_user=True)
 exchange = None
-bank_account, ba_type = None, 'IBAN'
+bank_account = None
 
 back_to = b64decode_s(request.path['back_to'], default=None)
 
@@ -56,14 +56,15 @@ if show_form or not success:
     show_form = withdrawable > 0
 
 if show_form:
+    mp_account = participant.get_mangopay_account()
     route = ExchangeRoute.from_network(participant, 'mango-ba')
     if route:
         bank_account = BankAccount.get(
             route.address, user_id=participant.mangopay_user_id
         )
         ba_type = bank_account.Type
+        country = get_bank_account_country(bank_account)
     else:
-        mp_account = participant.get_mangopay_account()
         country = (
             getattr(mp_account, 'LegalRepresentativeCountryOfResidence', None) or
             getattr(mp_account, 'CountryOfResidence', None)
@@ -277,6 +278,7 @@ title = _("Withdraw money")
                     % for code, name in locale.countries.items()
                         % set disable = code in NOT_OTHER
                         <option value="{{ code }}" {{ 'disabled' if disable }}
+                                {{ 'selected' if code == country and not disable }}
                                 >{{ name }}</option>
                     % endfor
                     </select>


### PR DESCRIPTION
- prevent users from inputting a BBAN instead of an IBAN (MangoPay doesn't support automatic conversion and doesn't show a proper error message)
- preselect country and bank account type
- prefill bank account owner address
- fix bad redirects (regression from #488)