### PR TITLE
Improve "statements"

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -347,16 +347,28 @@ class Participant(Model, MixinTeam):
 
     def get_statement(self, langs, type='profile'):
         """Get the participant's statement in the language that best matches
-        the list provided.
+        the list provided, or the participant's "primary" statement if there
+        are no matches. Returns a tuple `(content, lang)`.
+
+        If langs isn't a list but a string, then it's assumed to be a language
+        code and the corresponding statement content will be returned, or None.
         """
         p_id = self.id
+        if not isinstance(langs, list):
+            return self.db.one("""
+                SELECT content
+                  FROM statements
+                 WHERE participant = %(p_id)s
+                   AND type = %(type)s
+                   AND lang = %(langs)s
+            """, locals())
         return self.db.one("""
             SELECT content, lang
               FROM statements
-              JOIN enumerate(%(langs)s) langs ON langs.value = statements.lang
+         LEFT JOIN enumerate(%(langs)s::text[]) langs ON langs.value = statements.lang
              WHERE participant = %(p_id)s
                AND type = %(type)s
-          ORDER BY langs.rank
+          ORDER BY langs.rank NULLS LAST, statements.id
              LIMIT 1
         """, locals(), default=(None, None))
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -377,6 +377,7 @@ class Participant(Model, MixinTeam):
         r = self.db.one("""
             UPDATE statements
                SET content=%s
+                 , mtime=now()
              WHERE participant=%s
                AND type=%s
                AND lang=%s
@@ -387,8 +388,8 @@ class Participant(Model, MixinTeam):
             try:
                 self.db.run("""
                     INSERT INTO statements
-                                (lang, content, participant, search_conf, type)
-                         VALUES (%s, %s, %s, %s, %s)
+                                (lang, content, participant, search_conf, type, ctime, mtime)
+                         VALUES (%s, %s, %s, %s, %s, now(), now())
                 """, (lang, statement, self.id, search_conf, type))
             except IntegrityError:
                 return self.upsert_statement(lang, statement)

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+ALTER TABLE statements
+    ADD COLUMN id bigserial NOT NULL,
+    ADD COLUMN ctime timestamptz NOT NULL DEFAULT '1970-01-01T00:00:00+00'::timestamptz,
+    ADD COLUMN mtime timestamptz NOT NULL DEFAULT '1970-01-01T00:00:00+00'::timestamptz;

--- a/style/base/banderoles.scss
+++ b/style/base/banderoles.scss
@@ -20,7 +20,7 @@
         color: $state-success-text;
     }
 
-    .dropdown-toggle {
+    .btn-sm {
         border: none;
         background: transparent;
         color: inherit;

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -21,7 +21,7 @@ if request.method == 'POST':
 else:
     lang = request.qs.get('lang')
     if lang:
-        statement = participant.get_statement([lang])[0]
+        statement = participant.get_statement(lang)
     else:
         statement, lang = participant.get_statement(request.accept_langs)
 

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -10,7 +10,7 @@ title = participant.username
 
 lang = request.qs.get('lang')
 if lang:
-    statement = participant.get_statement([lang])[0]
+    statement = participant.get_statement(lang)
 else:
     statement, lang = participant.get_statement(request.accept_langs)
 
@@ -45,9 +45,11 @@ show_income = not participant.hide_receiving and participant.accepts_tips
             % endfor
             </ul>
         </span>
+        % elif lang != locale.language
+        <span class="pull-right btn-sm">{{ locale.languages_2[lang] }}</span>
         % endif
         </h3>
-        <section class="profile-statement">
+        <section class="profile-statement" lang="{{ lang }}">
             {{ markdown.render(statement) }}
         </section>
     % endif

--- a/www/explore/communities.spt
+++ b/www/explore/communities.spt
@@ -8,10 +8,10 @@ communities_top = query_cache.all("""
     SELECT c.*, replace(name, '_', ' ') AS pretty_name
          , ( SELECT content
                FROM statements
-               JOIN enumerate(string_to_array(%s, ' ')) langs ON langs.value = statements.lang
+          LEFT JOIN enumerate(string_to_array(%s, ' ')) langs ON langs.value = statements.lang
               WHERE participant = c.participant
                 AND type = 'subtitle'
-           ORDER BY langs.rank
+           ORDER BY langs.rank NULLS LAST, statements.id
               LIMIT 1
            ) AS subtitle
       FROM communities c

--- a/www/for/%name/edit.spt
+++ b/www/for/%name/edit.spt
@@ -19,8 +19,8 @@ if request.method == 'POST':
 else:
     lang = request.qs.get('lang')
     if lang:
-        subtitle = c.participant.get_statement([lang], 'subtitle')[0]
-        sidebar = c.participant.get_statement([lang], 'sidebar')[0]
+        subtitle = c.participant.get_statement(lang, 'subtitle')
+        sidebar = c.participant.get_statement(lang, 'sidebar')
     else:
         subtitle, lang = c.participant.get_statement(request.accept_langs, 'subtitle')
         sidebar, lang = c.participant.get_statement(request.accept_langs, 'sidebar')

--- a/www/for/%name/index.html.spt
+++ b/www/for/%name/index.html.spt
@@ -104,9 +104,10 @@ title = pretty_name = community.pretty_name
         <p>{{ ngettext("{n} subscriber", "{n} subscribers", community.nsubscribers) }}</p>
     </form>
 
-    <section class="community-sidebar">{{ markdown.render(
-        community.participant.get_statement(request.accept_langs, 'sidebar')[0] or ''
-    ) }}</section>
+    % set sidebar = community.participant.get_statement(request.accept_langs, 'sidebar')
+    <section class="community-sidebar" lang="{{ sidebar.lang or '' }}">{{
+        markdown.render(sidebar.content or '')
+    }}</section>
 
 </div>
 </div>


### PR DESCRIPTION
This PR improves how we handle profile statements (and community sidebars along with them):

- on the technical side it adds columns that should have been there from the start: `id`, `ctime`, and `mtime` (that last one will help in fixing #444)
- on the UI side it allows users to see statements even if none of the available languages matches the request's `Accept-Language` header