### PR TITLE
Fix suggested payin amounts

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -158,7 +158,8 @@ PARTICIPANT_KINDS = {
 PASSWORD_MIN_SIZE = 8
 PASSWORD_MAX_SIZE = 150
 
-PAYIN_BANK_WIRE_MIN = Decimal('2.00')
+PAYIN_BANK_WIRE_MIN = Decimal('2.00')  # fee ≈ 0.99%
+PAYIN_BANK_WIRE_TARGET = Decimal('5.00')  # fee ≈ 0.6%
 PAYIN_CARD_MIN = Decimal("15.00")  # fee ≈ 3.5%
 PAYIN_CARD_TARGET = Decimal("92.00")  # fee ≈ 2.33%
 

--- a/www/%username/wallet/payin/bankwire/%back_to.spt
+++ b/www/%username/wallet/payin/bankwire/%back_to.spt
@@ -58,7 +58,10 @@ weekly = donations - participant.receiving
 if weekly > 0:
     funded = participant.balance // weekly
     min_weeks = (constants.PAYIN_BANK_WIRE_MIN / weekly).to_integral_value(ROUND_UP)
-    max_weeks = min(52, constants.KYC_PAYIN_YEARLY_THRESHOLD // weekly)
+    max_weeks = min(
+        max(constants.PAYIN_BANK_WIRE_TARGET // weekly, 52),
+        constants.KYC_PAYIN_YEARLY_THRESHOLD // weekly
+    )
     weeks_list = sorted(set((min_weeks, 4, 13, 26, 39, max_weeks)))
     weeks_list = [w for w in weeks_list if w >= min_weeks and w <= max_weeks] or [min_weeks]
 

--- a/www/%username/wallet/payin/bankwire/%back_to.spt
+++ b/www/%username/wallet/payin/bankwire/%back_to.spt
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from decimal import Decimal as D, InvalidOperation
+from decimal import Decimal as D, InvalidOperation, ROUND_UP
 
 from mangopay.resources import BankWirePayIn
 
@@ -57,7 +57,7 @@ donations = participant.get_giving_for_profile()[1]
 weekly = donations - participant.receiving
 if weekly > 0:
     funded = participant.balance // weekly
-    min_weeks = max(constants.PAYIN_BANK_WIRE_MIN // weekly, 1)
+    min_weeks = (constants.PAYIN_BANK_WIRE_MIN / weekly).to_integral_value(ROUND_UP)
     max_weeks = min(52, constants.KYC_PAYIN_YEARLY_THRESHOLD // weekly)
     weeks_list = sorted(set((min_weeks, 4, 13, 26, 39, max_weeks)))
     weeks_list = [w for w in weeks_list if w >= min_weeks and w <= max_weeks] or [min_weeks]

--- a/www/%username/wallet/payin/card/%back_to.spt
+++ b/www/%username/wallet/payin/card/%back_to.spt
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from decimal import Decimal as D, InvalidOperation
+from decimal import Decimal as D, InvalidOperation, ROUND_UP
 
 from mangopay.resources import Card, PayIn
 
@@ -50,7 +50,7 @@ donations = participant.get_giving_for_profile()[1]
 weekly = donations - participant.receiving
 if weekly > 0:
     funded = participant.balance // weekly
-    min_weeks = max(constants.PAYIN_CARD_MIN // weekly, 1)
+    min_weeks = (constants.PAYIN_CARD_MIN / weekly).to_integral_value(ROUND_UP)
     max_weeks = min(
         max(constants.PAYIN_CARD_TARGET // weekly, 52),
         PAYIN_CARD_MAX // weekly


### PR DESCRIPTION
The minimum amount was being rounded down instead of up, which in some cases could lead it to be below the enforced minimum, in which case the user would get a 400 error.