### PR TITLE
Use proper icon for language switcher in navbar

### DIFF
--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -4,7 +4,7 @@
     <button class="dropdown-toggle navbar-btn" type="button"
             data-toggle="dropdown"
             title="{{ _('Switch to another language') }}">
-        <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span>
+        <span class="fa fa-language" aria-hidden="true"></span>
         <span class="text">{{ locale.language.upper() }}</span>
         <span class="caret"></span>
     </button>


### PR DESCRIPTION
https://github.com/liberapay/liberapay.com/issues/608#issuecomment-323548507 made me realize that there is a proper icon for language switchers, and that it's in Font Awesome.