### PR TITLE
Add support for repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
 addons:
-  postgresql: 9.4
+  postgresql: 9.6
 branches:
   only:
     - master
@@ -32,3 +32,4 @@ notifications:
       - "%{repository} (%{branch}:%{commit} by %{author}): %{message} (%{build_url})"
     skip_join: true
 sudo: false
+dist: trusty

--- a/liberapay/cron.py
+++ b/liberapay/cron.py
@@ -1,5 +1,9 @@
+import logging
 import threading
 from time import sleep
+
+
+logger = logging.getLogger('liberapay.cron')
 
 
 class Cron(object):

--- a/liberapay/elsewhere/_extractors.py
+++ b/liberapay/elsewhere/_extractors.py
@@ -75,7 +75,7 @@ def drop_keys(*keys):
     def f(self, info):
         for k in keys:
             if callable(k):
-                for k2 in info.keys():
+                for k2 in list(info.keys()):
                     if k(k2):
                         info.pop(k2)
             else:

--- a/liberapay/elsewhere/_extractors.py
+++ b/liberapay/elsewhere/_extractors.py
@@ -71,6 +71,18 @@ def key(k, clean=lambda a: a):
     return f
 
 
+def drop_keys(*keys):
+    def f(self, info):
+        for k in keys:
+            if callable(k):
+                for k2 in info.keys():
+                    if k(k2):
+                        info.pop(k2)
+            else:
+                info.pop(k, None)
+    return f
+
+
 def not_available(self, extracted, info, default):
     return default
 

--- a/liberapay/elsewhere/_paginators.py
+++ b/liberapay/elsewhere/_paginators.py
@@ -62,7 +62,7 @@ def query_param_paginator(param, **kw):
     return f
 
 
-def header_links_paginator():
+def header_links_paginator(total_header=None):
     # https://tools.ietf.org/html/rfc5988
     # https://developer.github.com/v3/#pagination
     def f(self, response, parsed):
@@ -72,6 +72,11 @@ def header_links_paginator():
                  for k, v in response.links.items()
                  if k in links_keys}
         total_count = -1 if links else len(parsed)
+        if total_header and total_count == -1:
+            try:
+                total_count = int(response.headers.get('X-Total', None))
+            except (ValueError, TypeError):
+                pass
         return parsed, total_count, links
     return f
 

--- a/liberapay/elsewhere/github.py
+++ b/liberapay/elsewhere/github.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from liberapay.elsewhere._base import PlatformOAuth2
 from liberapay.elsewhere._exceptions import CantReadMembership
-from liberapay.elsewhere._extractors import key
+from liberapay.elsewhere._extractors import key, drop_keys
 from liberapay.elsewhere._paginators import header_links_paginator
 
 
@@ -12,6 +12,7 @@ class GitHub(PlatformOAuth2):
     name = 'github'
     display_name = 'GitHub'
     account_url = 'https://github.com/{user_name}'
+    repo_url = 'https://github.com/{slug}'
     allows_team_connect = True
 
     # Auth attributes
@@ -30,6 +31,7 @@ class GitHub(PlatformOAuth2):
     api_user_self_info_path = '/user'
     api_team_members_path = '/orgs/{user_name}/public_members'
     api_friends_path = '/users/{user_name}/following'
+    api_repos_path = '/users/{user_name}/repos?type=owner&sort=updated&per_page=100'
     ratelimit_headers_prefix = 'x-ratelimit-'
 
     # User info extractors
@@ -40,6 +42,17 @@ class GitHub(PlatformOAuth2):
     x_gravatar_id = key('gravatar_id')
     x_avatar_url = key('avatar_url')
     x_is_team = key('type', clean=lambda t: t.lower() == 'organization')
+
+    # Repo info extractors
+    x_repo_id = key('id')
+    x_repo_name = key('name')
+    x_repo_slug = key('full_name')
+    x_repo_description = key('description')
+    x_repo_last_update = key('updated_at')
+    x_repo_is_fork = key('fork')
+    x_repo_stars_count = key('stargazers_count')
+    x_repo_owner_id = key('owner', clean=lambda d: d['id'])
+    x_repo_extra_info_drop = drop_keys(lambda k: k.endswith('_url'))
 
     def get_CantReadMembership_url(self, **kw):
         return 'https://github.com/settings/connections/applications/'+self.api_key

--- a/liberapay/elsewhere/gitlab.py
+++ b/liberapay/elsewhere/gitlab.py
@@ -11,6 +11,7 @@ class GitLab(PlatformOAuth2):
     name = 'gitlab'
     display_name = 'GitLab'
     account_url = 'https://gitlab.com/u/{user_name}'
+    repo_url = 'https://gitlab.com/{slug}'
 
     # Auth attributes
     # GitLab uses https://github.com/doorkeeper-gem/doorkeeper
@@ -27,6 +28,7 @@ class GitLab(PlatformOAuth2):
     # api_user_name_info_path = '/users?username={user_name}'
     api_user_self_info_path = '/user'
     # api_team_members_path = '/groups/{user_name}/members'
+    api_repos_path = '/projects?owned=true&visibility=public&order_by=last_activity_at&per_page=100'
 
     # The commented out paths are because we need this:
     # https://gitlab.com/gitlab-org/gitlab-ce/issues/13795
@@ -37,3 +39,13 @@ class GitLab(PlatformOAuth2):
     x_display_name = key('name')
     x_email = key('email')
     x_avatar_url = key('avatar_url')
+
+    # Repo info extractors
+    x_repo_id = key('id')
+    x_repo_name = key('name')
+    x_repo_slug = key('path_with_namespace')
+    x_repo_description = key('description')
+    x_repo_last_update = key('last_activity_at')
+    x_repo_is_fork = key('forked_from_project', clean=bool)
+    x_repo_stars_count = key('star_count')
+    x_repo_owner_id = key('owner', clean=lambda d: d['id'])

--- a/liberapay/elsewhere/gitlab.py
+++ b/liberapay/elsewhere/gitlab.py
@@ -22,7 +22,7 @@ class GitLab(PlatformOAuth2):
     # API attributes
     # http://doc.gitlab.com/ce/api/
     api_format = 'json'
-    api_paginator = header_links_paginator()
+    api_paginator = header_links_paginator(total_header='X-Total')
     api_url = 'https://gitlab.com/api/v3'
     # api_user_info_path = '/users/{user_id}'
     # api_user_name_info_path = '/users?username={user_name}'

--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -19,6 +19,7 @@ from liberapay import utils, wireup
 from liberapay.cron import Cron
 from liberapay.models.community import Community
 from liberapay.models.participant import Participant
+from liberapay.models.repository import refetch_repos
 from liberapay.security import authentication, csrf, set_default_security_headers
 from liberapay.utils import b64decode_s, b64encode_s, erase_cookie, http_caching, i18n, set_cookie
 from liberapay.utils.state_chain import (
@@ -92,6 +93,7 @@ if env.run_cron_jobs and conf:
     cron(conf.check_db_every, website.db.self_check, True)
     cron(conf.dequeue_emails_every, Participant.dequeue_emails, True)
     cron(conf.send_newsletters_every, Participant.send_newsletters, True)
+    cron(conf.refetch_repos_every, refetch_repos, True)
 
 
 # Website Algorithm

--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -11,6 +11,7 @@ from six.moves.urllib.parse import quote as urlquote
 import aspen
 import aspen.http.mapping
 import pando
+from pando import json
 from pando.algorithms.website import fill_response_with_output
 from pando.utils import maybe_encode
 
@@ -168,6 +169,15 @@ def _success(self, code=200, msg=''):
     self.body = msg
     raise self
 pando.Response.success = _success
+
+if hasattr(pando.Response, 'json'):
+    raise Warning('pando.Response.json() already exists')
+def _json(self, obj, code=200):
+    self.code = code
+    self.body = json.dumps(obj)
+    self.headers[b'Content-Type'] = b'application/json'
+    raise self
+pando.Response.json = _json
 
 if hasattr(pando.Response, 'sanitize_untrusted_url'):
     raise Warning('pando.Response.sanitize_untrusted_url() already exists')

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1675,6 +1675,17 @@ class Participant(Model, MixinTeam):
         return -1
 
 
+    def get_mangopay_account(self):
+        """Fetch the mangopay account for this participant.
+        """
+        if not self.mangopay_user_id:
+            return
+        return mangopay.resources.User.get(self.mangopay_user_id)
+
+
+    # Accounts Elsewhere
+    # ==================
+
     def get_account_elsewhere(self, platform):
         """Return an AccountElsewhere instance.
         """
@@ -1686,7 +1697,6 @@ class Participant(Model, MixinTeam):
                AND platform=%s
 
         """, (self.id, platform))
-
 
     def get_accounts_elsewhere(self):
         """Return a dict of AccountElsewhere instances.
@@ -1701,15 +1711,6 @@ class Participant(Model, MixinTeam):
         """, (self.id,))
         accounts_dict = {account.platform: account for account in accounts}
         return accounts_dict
-
-
-    def get_mangopay_account(self):
-        """Fetch the mangopay account for this participant.
-        """
-        if not self.mangopay_user_id:
-            return
-        return mangopay.resources.User.get(self.mangopay_user_id)
-
 
     def take_over(self, account, have_confirmation=False):
         """Given an AccountElsewhere or a tuple (platform_name, domain, user_id),
@@ -1883,6 +1884,10 @@ class Participant(Model, MixinTeam):
                 platform=platform, domain=domain, user_id=user_id
             ))
         self.update_avatar()
+
+
+    # More Random Stuff
+    # =================
 
     def to_dict(self, details=False, inquirer=None):
         output = {

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1876,11 +1876,11 @@ class Participant(Model, MixinTeam):
         with self.db.get_cursor() as c:
             c.one("""
                 DELETE FROM elsewhere
-                WHERE participant=%s
-                AND platform=%s
-                AND domain=%s
-                AND user_id=%s
-                RETURNING participant
+                 WHERE participant=%s
+                   AND platform=%s
+                   AND domain=%s
+                   AND user_id=%s
+             RETURNING participant
             """, (self.id, platform, domain, user_id), default=NonexistingElsewhere)
             self.add_event(c, 'delete_elsewhere', dict(
                 platform=platform, domain=domain, user_id=user_id

--- a/liberapay/models/repository.py
+++ b/liberapay/models/repository.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from postgres.orm import Model
 
+from liberapay.utils import utcnow
 from liberapay.website import website
 
 
@@ -13,3 +14,26 @@ class Repository(Model):
     def url(self):
         platform = getattr(website.platforms, self.platform)
         return platform.repo_url.format(**self.__dict__)
+
+
+def upsert_repos(cursor, repos, participant):
+    if not repos:
+        return repos
+    r = []
+    for repo in repos:
+        repo.participant = participant.id
+        repo.extra_info = json.dumps(repo.extra_info)
+        repo.info_fetched_at = utcnow()
+        cols, vals = zip(*repo.__dict__.items())
+        on_conflict_set = ','.join('{0}=excluded.{0}'.format(col) for col in cols)
+        cols = ','.join(cols)
+        placeholders = ('%s,'*len(vals))[:-1]
+        r.append(cursor.one("""
+            INSERT INTO repositories
+                        ({0})
+                 VALUES ({1})
+            ON CONFLICT (platform, remote_id) DO UPDATE
+                    SET {2}
+              RETURNING repositories
+        """.format(cols, placeholders, on_conflict_set), vals))
+    return r

--- a/liberapay/models/repository.py
+++ b/liberapay/models/repository.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from postgres.orm import Model
+
+from liberapay.website import website
+
+
+class Repository(Model):
+
+    typname = "repositories"
+
+    @property
+    def url(self):
+        platform = getattr(website.platforms, self.platform)
+        return platform.repo_url.format(**self.__dict__)

--- a/liberapay/models/repository.py
+++ b/liberapay/models/repository.py
@@ -1,7 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import json
+from time import sleep
+
 from postgres.orm import Model
 
+from liberapay.cron import logger
+from liberapay.models.participant import Participant
 from liberapay.utils import utcnow
 from liberapay.website import website
 
@@ -16,14 +21,14 @@ class Repository(Model):
         return platform.repo_url.format(**self.__dict__)
 
 
-def upsert_repos(cursor, repos, participant):
+def upsert_repos(cursor, repos, participant, info_fetched_at):
     if not repos:
         return repos
     r = []
     for repo in repos:
         repo.participant = participant.id
         repo.extra_info = json.dumps(repo.extra_info)
-        repo.info_fetched_at = utcnow()
+        repo.info_fetched_at = info_fetched_at
         cols, vals = zip(*repo.__dict__.items())
         on_conflict_set = ','.join('{0}=excluded.{0}'.format(col) for col in cols)
         cols = ','.join(cols)
@@ -37,3 +42,45 @@ def upsert_repos(cursor, repos, participant):
               RETURNING repositories
         """.format(cols, placeholders, on_conflict_set), vals))
     return r
+
+
+def refetch_repos():
+    with website.db.get_cursor() as cursor:
+        repo = cursor.one("""
+            SELECT r.participant, r.platform
+              FROM repositories r
+             WHERE r.info_fetched_at < now() - interval '6 days'
+          ORDER BY r.info_fetched_at ASC
+             LIMIT 1
+        """)
+        if not repo:
+            return
+        participant = Participant.from_id(repo.participant)
+        account = participant.get_account_elsewhere(repo.platform)
+        sess = account.get_auth_session()
+        start_time = utcnow()
+        logger.debug(
+            "Refetching repository data for participant ~%s from %s account %s" %
+            (participant.id, account.platform, account.user_id)
+        )
+        next_page = None
+        for i in range(10):
+            r = account.platform_data.get_repos(account, page_url=next_page, sess=sess)
+            upsert_repos(cursor, r[0], participant, utcnow())
+            next_page = r[2].get('next')
+            if not next_page:
+                break
+            sleep(1)
+        deleted_count = cursor.one("""
+            WITH deleted AS (
+                     DELETE FROM repositories
+                      WHERE participant = %s
+                        AND platform = %s
+                        AND info_fetched_at < %s
+                  RETURNING id
+                 )
+            SELECT count(*) FROM deleted
+        """, (participant.id, account.platform, start_time))
+        event_type = 'fetch_repos:%s' % account.id
+        payload = dict(partial_list=bool(next_page), deleted_count=deleted_count)
+        participant.add_event(cursor, event_type, payload)

--- a/liberapay/utils/i18n.py
+++ b/liberapay/utils/i18n.py
@@ -27,7 +27,7 @@ from liberapay.website import website
 Money = namedtuple('Money', 'amount currency')
 
 
-class datedelta(timedelta):
+class Age(timedelta):
 
     def __new__(cls, *a, **kw):
         if len(a) == 1 and not kw and isinstance(a[0], timedelta):
@@ -142,8 +142,8 @@ def i_format(loc, s, *a, **kw):
                 c[k] = format_number(o, locale=loc)
             elif isinstance(o, Money):
                 c[k] = format_money(*o, locale=loc)
-            elif isinstance(o, datedelta):
-                c[k] = format_timedelta(o, locale=loc, granularity='day')
+            elif isinstance(o, Age):
+                c[k] = format_timedelta(o, locale=loc, **o.format_args)
             elif isinstance(o, timedelta):
                 c[k] = format_timedelta(o, locale=loc)
             elif isinstance(o, datetime):
@@ -189,10 +189,14 @@ def n_get_text(state, loc, s, p, n, *a, **kw):
     return i_format(loc, escape(s2), *a, **kw)
 
 
-def to_age(dt):
+def to_age(dt, **kw):
     if isinstance(dt, datetime):
-        return dt - utcnow()
-    return datedelta(dt - date.today())
+        delta = Age(dt - utcnow())
+    else:
+        delta = Age(dt - date.today())
+        kw.setdefault('granularity', 'day')
+    delta.format_args = kw
+    return delta
 
 
 def regularize_locale(loc):

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -31,6 +31,7 @@ from liberapay.models.account_elsewhere import _AccountElsewhere, AccountElsewhe
 from liberapay.models.community import _Community, Community
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.models.participant import Participant
+from liberapay.models.repository import Repository
 from liberapay.models import DB
 from liberapay.security.authentication import ANON
 from liberapay.utils import find_files, markdown
@@ -86,7 +87,7 @@ def database(env, tell_sentry):
 
     models = (
         _AccountElsewhere, AccountElsewhere, _Community, Community,
-        ExchangeRoute, Participant,
+        ExchangeRoute, Participant, Repository,
     )
     for model in models:
         db.register_model(model)

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -139,6 +139,7 @@ class AppConf(object):
         openstreetmap_id=str,
         openstreetmap_secret=str,
         password_rounds=int,
+        refetch_repos_every=int,
         s3_endpoint=str,
         s3_public_access_key=str,
         s3_secret_key=str,

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -390,11 +390,14 @@ def accounts_elsewhere(app_conf, asset, canonical_url, db):
     friends_platforms = [p for p in platforms if getattr(p, 'api_friends_path', None)]
     friends_platforms = PlatformRegistry(friends_platforms)
 
+    platforms_with_repos_api = [p for p in platforms if hasattr(p, 'api_repos_path')]
+
     for platform in platforms:
         platform.icon = asset('platforms/%s.16.png' % platform.name)
         platform.logo = asset('platforms/%s.png' % platform.name)
 
-    return {'platforms': platforms, 'friends_platforms': friends_platforms}
+    return {'platforms': platforms, 'friends_platforms': friends_platforms,
+            'platforms_with_repos_api': platforms_with_repos_api}
 
 
 def load_i18n(canonical_host, canonical_scheme, project_root, tell_sentry):

--- a/sql/app-conf-tests.sql
+++ b/sql/app-conf-tests.sql
@@ -8,6 +8,7 @@ BEGIN
     PERFORM update_app_conf('dequeue_emails_every', '0'::jsonb);
     PERFORM update_app_conf('update_homepage_every', '0'::jsonb);
     PERFORM update_app_conf('send_newsletters_every', '0'::jsonb);
+    PERFORM update_app_conf('refetch_repos_every', '0'::jsonb);
 END;
 $$;
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -19,3 +19,6 @@ CREATE TABLE repositories
 
 CREATE INDEX repositories_trgm_idx ON repositories
     USING gist(name gist_trgm_ops);
+
+INSERT INTO app_conf (key, value) VALUES
+    ('refetch_repos_every', '60'::jsonb);

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -16,3 +16,6 @@ CREATE TABLE repositories
 , UNIQUE (platform, remote_id)
 , UNIQUE (platform, slug)
 );
+
+CREATE INDEX repositories_trgm_idx ON repositories
+    USING gist(name gist_trgm_ops);

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -11,7 +11,7 @@ CREATE TABLE repositories
 , stars_count           int
 , extra_info            json
 , info_fetched_at       timestamptz     NOT NULL DEFAULT now()
-, participant           bigint          NOT NULL REFERENCES participants
+, participant           bigint          REFERENCES participants
 , show_on_profile       boolean         NOT NULL DEFAULT FALSE
 , UNIQUE (platform, remote_id)
 , UNIQUE (platform, slug)

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,18 @@
+CREATE TABLE repositories
+( id                    bigserial       PRIMARY KEY
+, platform              text            NOT NULL
+, remote_id             text            NOT NULL
+, owner_id              text            NOT NULL
+, name                  text            NOT NULL
+, slug                  text            NOT NULL
+, description           text
+, last_update           timestamptz     NOT NULL
+, is_fork               boolean
+, stars_count           int
+, extra_info            json
+, info_fetched_at       timestamptz     NOT NULL DEFAULT now()
+, participant           bigint          NOT NULL REFERENCES participants
+, show_on_profile       boolean         NOT NULL DEFAULT FALSE
+, UNIQUE (platform, remote_id)
+, UNIQUE (platform, slug)
+);

--- a/style/base/utils.scss
+++ b/style/base/utils.scss
@@ -14,3 +14,7 @@
         text-align: center;
     }
 }
+
+.paragraph {
+    margin-bottom: ($line-height-computed / 2);
+}

--- a/templates/import-repos.html
+++ b/templates/import-repos.html
@@ -1,0 +1,22 @@
+% from "templates/repos.html" import show_repo with context
+
+% set repos = participant.get_repos_for_profile()
+% if repos
+<p>{{ _("The following repositories are currently displayed on your profile:") }}</p>
+<form action="{{ participant.path('repos') }}" class="js-submit"
+      data-on-success="fadeOut:.repo" method="POST">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+    % for repo in repos
+        {{ show_repo(repo, unlist=True) }}
+    % endfor
+</form>
+<hr>
+% endif
+
+<p>{{ _("We can import a list of your repositories from:") }}</p>
+<p>
+% for platform in website.platforms_with_repos_api
+<a class="btn btn-default" href="{{ participant.path('repos/' + platform.name) }}" target="_blank"
+    >{{ platform.display_name }}</a> &nbsp;&nbsp;
+% endfor
+</p>

--- a/templates/repos.html
+++ b/templates/repos.html
@@ -1,0 +1,31 @@
+% from "templates/icons.html" import glyphicon
+
+% macro show_repo(repo, edit=False, unlist=False)
+<div class="repo">
+    <h4>
+        <a href="{{ repo.url }}">{{ repo.name }}</a>
+        {{ _("(fork)") if repo.is_fork else '' }}
+        % if repo.stars_count != None
+        &nbsp;&nbsp;<small>{{ glyphicon('star') }} {{ repo.stars_count }}</small>
+        % endif
+        % set last_update = to_age(repo.last_update, granularity='week')
+        &nbsp;&nbsp;<small>{{
+            _("Updated this week") if last_update.days > -7 else
+            _("Updated {0} ago", last_update)
+        }}</small>
+        % if unlist
+        &nbsp;&nbsp;
+        <button class="btn btn-warning btn-sm" name="show_on_profile:{{ repo.id }}"
+                value="off">{{ _("Unlist") }}</button>
+        % endif
+    </h4>
+    <p>{{ repo.description }}</p>
+    % if edit
+    <p><label>
+        <input type="checkbox" name="show_on_profile:{{ repo.id }}" value="on"
+               {{ 'checked' if repo.show_on_profile }} />
+        {{ _("Show on your profile") }}
+    </label></p>
+    % endif
+</div>
+% endmacro

--- a/tests/py/fixtures/TestPages.yml
+++ b/tests/py/fixtures/TestPages.yml
@@ -557,4 +557,304 @@ interactions:
       transfer-encoding: [chunked]
       vary: [Accept, Accept-Encoding]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.github.com:443/users/david/repos?type=owner&sort=updated&per_page=100&client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2d72/juNGA/xXDXy+OLflHHAHF9XptgRa9L9f0S4sikG0l1q5tGZKcdNfY/71D
+        SaRGJB1LnElzXQh40Tdncx6NJFKynh1S/zoP480w8KfT5exmeAj30TAY7pLnVZIPb4ZPp93usfpw
+        E77Em7H6Knk9ROkwOIvG8QGCiu8hpsDdT2+G4UuYh+njKd3Bt9s8P2bBeFx+mPm3z3G+Pa1OWZSu
+        k0MeHfLbdbIfn8YQ+uPL76YAek4rgiAO4QONdIwrSBkJpGwsk9jm+5225XKDRVvZ6inZ7ZJXiNOT
+        vIgeqxBxdIrw+PDcNRxCzuMk30ZwdCDtb2Jn4yzvkEbR/DwW/+8x3ghABsc6jTbtU6kCIBFxJr+d
+        x2l0TArSaZWt0/iYx8mhQ0qNMMAk6XN4iL+GHTEQlkG0SKbDxovmEBa9QE/qEFe2P4+PafwSrr+I
+        3U+jdRS/wJHsytICAZV/OYrh9A84x+K4xnn0GG72YrQ8hbss+nYzLLabQ6PigxsYJlf7bT0EN5E6
+        T7CVnwYwEmEoPg9g7A6eknTwl19/hs3CX58V/80hVBzEcnDUGxHhVw6oGQfDBKJg45+jL92DRdB5
+        DP9bde01jLNwlaRhnlwbqpZUGtHnMf5PcbrzKNx3T7GIguhtkjgcnSIKouMsO0Wt+pllv4rgbCx7
+        8OG0X5WXkjb91sIrwyCrMMvi50MUdT8qKvI8lte1VRoe1lsHlgw8j8u/inMVPndPSgRB7GqXrLoH
+        w01jXESex9k2LC/U+aNTHgIlAhukNHpyS0oEKlKeupytIiERqThwS8jhxHXPSAaOz9VR2oWH51P4
+        7IBSkXDOxC3qOfx69QZt6c11KHDEL4w0Xp0crx91sMipvDvCWHM4THVsTSrus2/ftm37h27SxR7u
+        9/G1G58FU8U1+qQrS/QnnSf++/od+UJiIvA8ri9s5eWyQnY+YtX1UmaEwdUv0O4nVAaOzz8cw3wr
+        rg/AP4Zp1Dm9Km58XoXwy+D29va8jcLil90+Sl0GUhkG8WG63sIPms4ZnWUg3Mz3YV78QnwSCW3g
+        F+MuCTfdj5eKBEp5PjpnVYbhs3eEh5TuqRRRGLOPd1GWJweHa1YdioGHJI+f4nWbH8CWAdCIPv+Y
+        xYd1dBPudjfQu/J4HUN/g9964nTAb6PI4QCUYZAwPPOVv3t3EXS97kcyjcrA87h8EtlEx13yxW3Y
+        o1gxltIIfhxvHsMcft/6k8lyNFmMJsuHyTKYLgPP+ye0OR03uI0nGoy8yYPvBTNosxRtjqdsq2P8
+        uwdvEXjzYFJg4OJVdUX4C55T9afF6gexeOKE1lm2rVv/vm4b4Ifkqu16B31K6+ZX6C/6/eBCe8hk
+        m+yjI9xoyyfkLP4Kfy2XjVvnOjkd4AD6N8PXMIffYnDjqj+St1uI//W0+iKIYfZYDrJhkKcn8VAC
+        nxzT5FO0zjP8WT2aUcPX+HPcCBS/AtTzR/k0UW1+Ate2OE2TyhEcYETCY+MxOlTbl2lCu/J5IoC/
+        0PdD8d9yn4od3ERP4WmXP5Y/GWGf9mGWw8PXt5tKc3jLBZiJymjAk1h8yXPU3/WioxcdxeOMfDTu
+        RUfTkMA1431ERz0GddOR7eFOKPxG6TpSuIW9gnG4hVTcdAe6FHTzHVWgo/CQ0UzGQ+J4lYekOjoP
+        GU6THpLCZj0kkKI9JIPFe0gYXXyoE+ZkPmS0eJyjqg/MIroPjKLIj0ZKRPshWRz6Q7Ko/gPlVLkT
+        uCi6CRCJwtHix6+LAVFpMSgQjVUIlGInOzqQev+KQJoEwf2KbkFwakwaRCJZPQjuIiJPighB+ywM
+        CoMJkUR3FSIJnC5EMikypHkyCTZEglh0iDreSqUw+BAJfT8hIrdANyKSxKJEVD+pfYq4ylmdyPQB
+        TMZ8FkwK3+HmRO6ENvG8wAcnMmvlRKoM20mRZuNWVkTjX9ciVYCwGBYv4nmgCNC/KVQawjPFCHz0
+        HYkR2JtrYmQ58+8XSoxs9qM4G6XRS5zBrTUSVR1mJYilUa9KelXSqxLsiv5XNSGWwdh0Jn+EWqxf
+        wuMxSgcvoLJgWItKkePuBBUjg9dtvN4O4mwQDlZxPtgnaTR42kX/iVe7aJBvw8Og5FeR5QXBqazE
+        kmfHAhOd4GheDAyTgjG4vC7GwDtKGYNDszMGjk3TGGSKrzFgLOLGoNINjoF0K2IxMBxOxwolyh0r
+        k2J5rEBqsYsB5fA+BpQqgAwgQymMweRQQgYUiaVaM3Usj7kEdZZEBlCXOzCm4B8qO6ongypGpk6W
+        pSrtayQMrEQwlNEYbFaRZNA5Smss0KI4h0EtGWh3x2SgOGWTAadYJwNGLsYxiCweyqCyFugY9Pcz
+        U8am6IrKQLK4KoN6rZDH80cTkFZ+4C+C2fSCtJqLYh9vGfh+MJlYC3kEZi7cl3cfzP1W0kpPtZ29
+        uhDVSmNdiM2u+yw98oLYshf8QKGLXvADH31HXgv25prXupvOl3d1wU+Urh7TKEtO6ToCo2X1WnAh
+        1xv1Xqv3Wr3X+givZRmMWi3QZgPWahfnOaiqffgcrwd5MhA/e5PDAA11+AjK+GEiEcgvQpmQeW3o
+        qK/0HXLUVwaGSV8ZXF59ZeAd9ZXBoekrA8emrwwyRV8ZMBZ9ZVDp+spAuukrA8Ohr6xQor6yMin6
+        ygqk6isDyqGvDChVXxlABn1lMDn0lQHl0FeXoM76ygDqkslJXxlUHn1lYBn1lcFm1VcGnUNfWaBc
+        +spAwwdinobDbDEDxamvDDhFXxkwsr4yiCz6yqCy6iuD/n76ytgUXV8ZSBZ9ZVCv6itvNLl/AOnk
+        L4PJ/Zv6ahFMp9UkM20e2v1oAhjvwbsLZlC61bLmSnsEaaev9B3sMjftQmwLfaVHXtBXng9Lz/R1
+        WeutOWFtMfMX901/tT6ti6UeLssr1KI3V7256s3Vh5krNBKb2uoXuIoPfhj8XI3lQQxLYMF6V9VM
+        Bsc5bOLOgK8OHWey4XCKlpIpiBV8ONbxKe4iCvoOQkqxKTZKQRhUlGLxeiiFJUsoReIzUArJpJ/q
+        k+o2C67R6djEk8pKEDmsUwNIVk7N9Kiz4xqHkE02qRxZTJOicWkmBWRzTHWKHHPnmieFuIqQfmnm
+        mEdnDDzdWHUvizLT5JpT10iW3yg1OhN5fp12H2V1SSpTONYUkaQ47BZJkckKSZF4/JHC8cmj+myw
+        zsRrdKB31kZqF5ickeLxCaO6R12ZoedNRt6dWJFosgj8S6sWlcVOMPduDjPwLMVOYIumIw/qoSbB
+        FGxRu2KnxpWvgyqSu9bZE2mBbSWRDLtgiKb31pl7whvpJU7is4+scfLmnVc1EiFvLGsEO3StzGk6
+        8ef19L1yjebR6+ur1RE1vu4FUS+IekH0EYKoMQybduhhC3Px4P9ghfDBa7Qq7FD6FK5hMl4iVnmu
+        Fi1zmoHXvDh0U0R1rKMfQgAmOYSIvGYIgR21ECLQnBACsQkhxKTYIIRhUUGIR/dA+BQ6SSAE4DBA
+        Go6ofzQaxf3oiRHFD8JxWB+EoyqfZmbU9ZEQjUP24OQYTI+Jcy4iauwog+PR+htd8GgJMtkdRGVV
+        O1q/oXqd5s4zzW9DUHejgyCcOgdhKS7HOL2EZZQQi8Xi4MPPqXAQ9/38DdoIXd4gGIu5wZ3niraZ
+        3BXVOTD5TFiZC0U+05E/e5j4ATSbFRU85mLTsLASYMD+3AXeotUctTrJds7GaN9qXpoR1cLW1DEX
+        VM2FYp7f3urTsCpSx9WnIeINTXPd0swni8XCnwKmWoA6jFP4lfs5smoa9GUvaXpJ00uaj5A0aBDq
+        iiYaJE/weoc43A1+qsYxzEOD8Zx+Kd6+JZbTH8CKSzv5CggxygtlU66q3/pVXPgq0c3XyEhHW6PC
+        mVyN4vGaGoV19DQqnmZpFIbN0SgixdAoCIufUTS6nalPm5ObUeEcZqYBI3qZBotiZZpJEZ2MgnEY
+        GQWj+hicFdXGKBaHi6kTYzAxOszZw6BdZLAwjf5FdzCN5JgMjGKy+pdGT6HaF7zbTO5FId3Ni0Jw
+        ehcFpVgX7ZQSnIsisRiX+qBz+hZFfT/bojZBdy0KxWJa6u7ylmcRL+zyRj5MpoKilvtgeqk8Brcp
+        al+anqXGeAFUyPjtJlPJFNtZFq11K8eib+H6mj8youlX1Puzq0eN2ziBBuX7vvzpAipIzAlU6O1Y
+        6FVabxfHyPcQ/3+88gv28FppzGw6uZv7czhAlXRZhevPK1jV+nYfpmJ16xxev2xb39rerlcxvYrp
+        VcxHqBj7eDStzB+q8T34s3wtmKt4sW+x44I/FoijjrGRmMyMDc0raWxbcPQ1NhRN3diIbBbHBqcI
+        HRuPxe3YwHTNY6O6LQdkI3HIn0tcoge6hKUooUtM6tJANi6HKLJxqc7IxmSYvGXDcpgkG5djpaA3
+        uM5+ycbUxZDTekE2MM+SQTYy46pBNjyri7JtgGPtIDuXa8qXje4uq2w0Tm9l41MUlo1Hngpmg7KI
+        LRuYdUEh2wbeT3fZtkY3XzYqiwSzgd9cXMiDeWD3oqYIFrX2p8H8zlZ3hNuANrOsjV1j4HtYf6ho
+        Iq7d5T87w1+2l9xbsm2nxi4HtrJkl8NblCRZgk13Bntb+55P2S3cI5Q/8ybLhXV+2VWB9tfwJfz7
+        Oo2PudgiOLPyMqBedy8+OqbJp2idZ/Lf/cVn9dWnKgYQH77Gn+NmZChm0gaVkiufO6t31kFmHYuX
+        IOJy8VILj7ZcTmfT2VJptGgfrrNb+6vh6u96Xdbrsl6XfYQuq8dgQ5EdTrudrEOqLiytC5HQkO9W
+        h1QFOnovGc3kuiSO129JqqPTkuE0jyUpbO5KAim+SjJYHJWE0b2UOmFO1UcymsM/YRbROWEUxTM1
+        UiJWHkkWh0+SLKpDQjlRy44kisMVqbQYio40lrMTqvePoeQI9ytdLHVf1genxlRwJJGsjgd3EWq5
+        EdpnpmojSXT3N5LA6Wwkk+JpmieTUGkkQSw+Rh1vzjojCX0/7yK3QHctksTiV1Q/ebPGaFqsnXMn
+        5nLNp8HMumAzOJXZaLIQ6+vMYMqXrcbI1uSqU6kybOdRmo1buRONf73AqApoOJLysaAsJ5rO3WTI
+        n4QRGPwtzo6aDCnnOzi4EBT4W1IhPuiipTet3yt2TKNReTuzVhI1vu6NSG9EeiPyEUakMQy1t4gN
+        sl38vM13XwbxHoTtS7QZ1M0H4qm8mNMFF3vXYqLmNaKbP6ljHRUKAjBZFETkFSkI7OhSEIGmUxCI
+        zaggJkWqIAyLV0E8ulrBp9DJriAAh2DRcETHotEomkVPjGhaEI5DtiAc1bc0M6MqF0TjsC44OQbx
+        YuKc3UtjRxn0i9bf6AZGS5BJwiAqq4fR+g1VxTR3nsnGIKi7kEEQTieDsBQtY5xegplBLBY5gw8/
+        p59B3PdTNGgjdEuDYCyiBneeN13NbAQvdZ9OxII5Hrwbfmmrf0Ft4N3wc8u6O56tyVVXUyfZTtcY
+        7VsZGyOqRZFLHWOtbfkUZ1uR8va0EqUtY3S0VZnL8m4JdR4O08Teocrlt2p2/IU3uffrKhfo+nBk
+        R8+RqBaCN8bvHqtZZJvwJd6MG1/3Zqc3O73Z+Qiz0xiGTbPz8y6G33kDGMCFwBHTaKEUsAyAxXmq
+        OkCndXma14ZuRqeOdTQ6CMBkdBCR1+ggsKPRQQSa0UEgNqODmBSjgzAsRgfx6EYHn0Ino4MAHEZH
+        wxGNjkajGB09MaLRQTgOo4NwVKPTzIxqdBCNw+jg5BiMjolzNjqNHWUwOlp/oxsdLUEmo4OorEZH
+        6zdUo9PceSajg6DuRgdBOI0OwlKMjnF6CUYHsViMDj78nEYHcd/P6KCN0I0OgsGfUZhF8HbWePMN
+        nmzRjKRqgpBab+YYY6+QRsckG+sPv+O3ZzRBWc0SimseQOfAIj+edYUf3GYeeJYXYIHRqTGyyVWj
+        U+90O6NjtG9ldIyoFkanjrEanfLr+hGlWupnBm8Dd1A4YjFSrSrnu1vpZ7GEdX7u6oV+9rCy8ijO
+        RyuxxM+F16XrTXqH0zuc3uF8hMMxRivbtCWD3HEFn2a8o6/RIEzORqPyehsN7uhuNArN32gwNoej
+        cSkeR0OxuByNSfc5+ql1cjoahMPrWJBEt2MhUvyOBUdde0dDcngeDUl1PWaGVN+jETmcj54kg/ex
+        I53dj7HTDP7H0h/pDsiSKJMH0sisLsjIGl6aeciz8fmHY5hvxVMuHBnhdNo/4RpIrvVzNLC7F9JA
+        nG5IQ1P8kPW0ExyRxmPxRPop4XRFGvv9fJG2Iboz0oAs3kjvWG9WA/nw7qyRPxer4cxgJZvi9Vmn
+        4ybMo81jmA+DoT8RYghmZsErtmC5HHgLV7FijrY6NEwA82EO2IOoFoKXeRUTwK66o2ai7fyRNaaV
+        Q7JGtvBIzbiGS8KzurzZAl4kzqOOvpsJXf/+L0EsVPL/1gAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      etag: [W/"90d00bae53da26a9c4edc00727cc95fb"]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: [Accept]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.github.com:443/users/team/repos?type=owner&sort=updated&per_page=100&client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VY0W6jOBT9F143iUPSzrRIq9k/mHno065WkQMOeAo2sk26Leq/77ENAVLRpI5U
+        pcS55/j4+t7ra/5pI55FSbyJHx+28SIStGJREv0qJBP8v+WTotkqWkSHpix33W9PjFbk3EC+CKai
+        pI1KmXMBBmsFoCW/v/seP24WET1SQ9WuUSV+L4ypdUKIH9TxKuemaPaNZiqVwjBhVqmsSEM8+sfx
+        zy3octWRWN4IA2dkNe94PBhkmnRKClOVZ3P7KZ1pZ3SQZSlfgDpXOUdMTgjrJYfmIv8iGoiWSFMw
+        OAeS3+1CuTbXi3DWLbH/djyzeA1PK5ZdLaSzhwy7ke8tUayWjqjZ61Tx2nAprhc0QYFFqpwK/ka/
+        xgKUBthKuX5qZw0UOyKGrod585bUih9p+mqXrljK+BFO/CLVGQ5M5rW2WfVz5AXrWm7YjmaVzZcD
+        LTV7X0RuegNjN7BAmlyK2g+pmLHThkWJQOLawFTPJ8pPU8Z5z2XDB15LcsGfc2hkCbBY8jN7DaWw
+        0Jbgs4vwFMlG91JRIy+l66ysCUdLxl9tABi4IVSuw4KjkDLYaw4LDq51w66KwtmVOgpN+igXTbX3
+        heaa2J5l9WAopFrzXDAW6q0TviV9BdwrKtIimLGHt8Q/uf2keahACwXDvpT7UAqcNsThW6IL6ou8
+        2d2gyRJa+IRPscMtAi38xGdU+I46cRZ/YsMRY7C5oep6OGk775VU5A3NgwlPeFuKcVzm9O3iwT+b
+        CQMB2GwDo/i+uakyDRRWnz+FkbPB7hsYBj53qn/eI8yveNQYuDVXFb903s6SdehJJN/GaOPvnNV+
+        v9wUfCrSwlsylE9fmjviQE92tblXN6bvWuHQTe/hpP2jpqawNQez1FSxQKkdmrR7inZltVq1BaOu
+        4ayYCk9FDwYLVWmBlitQXdvD0W5U1Lgu9mDFZehqS0mzUD+e8ODyuxWo0IPHO1yjQQuV5bBjsoqX
+        TBspgmviQDCmFdLwA0+v6d5nk2fC0f7QXKRsQdGcIhoNTzniE9cgu1no6liwSzwY4nGP9T18yRCq
+        oR5WzMNb4q9VGatL+XpLERkx2GxUDN1+tqMG14PNOo6Xa/zdPcXfkvVDst38DZumziY235br7TJ+
+        eIq3yd06uf9ubepGFzM0j0nsTFAQu6DFEy7eZ5ffabtvb9HAaF0MmL8GRPLxgtAh0hLRd5YcV810
+        PD+HPkVBWyErVuP49+8BNH/DU7y+n5zlqWwEPLtZRC/UoJnE6TkM9ed/f0kqqN75/IwSoxp7+cJI
+        reRvlho9HhvKwcjwhT/zCdC2Jv2Avzt1c+M1S8WVkt2rEH9FkzUT3fS9Rtj5e1OCp9HvWOewILe6
+        jB1oU5qdb3XhkbxYWt/o6P3f/wEyiHka4hEAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      etag: [W/"a5753eeedfe37677d79aaae50f4dd447"]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: [Accept, Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.github.com:443/users/david/repos?type=owner&sort=updated&per_page=100&client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2d72/juNGA/xXDXy+OLflHHAHF9XptgRa9L9f0S4sikG0l1q5tGZKcdNfY/71D
+        SaRGJB1LnElzXQh40Tdncx6NJFKynh1S/zoP480w8KfT5exmeAj30TAY7pLnVZIPb4ZPp93usfpw
+        E77Em7H6Knk9ROkwOIvG8QGCiu8hpsDdT2+G4UuYh+njKd3Bt9s8P2bBeFx+mPm3z3G+Pa1OWZSu
+        k0MeHfLbdbIfn8YQ+uPL76YAek4rgiAO4QONdIwrSBkJpGwsk9jm+5225XKDRVvZ6inZ7ZJXiNOT
+        vIgeqxBxdIrw+PDcNRxCzuMk30ZwdCDtb2Jn4yzvkEbR/DwW/+8x3ghABsc6jTbtU6kCIBFxJr+d
+        x2l0TArSaZWt0/iYx8mhQ0qNMMAk6XN4iL+GHTEQlkG0SKbDxovmEBa9QE/qEFe2P4+PafwSrr+I
+        3U+jdRS/wJHsytICAZV/OYrh9A84x+K4xnn0GG72YrQ8hbss+nYzLLabQ6PigxsYJlf7bT0EN5E6
+        T7CVnwYwEmEoPg9g7A6eknTwl19/hs3CX58V/80hVBzEcnDUGxHhVw6oGQfDBKJg45+jL92DRdB5
+        DP9bde01jLNwlaRhnlwbqpZUGtHnMf5PcbrzKNx3T7GIguhtkjgcnSIKouMsO0Wt+pllv4rgbCx7
+        8OG0X5WXkjb91sIrwyCrMMvi50MUdT8qKvI8lte1VRoe1lsHlgw8j8u/inMVPndPSgRB7GqXrLoH
+        w01jXESex9k2LC/U+aNTHgIlAhukNHpyS0oEKlKeupytIiERqThwS8jhxHXPSAaOz9VR2oWH51P4
+        7IBSkXDOxC3qOfx69QZt6c11KHDEL4w0Xp0crx91sMipvDvCWHM4THVsTSrus2/ftm37h27SxR7u
+        9/G1G58FU8U1+qQrS/QnnSf++/od+UJiIvA8ri9s5eWyQnY+YtX1UmaEwdUv0O4nVAaOzz8cw3wr
+        rg/AP4Zp1Dm9Km58XoXwy+D29va8jcLil90+Sl0GUhkG8WG63sIPms4ZnWUg3Mz3YV78QnwSCW3g
+        F+MuCTfdj5eKBEp5PjpnVYbhs3eEh5TuqRRRGLOPd1GWJweHa1YdioGHJI+f4nWbH8CWAdCIPv+Y
+        xYd1dBPudjfQu/J4HUN/g9964nTAb6PI4QCUYZAwPPOVv3t3EXS97kcyjcrA87h8EtlEx13yxW3Y
+        o1gxltIIfhxvHsMcft/6k8lyNFmMJsuHyTKYLgPP+ye0OR03uI0nGoy8yYPvBTNosxRtjqdsq2P8
+        uwdvEXjzYFJg4OJVdUX4C55T9afF6gexeOKE1lm2rVv/vm4b4Ifkqu16B31K6+ZX6C/6/eBCe8hk
+        m+yjI9xoyyfkLP4Kfy2XjVvnOjkd4AD6N8PXMIffYnDjqj+St1uI//W0+iKIYfZYDrJhkKcn8VAC
+        nxzT5FO0zjP8WT2aUcPX+HPcCBS/AtTzR/k0UW1+Ate2OE2TyhEcYETCY+MxOlTbl2lCu/J5IoC/
+        0PdD8d9yn4od3ERP4WmXP5Y/GWGf9mGWw8PXt5tKc3jLBZiJymjAk1h8yXPU3/WioxcdxeOMfDTu
+        RUfTkMA1431ERz0GddOR7eFOKPxG6TpSuIW9gnG4hVTcdAe6FHTzHVWgo/CQ0UzGQ+J4lYekOjoP
+        GU6THpLCZj0kkKI9JIPFe0gYXXyoE+ZkPmS0eJyjqg/MIroPjKLIj0ZKRPshWRz6Q7Ko/gPlVLkT
+        uCi6CRCJwtHix6+LAVFpMSgQjVUIlGInOzqQev+KQJoEwf2KbkFwakwaRCJZPQjuIiJPighB+ywM
+        CoMJkUR3FSIJnC5EMikypHkyCTZEglh0iDreSqUw+BAJfT8hIrdANyKSxKJEVD+pfYq4ylmdyPQB
+        TMZ8FkwK3+HmRO6ENvG8wAcnMmvlRKoM20mRZuNWVkTjX9ciVYCwGBYv4nmgCNC/KVQawjPFCHz0
+        HYkR2JtrYmQ58+8XSoxs9qM4G6XRS5zBrTUSVR1mJYilUa9KelXSqxLsiv5XNSGWwdh0Jn+EWqxf
+        wuMxSgcvoLJgWItKkePuBBUjg9dtvN4O4mwQDlZxPtgnaTR42kX/iVe7aJBvw8Og5FeR5QXBqazE
+        kmfHAhOd4GheDAyTgjG4vC7GwDtKGYNDszMGjk3TGGSKrzFgLOLGoNINjoF0K2IxMBxOxwolyh0r
+        k2J5rEBqsYsB5fA+BpQqgAwgQymMweRQQgYUiaVaM3Usj7kEdZZEBlCXOzCm4B8qO6ongypGpk6W
+        pSrtayQMrEQwlNEYbFaRZNA5Smss0KI4h0EtGWh3x2SgOGWTAadYJwNGLsYxiCweyqCyFugY9Pcz
+        U8am6IrKQLK4KoN6rZDH80cTkFZ+4C+C2fSCtJqLYh9vGfh+MJlYC3kEZi7cl3cfzP1W0kpPtZ29
+        uhDVSmNdiM2u+yw98oLYshf8QKGLXvADH31HXgv25prXupvOl3d1wU+Urh7TKEtO6ToCo2X1WnAh
+        1xv1Xqv3Wr3X+givZRmMWi3QZgPWahfnOaiqffgcrwd5MhA/e5PDAA11+AjK+GEiEcgvQpmQeW3o
+        qK/0HXLUVwaGSV8ZXF59ZeAd9ZXBoekrA8emrwwyRV8ZMBZ9ZVDp+spAuukrA8Ohr6xQor6yMin6
+        ygqk6isDyqGvDChVXxlABn1lMDn0lQHl0FeXoM76ygDqkslJXxlUHn1lYBn1lcFm1VcGnUNfWaBc
+        +spAwwdinobDbDEDxamvDDhFXxkwsr4yiCz6yqCy6iuD/n76ytgUXV8ZSBZ9ZVCv6itvNLl/AOnk
+        L4PJ/Zv6ahFMp9UkM20e2v1oAhjvwbsLZlC61bLmSnsEaaev9B3sMjftQmwLfaVHXtBXng9Lz/R1
+        WeutOWFtMfMX901/tT6ti6UeLssr1KI3V7256s3Vh5krNBKb2uoXuIoPfhj8XI3lQQxLYMF6V9VM
+        Bsc5bOLOgK8OHWey4XCKlpIpiBV8ONbxKe4iCvoOQkqxKTZKQRhUlGLxeiiFJUsoReIzUArJpJ/q
+        k+o2C67R6djEk8pKEDmsUwNIVk7N9Kiz4xqHkE02qRxZTJOicWkmBWRzTHWKHHPnmieFuIqQfmnm
+        mEdnDDzdWHUvizLT5JpT10iW3yg1OhN5fp12H2V1SSpTONYUkaQ47BZJkckKSZF4/JHC8cmj+myw
+        zsRrdKB31kZqF5ickeLxCaO6R12ZoedNRt6dWJFosgj8S6sWlcVOMPduDjPwLMVOYIumIw/qoSbB
+        FGxRu2KnxpWvgyqSu9bZE2mBbSWRDLtgiKb31pl7whvpJU7is4+scfLmnVc1EiFvLGsEO3StzGk6
+        8ef19L1yjebR6+ur1RE1vu4FUS+IekH0EYKoMQybduhhC3Px4P9ghfDBa7Qq7FD6FK5hMl4iVnmu
+        Fi1zmoHXvDh0U0R1rKMfQgAmOYSIvGYIgR21ECLQnBACsQkhxKTYIIRhUUGIR/dA+BQ6SSAE4DBA
+        Go6ofzQaxf3oiRHFD8JxWB+EoyqfZmbU9ZEQjUP24OQYTI+Jcy4iauwog+PR+htd8GgJMtkdRGVV
+        O1q/oXqd5s4zzW9DUHejgyCcOgdhKS7HOL2EZZQQi8Xi4MPPqXAQ9/38DdoIXd4gGIu5wZ3niraZ
+        3BXVOTD5TFiZC0U+05E/e5j4ATSbFRU85mLTsLASYMD+3AXeotUctTrJds7GaN9qXpoR1cLW1DEX
+        VM2FYp7f3urTsCpSx9WnIeINTXPd0swni8XCnwKmWoA6jFP4lfs5smoa9GUvaXpJ00uaj5A0aBDq
+        iiYaJE/weoc43A1+qsYxzEOD8Zx+Kd6+JZbTH8CKSzv5CggxygtlU66q3/pVXPgq0c3XyEhHW6PC
+        mVyN4vGaGoV19DQqnmZpFIbN0SgixdAoCIufUTS6nalPm5ObUeEcZqYBI3qZBotiZZpJEZ2MgnEY
+        GQWj+hicFdXGKBaHi6kTYzAxOszZw6BdZLAwjf5FdzCN5JgMjGKy+pdGT6HaF7zbTO5FId3Ni0Jw
+        ehcFpVgX7ZQSnIsisRiX+qBz+hZFfT/bojZBdy0KxWJa6u7ylmcRL+zyRj5MpoKilvtgeqk8Brcp
+        al+anqXGeAFUyPjtJlPJFNtZFq11K8eib+H6mj8youlX1Puzq0eN2ziBBuX7vvzpAipIzAlU6O1Y
+        6FVabxfHyPcQ/3+88gv28FppzGw6uZv7czhAlXRZhevPK1jV+nYfpmJ16xxev2xb39rerlcxvYrp
+        VcxHqBj7eDStzB+q8T34s3wtmKt4sW+x44I/FoijjrGRmMyMDc0raWxbcPQ1NhRN3diIbBbHBqcI
+        HRuPxe3YwHTNY6O6LQdkI3HIn0tcoge6hKUooUtM6tJANi6HKLJxqc7IxmSYvGXDcpgkG5djpaA3
+        uM5+ycbUxZDTekE2MM+SQTYy46pBNjyri7JtgGPtIDuXa8qXje4uq2w0Tm9l41MUlo1Hngpmg7KI
+        LRuYdUEh2wbeT3fZtkY3XzYqiwSzgd9cXMiDeWD3oqYIFrX2p8H8zlZ3hNuANrOsjV1j4HtYf6ho
+        Iq7d5T87w1+2l9xbsm2nxi4HtrJkl8NblCRZgk13Bntb+55P2S3cI5Q/8ybLhXV+2VWB9tfwJfz7
+        Oo2PudgiOLPyMqBedy8+OqbJp2idZ/Lf/cVn9dWnKgYQH77Gn+NmZChm0gaVkiufO6t31kFmHYuX
+        IOJy8VILj7ZcTmfT2VJptGgfrrNb+6vh6u96Xdbrsl6XfYQuq8dgQ5EdTrudrEOqLiytC5HQkO9W
+        h1QFOnovGc3kuiSO129JqqPTkuE0jyUpbO5KAim+SjJYHJWE0b2UOmFO1UcymsM/YRbROWEUxTM1
+        UiJWHkkWh0+SLKpDQjlRy44kisMVqbQYio40lrMTqvePoeQI9ytdLHVf1genxlRwJJGsjgd3EWq5
+        EdpnpmojSXT3N5LA6Wwkk+JpmieTUGkkQSw+Rh1vzjojCX0/7yK3QHctksTiV1Q/ebPGaFqsnXMn
+        5nLNp8HMumAzOJXZaLIQ6+vMYMqXrcbI1uSqU6kybOdRmo1buRONf73AqApoOJLysaAsJ5rO3WTI
+        n4QRGPwtzo6aDCnnOzi4EBT4W1IhPuiipTet3yt2TKNReTuzVhI1vu6NSG9EeiPyEUakMQy1t4gN
+        sl38vM13XwbxHoTtS7QZ1M0H4qm8mNMFF3vXYqLmNaKbP6ljHRUKAjBZFETkFSkI7OhSEIGmUxCI
+        zaggJkWqIAyLV0E8ulrBp9DJriAAh2DRcETHotEomkVPjGhaEI5DtiAc1bc0M6MqF0TjsC44OQbx
+        YuKc3UtjRxn0i9bf6AZGS5BJwiAqq4fR+g1VxTR3nsnGIKi7kEEQTieDsBQtY5xegplBLBY5gw8/
+        p59B3PdTNGgjdEuDYCyiBneeN13NbAQvdZ9OxII5Hrwbfmmrf0Ft4N3wc8u6O56tyVVXUyfZTtcY
+        7VsZGyOqRZFLHWOtbfkUZ1uR8va0EqUtY3S0VZnL8m4JdR4O08Teocrlt2p2/IU3uffrKhfo+nBk
+        R8+RqBaCN8bvHqtZZJvwJd6MG1/3Zqc3O73Z+Qiz0xiGTbPz8y6G33kDGMCFwBHTaKEUsAyAxXmq
+        OkCndXma14ZuRqeOdTQ6CMBkdBCR1+ggsKPRQQSa0UEgNqODmBSjgzAsRgfx6EYHn0Ino4MAHEZH
+        wxGNjkajGB09MaLRQTgOo4NwVKPTzIxqdBCNw+jg5BiMjolzNjqNHWUwOlp/oxsdLUEmo4OorEZH
+        6zdUo9PceSajg6DuRgdBOI0OwlKMjnF6CUYHsViMDj78nEYHcd/P6KCN0I0OgsGfUZhF8HbWePMN
+        nmzRjKRqgpBab+YYY6+QRsckG+sPv+O3ZzRBWc0SimseQOfAIj+edYUf3GYeeJYXYIHRqTGyyVWj
+        U+90O6NjtG9ldIyoFkanjrEanfLr+hGlWupnBm8Dd1A4YjFSrSrnu1vpZ7GEdX7u6oV+9rCy8ijO
+        RyuxxM+F16XrTXqH0zuc3uF8hMMxRivbtCWD3HEFn2a8o6/RIEzORqPyehsN7uhuNArN32gwNoej
+        cSkeR0OxuByNSfc5+ql1cjoahMPrWJBEt2MhUvyOBUdde0dDcngeDUl1PWaGVN+jETmcj54kg/ex
+        I53dj7HTDP7H0h/pDsiSKJMH0sisLsjIGl6aeciz8fmHY5hvxVMuHBnhdNo/4RpIrvVzNLC7F9JA
+        nG5IQ1P8kPW0ExyRxmPxRPop4XRFGvv9fJG2Iboz0oAs3kjvWG9WA/nw7qyRPxer4cxgJZvi9Vmn
+        4ybMo81jmA+DoT8RYghmZsErtmC5HHgLV7FijrY6NEwA82EO2IOoFoKXeRUTwK66o2ai7fyRNaaV
+        Q7JGtvBIzbiGS8KzurzZAl4kzqOOvpsJXf/+L0EsVPL/1gAA
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      etag: [W/"90d00bae53da26a9c4edc00727cc95fb"]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: [Accept]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.github.com:443/users/team/repos?type=owner&sort=updated&per_page=100&client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6VY0W6jOBT9F143iUPSzrRIq9k/mHno065WkQMOeAo2sk26Leq/77ENAVLRpI5U
+        pcS55/j4+t7ra/5pI55FSbyJHx+28SIStGJREv0qJBP8v+WTotkqWkSHpix33W9PjFbk3EC+CKai
+        pI1KmXMBBmsFoCW/v/seP24WET1SQ9WuUSV+L4ypdUKIH9TxKuemaPaNZiqVwjBhVqmsSEM8+sfx
+        zy3octWRWN4IA2dkNe94PBhkmnRKClOVZ3P7KZ1pZ3SQZSlfgDpXOUdMTgjrJYfmIv8iGoiWSFMw
+        OAeS3+1CuTbXi3DWLbH/djyzeA1PK5ZdLaSzhwy7ke8tUayWjqjZ61Tx2nAprhc0QYFFqpwK/ka/
+        xgKUBthKuX5qZw0UOyKGrod585bUih9p+mqXrljK+BFO/CLVGQ5M5rW2WfVz5AXrWm7YjmaVzZcD
+        LTV7X0RuegNjN7BAmlyK2g+pmLHThkWJQOLawFTPJ8pPU8Z5z2XDB15LcsGfc2hkCbBY8jN7DaWw
+        0Jbgs4vwFMlG91JRIy+l66ysCUdLxl9tABi4IVSuw4KjkDLYaw4LDq51w66KwtmVOgpN+igXTbX3
+        heaa2J5l9WAopFrzXDAW6q0TviV9BdwrKtIimLGHt8Q/uf2keahACwXDvpT7UAqcNsThW6IL6ou8
+        2d2gyRJa+IRPscMtAi38xGdU+I46cRZ/YsMRY7C5oep6OGk775VU5A3NgwlPeFuKcVzm9O3iwT+b
+        CQMB2GwDo/i+uakyDRRWnz+FkbPB7hsYBj53qn/eI8yveNQYuDVXFb903s6SdehJJN/GaOPvnNV+
+        v9wUfCrSwlsylE9fmjviQE92tblXN6bvWuHQTe/hpP2jpqawNQez1FSxQKkdmrR7inZltVq1BaOu
+        4ayYCk9FDwYLVWmBlitQXdvD0W5U1Lgu9mDFZehqS0mzUD+e8ODyuxWo0IPHO1yjQQuV5bBjsoqX
+        TBspgmviQDCmFdLwA0+v6d5nk2fC0f7QXKRsQdGcIhoNTzniE9cgu1no6liwSzwY4nGP9T18yRCq
+        oR5WzMNb4q9VGatL+XpLERkx2GxUDN1+tqMG14PNOo6Xa/zdPcXfkvVDst38DZumziY235br7TJ+
+        eIq3yd06uf9ubepGFzM0j0nsTFAQu6DFEy7eZ5ffabtvb9HAaF0MmL8GRPLxgtAh0hLRd5YcV810
+        PD+HPkVBWyErVuP49+8BNH/DU7y+n5zlqWwEPLtZRC/UoJnE6TkM9ed/f0kqqN75/IwSoxp7+cJI
+        reRvlho9HhvKwcjwhT/zCdC2Jv2Avzt1c+M1S8WVkt2rEH9FkzUT3fS9Rtj5e1OCp9HvWOewILe6
+        jB1oU5qdb3XhkbxYWt/o6P3f/wEyiHka4hEAAA==
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      cache-control: ['public, max-age=60, s-maxage=60']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      etag: [W/"a5753eeedfe37677d79aaae50f4dd447"]
+      status: [200 OK]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+      transfer-encoding: [chunked]
+      vary: [Accept]
+    status: {code: 200, message: OK}
 version: 1

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -202,6 +202,10 @@ title = _username
     % include "templates/members-listing.html"
     % endif
     % include "templates/connected-accounts.html"
+
+    <h3 class="banderole default" id="repos">{{ _("Repositories") }}</h3>
+    % include "templates/import-repos.html"
+
     % if participant.kind != 'group'
     % include "templates/team-listing.html"
     % include "templates/community-listing.html"

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -21,6 +21,8 @@ show_income = not participant.hide_receiving and participant.accepts_tips
 [-----------------------------------------------------------------------------]
 % extends "templates/profile.html"
 
+% from "templates/repos.html" import show_repo with context
+
 % block profile_btn
 % if user and user.controls(participant)
     <a href="{{ participant.path('edit') }}" class="btn btn-primary btn-lg pull-right">{{ _("Edit") }}</a>
@@ -53,6 +55,15 @@ show_income = not participant.hide_receiving and participant.accepts_tips
     % include "templates/members-listing.html"
     % endif
     % include "templates/connected-accounts.html"
+
+    % set repos = participant.get_repos_for_profile()
+    % if repos
+    <h3 class="banderole default">{{ _("Repositories") }}</h3>
+    % for repo in repos
+        {{ show_repo(repo) }}
+    % endfor
+    % endif
+
     % if participant.kind != 'group'
     % include "templates/team-listing.html"
     % include "templates/community-listing.html"

--- a/www/%username/invoices/new.spt
+++ b/www/%username/invoices/new.spt
@@ -1,7 +1,5 @@
 # coding: utf8
 
-import json
-
 from liberapay.constants import INVOICE_DOC_MAX_SIZE, INVOICE_DOCS_EXTS
 from liberapay.exceptions import AuthRequired
 from liberapay.utils import get_participant, to_javascript
@@ -79,7 +77,7 @@ if request.method == 'POST':
                  VALUES (%s, %s, %s, %s, %s, %s, '{}'::jsonb, 'pre')
               RETURNING id
         """, (user.id, addressee.id, invoice_nature, amount, description, details))
-    raise response.success(200, json.dumps({'invoice_id': invoice_id}))
+    raise response.json({'invoice_id': invoice_id})
 
 title = _("Invoice {someone}", someone=addressee.username)
 

--- a/www/%username/repos/%platform.spt
+++ b/www/%username/repos/%platform.spt
@@ -1,0 +1,128 @@
+# coding: utf8
+
+from datetime import timedelta
+
+from liberapay.models.repository import upsert_repos
+from liberapay.utils import get_participant, utcnow
+
+LIMIT = 20
+THREE_DAYS = timedelta(days=3)
+
+[---]
+
+request.allow('GET', 'POST')
+
+participant = get_participant(state, restrict=True, allow_member=True)
+
+if request.method == 'POST':
+    for k, v in request.body.items():
+        if k.startswith('show_on_profile:'):
+            try:
+                repo_id = int(k.split(':', 1)[-1])
+            except ValueError:
+                raise response.error(400, "bad key '%s'" % k)
+            v = v[-1] if isinstance(v, list) else v
+            show = v == 'on'
+            website.db.run("""
+                UPDATE repositories
+                   SET show_on_profile = %s
+                 WHERE participant = %s
+                   AND id = %s
+                   AND show_on_profile IS NOT %s
+            """, (show, participant.id, repo_id, show))
+    raise response.json({"msg": _("Your profile has been updated.")})
+
+platform_name = request.path['platform']
+if platform_name:
+    platform = getattr(website.platforms, platform_name, None)
+    if not platform:
+        raise response.error(404, "unknown platform")
+    if not hasattr(platform, 'api_repos_path'):
+        raise response.error(400, "repos are not implemented for platform '%s'" % platform_name)
+
+    account = participant.get_account_elsewhere(platform.name)
+    if account:
+        event_type = 'fetch_repos:%s' % account.id
+        last_fetch = participant.get_last_event_of_type(event_type)
+        try:
+            offset = max(int(request.qs.get('offset', 0)), 0)
+        except (TypeError, ValueError):
+            offset = 0
+        if last_fetch and last_fetch.ts > utcnow() - THREE_DAYS:
+            repos = participant.get_repos_on_platform(
+                platform.name, limit=LIMIT, offset=offset
+            )
+        else:
+            repos = []
+            sess = account.get_auth_session()
+            with website.db.get_cursor() as cursor:
+                next_page = None
+                for i in range(3):
+                    r = platform.get_repos(account, page_url=next_page, sess=sess)
+                    repos += upsert_repos(cursor, r[0], participant)
+                    next_page = r[2].get('next')
+                    if not next_page:
+                        break
+                payload = dict(partial_list=bool(next_page))
+                last_fetch = participant.add_event(cursor, event_type, payload)
+            repos = sorted(repos, key=lambda repo: (not repo.is_fork, repo.last_update), reverse=True)[:LIMIT]
+        total_count = website.db.one("""
+            SELECT count(*)
+              FROM repositories r
+             WHERE r.participant = %s
+               AND r.platform = %s
+        """, (participant.id, platform.name))
+
+title = _("{username}'s Repositories", username=participant.username)
+
+[---] text/html
+% extends "templates/base.html"
+
+% from "templates/repos.html" import show_repo with context
+% from "templates/auth.html" import auth_button with context
+
+% block content
+% if not platform_name
+
+    % include "templates/import-repos.html"
+
+% else
+
+    <h2>{{ _(platform.display_name) }}</h2>
+    % if not account
+        <p>{{ _(
+            "You don't have any {platform} account connected to your profile.",
+            platform=platform.display_name
+        ) }}</p>
+        % call auth_button(platform.name, 'connect')
+            {{ _("Connect {0} account", platform.display_name) }}
+        % endcall
+    % else
+        <noscript class="alert alert-danger">{{ _("JavaScript is required") }}</noscript>
+        <p>{{ _(
+            "A list of {n} repositories has been imported from your {platform} account, "
+            "{time} ago."
+            , n=total_count, platform=platform.display_name, time=to_age(last_fetch.ts)
+        ) }}</p>
+        <hr>
+        <form action="javascript:" class="js-submit" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+            % for repo in repos
+                {{ show_repo(repo, edit=True) }}
+                <hr>
+            % else
+                <p>{{ _("No repositories found.") }}</p>
+            % endfor
+            % if repos
+                <br>
+                % set next_offset = offset + LIMIT
+                % if next_offset < total_count
+                <a class="btn btn-default btn-lg pull-right" href="?offset={{ next_offset }}">{{ _("Next Page →") }}</a>
+                % endif
+                <button class="btn btn-primary btn-lg">{{ _("Save") }}</button>
+            % endif
+        </form>
+    % endif
+
+% endif
+% endblock

--- a/www/%username/repos/%platform.spt
+++ b/www/%username/repos/%platform.spt
@@ -59,7 +59,7 @@ if platform_name:
                 next_page = None
                 for i in range(3):
                     r = platform.get_repos(account, page_url=next_page, sess=sess)
-                    repos += upsert_repos(cursor, r[0], participant)
+                    repos += upsert_repos(cursor, r[0], participant, utcnow())
                     next_page = r[2].get('next')
                     if not next_page:
                         break

--- a/www/%username/wallet/payin/bankwire/%back_to.spt
+++ b/www/%username/wallet/payin/bankwire/%back_to.spt
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from decimal import Decimal as D, InvalidOperation
 
 from mangopay.resources import BankWirePayIn
-from pando import json
 
 from liberapay.billing.exchanges import payin_bank_wire, upcharge_bank_wire
 from liberapay.constants import EVENTS, KYC_PAYIN_YEARLY_THRESHOLD, PAYIN_BANK_WIRE_MIN
@@ -46,7 +45,7 @@ if request.method == 'POST' and request.body.get('action') == 'email':
     if not sent:
         raise response.error(500, _("An unknown error occurred."))
     if request.headers.get(b'X-Requested-With') == b'XMLHttpRequest':
-        raise response.success(200, json.dumps({'msg': _("The email has been sent.")}))
+        raise response.json({'msg': _("The email has been sent.")})
     else:
         response.redirect(request.line.uri)
 

--- a/www/admin/users.spt
+++ b/www/admin/users.spt
@@ -1,7 +1,5 @@
 # coding: utf8
 
-import json
-
 from liberapay.exceptions import LoginRequired
 from liberapay.models.participant import Participant
 
@@ -32,7 +30,7 @@ if request.method == 'POST':
             continue
         p.update_bit(attr, 2, value == 'on')
         updated += 1
-    raise response.success(200, json.dumps({'msg': "Done, %i bits have been updated." % updated}))
+    raise response.json({'msg': "Done, %i bits have been updated." % updated})
 
 participants = website.db.all("""
     SELECT p

--- a/www/search.spt
+++ b/www/search.spt
@@ -66,6 +66,7 @@ if query:
               FROM communities c
               JOIN participants p ON p.id = c.participant
              WHERE name %% %(q)s
+               AND p.hide_from_search = 0
           ORDER BY rank DESC, name
              LIMIT 10
         """, locals())

--- a/www/search.spt
+++ b/www/search.spt
@@ -70,6 +70,25 @@ if query:
              LIMIT 10
         """, locals())
 
+    if scope in (None, 'repositories'):
+        results['repositories'] = website.db.all("""
+            SELECT r.id, r.platform, r.remote_id, r.name, r.slug
+                 , r.description, r.last_update, r.is_fork, r.stars_count
+                 , r.info_fetched_at, r.show_on_profile
+                 , similarity(r.name, %(q)s) AS rank
+                 , json_build_object(
+                       'id', p.id,
+                       'username', p.username,
+                       'avatar_url', p.avatar_url
+                   ) as owner
+              FROM repositories r
+              JOIN participants p ON p.id = r.participant
+             WHERE r.name %% %(q)s
+               AND p.hide_from_search = 0
+          ORDER BY similarity(r.name, %(q)s) DESC, r.is_fork ASC, r.last_update DESC, r.name
+             LIMIT 10
+        """, locals(), back_as=dict)
+
 [---] text/html
 % extends "templates/base.html"
 % from 'templates/avatar-url.html' import avatar_url, avatar_img with context
@@ -78,9 +97,10 @@ if query:
 
     % set usernames = results.get('usernames')
     % set communities = results.get('communities')
+    % set repositories = results.get('repositories')
     % set statements = results.get('statements')
 
-    % if query and not (usernames or communities or statements)
+    % if query and not (usernames or communities or repositories or statements)
         <p class="alert alert-warning">{{
             _("Sorry, we didn't find anything matching your query."
         ) }}</p>
@@ -126,6 +146,29 @@ if query:
     </div>
     % endif
     </div>
+
+    % if repositories
+    % set fork = ' ' + _("(fork)")
+    <div>
+        <h3>{{ ngettext("Found a matching repository",
+                        "Found matching repositories",
+                        len(statements)) }}</h3>
+        % for repo in repositories
+            % set owner = repo.owner
+            <div class="paragraph">
+                <a href="/{{ owner.username }}/" class="avatar-inline">
+                    {{ avatar_img(owner, size=28) }}
+                </a>
+                {{ _(
+                    "{username} has a repository named {repo_name} in their {platform} account",
+                    username=('<a href="/{0}/">{0}</a>'|safe).format(owner.username),
+                    repo_name='<em>%s</em>'|safe % (repo.name + (fork if repo.is_fork else '')),
+                    platform=website.platforms[repo.platform].display_name,
+                ) }}
+            </div>
+        % endfor
+    </div>
+    % endif
 
     % if statements
     <div>


### PR DESCRIPTION
This branch implements importing the list of a user's repositories from their GitHub or GitLab(.com) account. That allows the user to select repositories to show on their Liberapay profile. Repositories also show up in search results (even the ones that aren't shown on the profile page). The data about repositories is re-fetched regularly from the platforms, so stuff like the number of stars and the time of the last change don't become completely obsolete.