### PR TITLE
Rename duplicated id

### DIFF
--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -56,7 +56,7 @@ title = _("Introduction")
     </p>
 
 
-    <h3 id="who">{{ _("Why should you donate?") }}</h3>
+    <h3 id="why">{{ _("Why should you donate?") }}</h3>
 
     % include "templates/pitch-donors.html"
     % from "templates/buttons.html" import find_donees with context


### PR DESCRIPTION
`id` HTML attributes must be unique. Also it doesn't make much sense to have two `id`s with the value `who`, when one of them should be called why: https://liberapay.com/about/#why