### PR TITLE
Implement redirects for renamed profiles

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -195,6 +195,7 @@ QUARANTINE = timedelta(weeks=4)
 RATE_LIMITS = {
     'add_email.source': (5, 60*60*24),  # 5 per day
     'add_email.target': (2, 60*60*24),  # 2 per day
+    'change_username': (7, 60*60*24*7),  # 7 per week
     'log-in.email': (10, 60*60*24),  # 10 per day
     'log-in.email.not-verified': (2, 60*60*24),  # 2 per day
     'log-in.email.verified': (10, 60*60*24),  # 10 per day

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -93,6 +93,14 @@ class UsernameBeginsWithRestrictedCharacter(ProblemChangingUsername):
     def msg(self, _):
         return _("The username '{0}' begins with a restricted character.", *self.args)
 
+class TooManyUsernameChanges(ProblemChangingUsername):
+    code = 429
+    def msg(self, _):
+        return _(
+            "You've already changed your username many times recently, please "
+            "retry later (e.g. in a week) or contact support@liberapay.com."
+        )
+
 
 class ProblemChangingEmail(LazyResponse400): pass
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -39,6 +39,7 @@ from liberapay.exceptions import (
     NoTippee,
     TooManyEmailAddresses,
     TooManyEmailVerifications,
+    TooManyUsernameChanges,
     UserDoesntAcceptTips,
     UsernameAlreadyTaken,
     UsernameBeginsWithRestrictedCharacter,
@@ -1301,6 +1302,7 @@ class Participant(Model, MixinTeam):
 
         if suggested != self.username:
             with self.db.get_cursor(cursor) as c:
+                c.hit_rate_limit('change_username', self.id, TooManyUsernameChanges)
                 try:
                     # Will raise IntegrityError if the desired username is taken.
                     actual = c.one("""

--- a/liberapay/testing/__init__.py
+++ b/liberapay/testing/__init__.py
@@ -172,6 +172,8 @@ class Harness(unittest.TestCase):
             kw.setdefault('mangopay_user_id', -i)
             kw.setdefault('mangopay_wallet_id', -i)
         kw.setdefault('status', 'active')
+        if username:
+            kw['username'] = username
         if 'join_time' not in kw:
             kw['join_time'] = utcnow()
         cols, vals = zip(*kw.items())
@@ -179,10 +181,10 @@ class Harness(unittest.TestCase):
         placeholders = ', '.join(['%s']*len(vals))
         participant = self.db.one("""
             INSERT INTO participants
-                        (username, {0})
-                 VALUES (%s, {1})
+                        ({0})
+                 VALUES ({1})
               RETURNING participants.*::participants
-        """.format(cols, placeholders), (username,)+vals)
+        """.format(cols, placeholders), vals)
 
         self.db.run("""
             INSERT INTO elsewhere

--- a/liberapay/testing/vcr.py
+++ b/liberapay/testing/vcr.py
@@ -39,7 +39,7 @@ class CustomSerializer:
 vcr = VCR(
     cassette_library_dir=FIXTURES_ROOT,
     record_mode='once',
-    match_on=['url', 'method'],
+    match_on=['method', 'scheme', 'host', 'path', 'query'],
 )
 vcr.register_serializer('custom', CustomSerializer)
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,8 @@
+CREATE TABLE redirections
+( from_prefix   text          PRIMARY KEY
+, to_prefix     text          NOT NULL
+, ctime         timestamptz   NOT NULL DEFAULT now()
+, mtime         timestamptz   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX redirections_to_prefix_idx ON redirections (to_prefix);

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -54,11 +54,13 @@ class Tests(Harness):
         p = self.make_participant(None)
         p.change_username('alice')
         # 1st username change
+        self.db.run("UPDATE events SET ts = ts - interval '30 days'")
         p.change_username('bob')
         r = self.GxT('/alice')
         assert r.code == 302
         assert r.headers[b'Location'] == b'/bob'
         # 2nd username change
+        self.db.run("UPDATE events SET ts = ts - interval '30 days'")
         p.change_username('carl')
         r = self.GxT('/alice')
         assert r.code == 302
@@ -67,6 +69,7 @@ class Tests(Harness):
         assert r.code == 302
         assert r.headers[b'Location'] == b'/carl'
         # 3rd username change: back to the original
+        self.db.run("UPDATE events SET ts = ts - interval '30 days'")
         p.change_username('alice')
         r = self.client.GET('/alice')
         assert r.code == 200

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -27,33 +27,55 @@ class Tests(Harness):
         actual = utils.get_participant(state, restrict=False)
         assert actual == expected
 
-    def test_get_participant_raises_404_for_missing_id(self):
-        state = self.client.GET('/~/', return_after='handle_dispatch_exception',
+    def GxT(self, path):
+        state = self.client.GET(path, return_after='handle_dispatch_exception',
                                 want='state')
         with self.assertRaises(Response) as cm:
             utils.get_participant(state, restrict=False)
-        r = cm.exception
+        return cm.exception
+
+    def test_get_participant_raises_404_for_missing_id(self):
+        r = self.GxT('/~/')
         assert r.code == 404
 
     def test_get_participant_canonicalizes(self):
         self.make_participant('alice')
-        state = self.client.GET('/Alice/?foo=bar', return_after='handle_dispatch_exception',
-                                want='state')
-        with self.assertRaises(Response) as cm:
-            utils.get_participant(state, restrict=False)
-        r = cm.exception
+        r = self.GxT('/Alice/?foo=bar')
         assert r.code == 302
         assert r.headers[b'Location'] == b'/alice/?foo=bar'
 
     def test_get_participant_canonicalizes_id_to_username(self):
         self.make_participant('alice')
-        state = self.client.GET('/~1/?x=2', return_after='handle_dispatch_exception',
-                                want='state')
-        with self.assertRaises(Response) as cm:
-            utils.get_participant(state, restrict=False)
-        r = cm.exception
+        r = self.GxT('/~1/?x=2')
         assert r.code == 302
         assert r.headers[b'Location'] == b'/alice/?x=2'
+
+    def test_get_participant_redirects_after_username_change(self):
+        p = self.make_participant(None)
+        p.change_username('alice')
+        # 1st username change
+        p.change_username('bob')
+        r = self.GxT('/alice')
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/bob'
+        # 2nd username change
+        p.change_username('carl')
+        r = self.GxT('/alice')
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/carl'
+        r = self.GxT('/bob')
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/carl'
+        # 3rd username change: back to the original
+        p.change_username('alice')
+        r = self.client.GET('/alice')
+        assert r.code == 200
+        r = self.GxT('/bob')
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/alice'
+        r = self.GxT('/carl')
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/alice'
 
     def test_is_expired(self):
         expiration = datetime.utcnow() - timedelta(days=40)


### PR DESCRIPTION
This branch closes #22 and closes #91. Instead of trying to redirect every 404 request in general (see the 2nd item of #91), which would cost an extra DB query for each 404, we only try to redirect unknown usernames in the `get_participant()` function.