### PR TITLE
Block blind requests at the Apache level

### DIFF
--- a/.ebextensions/01_apache.config
+++ b/.ebextensions/01_apache.config
@@ -1,4 +1,13 @@
 files:
+  "/etc/httpd/conf.d/000_default_host.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+        <VirtualHost *:80>
+        SetEnvIf Host "^([0-9]{1,3}\.){3}[0-9]{1,3}$" dontlog
+        Redirect 404 /
+        </VirtualHost>
   "/etc/httpd/conf.d/zzz_liberapay.conf":
     mode: "000644"
     owner: root
@@ -10,3 +19,5 @@ files:
 commands:
   01_customlog:
     command: "sed -e 's|^\\s*CustomLog .logs/access_log. combined$|\\0 env=!dontlog|' -i /etc/httpd/conf/httpd.conf"
+  02_domains:
+    command: "sed -e 's|^\\s*<VirtualHost .*|\\0\\nServerName liberapay.com\\nServerAlias *.liberapay.com|' -i /etc/httpd/conf.d/wsgi.conf"


### PR DESCRIPTION
There are bots that scan IP addresses looking for vulnerable or unprotected phpMyAdmin instances or other similar software that could give them access to a database. We're getting a lot of those blind requests and they're annoying me so I've configured Apache to block/ignore them.