### PR TITLE
Record mangopay transaction IDs in exchanges table

### DIFF
--- a/liberapay/testing/__init__.py
+++ b/liberapay/testing/__init__.py
@@ -223,7 +223,7 @@ class Harness(unittest.TestCase):
                 route = ExchangeRoute.insert(participant, network, MangopayHarness.card_id)
                 assert route
         e_id = record_exchange(self.db, route, amount, fee, vat, participant, 'pre').id
-        record_exchange_result(self.db, e_id, status, error, participant)
+        record_exchange_result(self.db, e_id, -e_id, status, error, participant)
         return e_id
 
 

--- a/liberapay/utils/fake_data.py
+++ b/liberapay/utils/fake_data.py
@@ -166,7 +166,7 @@ def fake_exchange(db, participant, amount, fee, vat, timestamp):
         route=route.id,
         wallet_id=participant.mangopay_wallet_id,
     )
-    record_exchange_result(db, e.id, 'succeeded', '', participant)
+    record_exchange_result(db, e.id, -e.id, 'succeeded', '', participant)
     return e
 
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,7 @@
+ALTER TABLE exchanges ADD COLUMN remote_id text;
+
+SELECT 'after deployment';
+
+ALTER TABLE exchanges
+    ADD CONSTRAINT remote_id_null_chk CHECK ((status::text LIKE 'pre%') = (remote_id IS NULL)),
+    ADD CONSTRAINT remote_id_empty_chk CHECK (NOT (status <> 'failed' AND remote_id = ''));

--- a/tests/py/test_callbacks.py
+++ b/tests/py/test_callbacks.py
@@ -141,7 +141,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             homer.close(None)
             assert homer.status == 'closed'
             qs = "EventType=PAYOUT_NORMAL_"+status_up+"&RessourceId=123456790"
-            payout = BankWirePayOut()
+            payout = BankWirePayOut(Id=-1)
             payout.Status = status_up
             payout.ResultCode = '000001' if error else '000000'
             payout.ResultMessage = error
@@ -176,7 +176,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             assert homer.balance == 0
             homer.close(None)
             assert homer.status == 'closed'
-            payout = BankWirePayOut()
+            payout = BankWirePayOut(Id=-1)
             payout.Status = 'SUCCEEDED'
             payout.ResultCode = '000000'
             payout.AuthorId = homer.mangopay_user_id
@@ -185,7 +185,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             # Create the refund
             status_up = status.upper()
             error = 'FOO' if status == 'failed' else None
-            refund = Refund()
+            refund = Refund(Id=-1)
             refund.DebitedFunds = Money(900, 'EUR')
             refund.Fees = Money(-100, 'EUR')
             refund.Status = status_up
@@ -229,7 +229,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             homer.close(None)
             assert homer.status == 'closed'
             qs = "EventType=PAYIN_NORMAL_"+status_up+"&RessourceId=123456790"
-            payin = BankWirePayIn()
+            payin = BankWirePayIn(Id=-1)
             payin.Status = status_up
             payin.ResultCode = result_code
             payin.ResultMessage = error
@@ -272,7 +272,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
             assert homer.balance == 0
             assert homer.status == 'closed'
             qs = "EventType=PAYIN_NORMAL_"+status_up+"&RessourceId=123456790"
-            payin = BankWirePayIn()
+            payin = BankWirePayIn(Id=-1)
             payin.Status = status_up
             payin.ResultCode = result_code
             payin.ResultMessage = error
@@ -322,7 +322,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
         homer.close(None)
         assert homer.status == 'closed'
         qs = "EventType=PAYIN_NORMAL_SUCCEEDED&RessourceId=123456790"
-        payin = BankWirePayIn()
+        payin = BankWirePayIn(Id=-1)
         payin.Status = 'SUCCEEDED'
         payin.ResultCode = '000000'
         payin.ResultMessage = None

--- a/www/%username/wallet/payin/card/%back_to.spt
+++ b/www/%username/wallet/payin/card/%back_to.spt
@@ -32,7 +32,7 @@ if request.method == 'GET' and 'transactionId' in request.qs:
         raise response.error(403, "bad transactionId: user mistmatch")
     status = payin.Status.lower()
     error = repr_error(payin)
-    record_exchange_result(website.db, payin.Tag, status, error, participant)
+    record_exchange_result(website.db, payin.Tag, payin.Id, status, error, participant)
     response.redirect(request.path.raw+'?exchange_id=%s' % payin.Tag)
 
 exchange = None

--- a/www/%username/wallet/payin/direct-debit/%exchange_id.spt
+++ b/www/%username/wallet/payin/direct-debit/%exchange_id.spt
@@ -122,7 +122,7 @@ if request.method == 'POST':
         response.redirect(mandate.RedirectURL)
     elif mandate.Status == 'FAILED':
         error = repr_error(mandate)
-        record_exchange_result(website.db, exchange.id, 'failed', error, participant)
+        record_exchange_result(website.db, exchange.id, '', 'failed', error, participant)
     else:
         execute_direct_debit(website.db, exchange, route)
     response.redirect(return_url)
@@ -137,7 +137,7 @@ elif request.method == 'GET' and 'MandateId' in request.qs:
         if mandate.Status == 'FAILED':
             route.set_mandate(None)
             error = repr_error(mandate)
-            exchange = record_exchange_result(website.db, exchange.id, 'failed', error, participant)
+            exchange = record_exchange_result(website.db, exchange.id, '', 'failed', error, participant)
         else:
             exchange = execute_direct_debit(website.db, exchange, route)
 

--- a/www/callbacks/mangopay.spt
+++ b/www/callbacks/mangopay.spt
@@ -200,7 +200,7 @@ elif cls:
     if reopen:
         p.update_status('active')
     assert e_id
-    record_exchange_result(website.db, e_id, status, error, p)
+    record_exchange_result(website.db, e_id, payio.Id, status, error, p)
     e = website.db.one("SELECT * FROM exchanges WHERE id = %s", (e_id,))
 
     # Attempt to transfer the money to the user's current wallet


### PR DESCRIPTION
This should have been done a long time ago, and it has become somewhat of a priority now that we have transactions in mangopay's system that don't contain an exchange ID because they weren't created by our system (#695).