### PR TITLE
Handle unexpected bankwire payins

### DIFF
--- a/liberapay/models/exchange_route.py
+++ b/liberapay/models/exchange_route.py
@@ -63,6 +63,19 @@ class ExchangeRoute(Model):
         r.__dict__['participant'] = participant
         return r
 
+    @classmethod
+    def upsert_bankwire_route(cls, participant):
+        r = cls.db.one("""
+            INSERT INTO exchange_routes AS r
+                        (participant, network, address, one_off, error, remote_user_id)
+                 VALUES (%s, 'mango-bw', 'x', false, '', %s)
+            ON CONFLICT (participant, network, address) DO UPDATE
+                    SET one_off = false  -- dummy update
+              RETURNING r
+        """, (participant.id, participant.mangopay_user_id))
+        r.__dict__['participant'] = participant
+        return r
+
     def invalidate(self, obj=None):
         if self.network == 'mango-cc':
             card = obj or Card.get(self.address)

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -464,6 +464,9 @@ class Participant(Model, MixinTeam):
         transfers = []
         distributed = D_ZERO
 
+        if not total:
+            raise self.NoOneToGiveFinalGiftTo
+
         for tip in tips:
             rate = tip.amount / total
             pro_rated = (self.balance * rate).quantize(D_CENT, ROUND_DOWN)

--- a/tests/py/test_callbacks.py
+++ b/tests/py/test_callbacks.py
@@ -261,13 +261,15 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
     def test_payin_bank_wire_callback_unexpected(self, Get):
         homer = self.homer
         cases = (
-            ('failed', '000001', 'FOO'),
-            ('succeeded', '000000', None),
+            ('failed', '000001', 'FOO', 0),
+            ('succeeded', '000000', None, 5),
+            ('succeeded', '000000', None, 2),
         )
-        for status, result_code, error in cases:
+        for status, result_code, error, fee in cases:
             status_up = status.upper()
+            homer.set_tip_to(self.janet, D('1.00'))
+            homer.close('downstream')
             assert homer.balance == 0
-            homer.close(None)
             assert homer.status == 'closed'
             qs = "EventType=PAYIN_NORMAL_"+status_up+"&RessourceId=123456790"
             payin = BankWirePayIn()
@@ -278,16 +280,21 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             payin.PaymentType = 'BANK_WIRE'
             payin.DebitedFunds = Money(242, 'EUR')
             payin.DeclaredDebitedFunds = payin.DebitedFunds
-            payin.DeclaredFees = Money(2, 'EUR')
-            payin.Fees = Money(2, 'EUR')
-            payin.CreditedFunds = Money(0, 'XXX') if error else Money(240, 'EUR')
+            payin.DeclaredFees = Money(fee, 'EUR')
+            payin.Fees = Money(fee, 'EUR')
+            payin.CreditedFunds = Money(0, 'XXX') if error else Money(242 - fee, 'EUR')
             payin.CreditedWalletId = homer.mangopay_wallet_id
             Get.return_value = payin
             r = self.callback(qs)
             assert r.code == 200, r.text
+            amount = D(242 - fee) / D(100)
+            e = self.db.one("SELECT * FROM exchanges ORDER BY timestamp DESC lIMIT 1")
+            assert e.status == status
+            assert e.amount == amount
+            assert e.fee == D(fee) / D(100)
             homer = homer.refetch()
             if status == 'succeeded':
-                assert homer.balance == D('2.40')
+                assert homer.balance == amount
                 assert homer.status == 'active'
             else:
                 assert homer.balance == 0

--- a/www/callbacks/mangopay.spt
+++ b/www/callbacks/mangopay.spt
@@ -10,7 +10,8 @@ from decimal import Decimal as D
 from mangopay.resources import BankWirePayOut, Dispute, Document, PayIn, Refund
 
 from liberapay.billing.transactions import (
-    record_exchange_result, record_payout_refund, repr_error, skim_bank_wire,
+    record_exchange_result, record_payout_refund, record_unexpected_payin,
+    repr_error, skim_bank_wire,
     lock_disputed_funds, recover_lost_funds,
 )
 from liberapay.models.participant import Participant
@@ -142,6 +143,8 @@ elif cls:
     if event == 'PAYOUT_REFUND':
         # Payout refunds are created by MangoPay and have no Tag
         e_id = record_payout_refund(website.db, payio)
+    elif event == 'PAYIN_NORMAL' and not e_id:
+        e_id = record_unexpected_payin(website.db, payio)
     e_status = website.db.one("SELECT status FROM exchanges WHERE id = %s", (e_id,))
     if e_status == status:
         raise response.success(200, "already done")
@@ -152,18 +155,19 @@ elif cls:
         else:
             expected = 0
         credited_amount = payio.CreditedFunds.Amount
-        if credited_amount != expected:
-            # The user didn't send the expected amount of money
+        if credited_amount != expected or not payio.Tag:
+            # Check the fee
             credited_amount = D(credited_amount) / D(100)
             paid_fees = D(payio.Fees.Amount) / D(100)
             debited_amount = D(payio.DebitedFunds.Amount) / D(100)
             standard_fee, new_vat = skim_bank_wire(debited_amount)[1:]
             if abs(paid_fees - standard_fee) > D('0.01'):
-                # MangoPay didn't properly adapt the fee to the received amount
                 try:
                     raise Exception('fee mismatch in bankwire payin')
                 except Exception as e:
                     website.tell_sentry(e, state, allow_reraise=False)
+        if credited_amount != expected:
+            # The user didn't send the expected amount of money
             note = (
                 'amount mismatch: expected %sc€ (fee %sc€)' %
                 (payio.DeclaredDebitedFunds.Amount, payio.DeclaredFees.Amount)


### PR DESCRIPTION
Usually bankwire payins are created on our side and have a tag that corresponds to the exchange ID in our database, but yesterday MangoPay created a payin on their side, thus without a tag. This branch modifies our code to record such unexpected payins.

Theoretically this enables recurring bank transfers (#649), but I asked MangoPay about that and their answer wasn't a clear yes so it's too early to celebrate.