### PR TITLE
Plusieurs adresses courriel ne sont pas obligatoires

### DIFF
--- a/i18n/core/cs.po
+++ b/i18n/core/cs.po
@@ -1355,7 +1355,7 @@ msgstr "Soukromí"
 msgid "Email settings"
 msgstr "Nastavení emailu"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Emailová adresa (soukromé)"
 
 msgid "Primary"

--- a/i18n/core/da.po
+++ b/i18n/core/da.po
@@ -1352,7 +1352,7 @@ msgstr "Privatlivsindstillinger"
 msgid "Email settings"
 msgstr "E-mail indstillinger"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "E-mail Adresser (Privat)"
 
 msgid "Primary"

--- a/i18n/core/de.po
+++ b/i18n/core/de.po
@@ -1352,7 +1352,7 @@ msgstr "Datenschutz"
 msgid "Email settings"
 msgstr "E-Mail Einstellungen"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "E-Mail-Adressen (Privat)"
 
 msgid "Primary"

--- a/i18n/core/eo.po
+++ b/i18n/core/eo.po
@@ -1376,7 +1376,7 @@ msgstr "Privateco"
 msgid "Email settings"
 msgstr "Retpoŝto agordojn"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Retpoŝtadreson (Privata)"
 
 msgid "Primary"

--- a/i18n/core/es.po
+++ b/i18n/core/es.po
@@ -1351,7 +1351,7 @@ msgstr "Privacidad"
 msgid "Email settings"
 msgstr "Ajustes del correo electrónico"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Correos electrónicos (privado)"
 
 msgid "Primary"

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -1351,7 +1351,7 @@ msgstr "Confidentialité"
 msgid "Email settings"
 msgstr "Paramètres de courriel"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Adresse(s) de courriel (Privé)"
 
 msgid "Primary"

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -1352,7 +1352,7 @@ msgid "Email settings"
 msgstr "Paramètres de courriel"
 
 msgid "Email Addresses (Private)"
-msgstr "Adresses de courriel (Privé)"
+msgstr "Adresse(s) de courriel (Privé)"
 
 msgid "Primary"
 msgstr "Principale"

--- a/i18n/core/hu.po
+++ b/i18n/core/hu.po
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/id.po
+++ b/i18n/core/id.po
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/it.po
+++ b/i18n/core/it.po
@@ -1359,7 +1359,7 @@ msgstr "Privacy"
 msgid "Email settings"
 msgstr "impostazioni e-mail"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Indirizzo Email (Privato)"
 
 msgid "Primary"

--- a/i18n/core/ja.po
+++ b/i18n/core/ja.po
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/nb.po
+++ b/i18n/core/nb.po
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/nl.po
+++ b/i18n/core/nl.po
@@ -1354,7 +1354,7 @@ msgstr "Privacy"
 msgid "Email settings"
 msgstr "Emailinstellingen"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Emailadressen (privé)"
 
 msgid "Primary"

--- a/i18n/core/pl.po
+++ b/i18n/core/pl.po
@@ -1356,7 +1356,7 @@ msgstr "Prywatność"
 msgid "Email settings"
 msgstr "Ustawienia poczty e-mail"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Adresy e-mail (prywatne)"
 
 msgid "Primary"

--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -1352,7 +1352,7 @@ msgstr "Privacidade"
 msgid "Email settings"
 msgstr "Configurações de e-mail"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Endereços de email (Privado)"
 
 msgid "Primary"

--- a/i18n/core/ru.po
+++ b/i18n/core/ru.po
@@ -1355,7 +1355,7 @@ msgstr "Приватность"
 msgid "Email settings"
 msgstr "Настройки email"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "Адреса электронной почты (Личные)"
 
 msgid "Primary"

--- a/i18n/core/sv.po
+++ b/i18n/core/sv.po
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/tr.po
+++ b/i18n/core/tr.po
@@ -1353,7 +1353,7 @@ msgstr "Gizlilik"
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "E-posta Adresi (Gizli)"
 
 msgid "Primary"

--- a/i18n/core/uk.po
+++ b/i18n/core/uk.po
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Email settings"
 msgstr ""
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr ""
 
 msgid "Primary"

--- a/i18n/core/zh.po
+++ b/i18n/core/zh.po
@@ -1347,7 +1347,7 @@ msgstr "隱私"
 msgid "Email settings"
 msgstr "電郵設定"
 
-msgid "Email Addresses (Private)"
+msgid "Email Address(es) (Private)"
 msgstr "電郵地址 (私人)"
 
 msgid "Primary"

--- a/www/%username/emails/index.spt
+++ b/www/%username/emails/index.spt
@@ -14,7 +14,7 @@ base_path = participant.path('emails/')
 
 % block content
 
-    <h3>{{ _("Email Addresses (Private)") }}</h3>
+    <h3>{{ _("Email Address(es) (Private)") }}</h3>
 
     <form action="{{ base_path }}modify.json" method="POST" class="js-submit">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />


### PR DESCRIPTION
Lorsque l'on a qu'une seule adresse, c'est étrange d'avoir cette phrase au pluriel.

En la lisant, je me suis dis pendant 2 secondes : "dois-je obligatoirement en avoir plusieurs ?" avant de me dire que ça devait être un glitch de traduction/formulation.
