### PR TITLE
Bigger footer

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -11,12 +11,12 @@ body {
         margin: 100px auto 20px auto;
 
         ul {
-          list-style: none;
-          padding: 0px;
+            list-style: none;
+            padding: 0px;
 
-          li {
-            margin: 10px auto;
-          }
+            li {
+                margin: 10px auto;
+            }
         }
     }
 }

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -15,12 +15,16 @@ body {
             text-align: center;
         }
 
-        ul {
+        & > ul {
             list-style: none;
             padding: 0px;
 
-            li {
-                margin: 10px auto;
+            & > li {
+                display: inline-block;
+                & > a {
+                    display: inline-block;
+                    padding: 10px;
+                }
             }
         }
     }

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -6,11 +6,17 @@ html, body {
 body {
     overflow-y: scroll;
     & > footer {
-        margin: 100px 0 20px 0;
-        text-align: center;
-        & > a {
-            display: inline-block;
-            padding: 10px;
+        display: flex;
+        justify-content: space-around;
+        margin: 100px auto 20px auto;
+
+        ul {
+          list-style: none;
+          padding: 0px;
+
+          li {
+            margin: 10px auto;
+          }
         }
     }
 }

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -10,6 +10,11 @@ body {
         justify-content: space-around;
         margin: 100px auto 20px auto;
 
+        @media (max-width: $screen-sm-min) {
+            flex-direction: column;
+            text-align: center;
+        }
+
         ul {
             list-style: none;
             padding: 0px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -114,17 +114,17 @@
 
     <footer class="container" role="navigation">
         <ul>
-          <li><a href="/about/">{{ _("About") }}</a></li>
-          <li><a href="/about/contact">{{ _("Contact Us") }}</a></li>
-          <li><a href="/about/faq">{{ _("FAQ") }}</a></li>
-          <li><a href="/about/legal">{{ _("Legal") }}</a></li>
+            <li><a href="/about/">{{ _("About") }}</a></li>
+            <li><a href="/about/contact">{{ _("Contact Us") }}</a></li>
+            <li><a href="/about/faq">{{ _("FAQ") }}</a></li>
+            <li><a href="/about/legal">{{ _("Legal") }}</a></li>
         </ul>
         <ul>
-          <li><a href="https://mastodon.rocks/@Liberapay">Mastodon</a></li>
-          <li><a href="https://framasphere.org/u/liberapay">Diaspora*</a></li>
-          <li><a href="https://github.com/liberapay/liberapay.com">GitHub</a></li>
-          <li><a href="https://twitter.com/liberapaye">Twitter</a></li>
-          <li><a href="https://www.facebook.com/Liberapay-472128142945598/">Facebook</a></li>
+            <li><a href="https://mastodon.rocks/@Liberapay">Mastodon</a></li>
+            <li><a href="https://framasphere.org/u/liberapay">Diaspora*</a></li>
+            <li><a href="https://github.com/liberapay/liberapay.com">GitHub</a></li>
+            <li><a href="https://twitter.com/liberapaye">Twitter</a></li>
+            <li><a href="https://www.facebook.com/Liberapay-472128142945598/">Facebook</a></li>
         </ul>
     </footer>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -112,15 +112,19 @@
         </div>
     </div>
 
-    <footer role="navigation">
-        <a href="/about/">{{ _("About") }}</a>
-        <a href="/about/contact">{{ _("Contact Us") }}</a>
-        <a href="/about/faq">{{ _("FAQ") }}</a>
-        <a href="/about/legal">{{ _("Legal") }}</a>
-        <a href="https://framasphere.org/u/liberapay">Diaspora*</a>
-        <a href="https://github.com/liberapay/liberapay.com">GitHub</a>
-        <a href="https://twitter.com/liberapaye">Twitter</a>
-        <a href="https://www.facebook.com/Liberapay-472128142945598/">Facebook</a>
+    <footer class="container" role="navigation">
+        <ul>
+          <li><a href="/about/">{{ _("About") }}</a></li>
+          <li><a href="/about/contact">{{ _("Contact Us") }}</a></li>
+          <li><a href="/about/faq">{{ _("FAQ") }}</a></li>
+          <li><a href="/about/legal">{{ _("Legal") }}</a></li>
+        </ul>
+        <ul>
+          <li><a href="https://framasphere.org/u/liberapay">Diaspora*</a></li>
+          <li><a href="https://github.com/liberapay/liberapay.com">GitHub</a></li>
+          <li><a href="https://twitter.com/liberapaye">Twitter</a></li>
+          <li><a href="https://www.facebook.com/Liberapay-472128142945598/">Facebook</a></li>
+        </ul>
     </footer>
 
 <script src="{{ website.asset('jquery.min.js') }}"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,6 +120,7 @@
           <li><a href="/about/legal">{{ _("Legal") }}</a></li>
         </ul>
         <ul>
+          <li><a href="https://mastodon.rocks/@Liberapay">Mastodon</a></li>
           <li><a href="https://framasphere.org/u/liberapay">Diaspora*</a></li>
           <li><a href="https://github.com/liberapay/liberapay.com">GitHub</a></li>
           <li><a href="https://twitter.com/liberapaye">Twitter</a></li>

--- a/www/about/feeds.spt
+++ b/www/about/feeds.spt
@@ -5,19 +5,24 @@ title = _("Feeds")
 % from "templates/icons.html" import fontawesome
 
 % block content
-<div class="row paragraph"><div class="col-md-6">
+<div class="row paragraph"><div class="col-md-8">
 
     <p>{{ _("You can get updates from us on the following social networks:") }}</p>
+    <div class="buttons">
+    <a class="btn btn-default btn-lg" href="https://mastodon.rocks/@Liberapay">
+        {{ fontawesome('columns') }}&nbsp;Mastodon
+    </a>
     <a class="btn btn-default btn-lg" href="https://framasphere.org/u/liberapay">
-        {{ fontawesome('asterisk') }} <span>Diaspora</span>
+        {{ fontawesome('asterisk') }}&nbsp;Diaspora
     </a>
     <a class="btn btn-default btn-lg" href="https://twitter.com/liberapaye">
-        {{ fontawesome('twitter') }} <span>Twitter</span>
+        {{ fontawesome('twitter') }}&nbsp;Twitter
     </a>
     <a class="btn btn-default btn-lg" href="https://www.facebook.com/Liberapay-472128142945598/">
-        {{ fontawesome('facebook') }} <span>Facebook</span>
+        {{ fontawesome('facebook') }}&nbsp;Facebook
     </a>
-    <br><br>
+    </div>
+    <br>
 
     <p>{{ _(
         "You can also follow the {1}development of the Liberapay software{0}, "


### PR DESCRIPTION
There is now two columns in the footer, so we can add as many links as we want. The first one is for internal links, the second one for social network accounts (I added a link to the Mastodon account by the way).

![capture d ecran du 2017-06-08 17 58 52](https://user-images.githubusercontent.com/16254623/26940855-2b33b196-4c74-11e7-8a10-2d6b0951d52b.png)

Fix #293 
