### PR TITLE
Fix extraction and update of repository metadata

### DIFF
--- a/liberapay/elsewhere/_base.py
+++ b/liberapay/elsewhere/_base.py
@@ -308,7 +308,7 @@ class Platform(object):
         r.platform = self.name
         r.name = self.x_repo_name(r, info)
         r.slug = self.x_repo_slug(r, info)
-        r.remote_id = self.x_repo_id(r, info)
+        r.remote_id = str(self.x_repo_id(r, info))
         r.owner_id = self.x_repo_owner_id(r, info, None)
         r.description = self.x_repo_description(r, info, None)
         r.last_update = self.x_repo_last_update(r, info, None)

--- a/liberapay/elsewhere/github.py
+++ b/liberapay/elsewhere/github.py
@@ -49,7 +49,7 @@ class GitHub(PlatformOAuth2):
     x_repo_name = key('name')
     x_repo_slug = key('full_name')
     x_repo_description = key('description')
-    x_repo_last_update = key('updated_at')
+    x_repo_last_update = key('pushed_at')
     x_repo_is_fork = key('fork')
     x_repo_stars_count = key('stargazers_count')
     x_repo_owner_id = key('owner', clean=lambda d: d['id'])

--- a/liberapay/models/repository.py
+++ b/liberapay/models/repository.py
@@ -44,6 +44,12 @@ def upsert_repos(cursor, repos, participant, info_fetched_at):
         on_conflict_set = ','.join('{0}=excluded.{0}'.format(col) for col in cols)
         cols = ','.join(cols)
         placeholders = ('%s,'*len(vals))[:-1]
+        cursor.run("""
+            DELETE FROM repositories
+             WHERE platform = %s
+               AND slug = %s
+               AND remote_id <> %s
+        """, (repo.platform, repo.slug, repo.remote_id))
         r.append(cursor.one("""
             INSERT INTO repositories
                         ({0})


### PR DESCRIPTION
This branch:

- fixes [LIBERAPAYCOM-45](https://sentry.io/share/issue/3132343535362e333437323837353037/)
- changes the timestamp we use for GitHub repos, from the mysterious `updated_at` to the saner `pushed_at`