### PR TITLE
Allow translating "Payday"

### DIFF
--- a/www/about/money.spt
+++ b/www/about/money.spt
@@ -38,7 +38,7 @@ title = _("Money")
     "wallet per user, and only one currency (the euro) in that wallet."
 ) }}</p>
 
-<h3>Payday</h3>
+<h3>{{ _("Payday") }}</h3>
 
 <p>{{ _(
     "Payday is when donations are actually executed. It's a program ({0}this "


### PR DESCRIPTION
@pskosinski asked about this in IRC yesterday. I think translations should probably keep the name "payday" as-is, but adding a literal translation next to it could be useful.