### PR TITLE
Implement team rename

### DIFF
--- a/emails/team_rename.spt
+++ b/emails/team_rename.spt
@@ -1,0 +1,4 @@
+{{ _("A team you're a member of has been renamed") }}
+
+[---] text/html
+<p>{{ _("The team “{0}” has been renamed to “{1}” by {2}.", old_name, new_name, renamed_by) }}</p>

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1316,11 +1316,11 @@ class Participant(Model, MixinTeam):
                 if actual is None:
                     return suggested
                 assert (suggested, lowercased) == actual  # sanity check
-                c.hit_rate_limit('change_username', self.id, TooManyUsernameChanges)
 
                 # Deal with redirections
                 last_rename = self.get_last_event_of_type('set_username')
                 if last_rename:
+                    c.hit_rate_limit('change_username', self.id, TooManyUsernameChanges)
                     old_username = last_rename.payload
                     prefixes = {
                         'old': '/%s/' % old_username.lower(),

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1334,17 +1334,18 @@ class Participant(Model, MixinTeam):
                              , mtime = now()
                          WHERE to_prefix = %(old)s;
                     """, prefixes)
-                    # Add a redirection if the old name was in use long enough (1 hour)
-                    active_period = utcnow() - last_rename.ts
-                    if active_period.total_seconds() > 3600:
-                        c.run("""
-                            INSERT INTO redirections
-                                        (from_prefix, to_prefix)
-                                 VALUES (%(old)s || '%%', %(new)s)
-                            ON CONFLICT (from_prefix) DO UPDATE
-                                    SET to_prefix = excluded.to_prefix
-                                      , mtime = now()
-                        """, prefixes)
+                    if prefixes['old'] != prefixes['new']:
+                        # Add a redirection if the old name was in use long enough (1 hour)
+                        active_period = utcnow() - last_rename.ts
+                        if active_period.total_seconds() > 3600:
+                            c.run("""
+                                INSERT INTO redirections
+                                            (from_prefix, to_prefix)
+                                     VALUES (%(old)s || '%%', %(new)s)
+                                ON CONFLICT (from_prefix) DO UPDATE
+                                        SET to_prefix = excluded.to_prefix
+                                          , mtime = now()
+                            """, prefixes)
 
                 self.add_event(c, 'set_username', suggested)
                 self.set_attributes(username=suggested)

--- a/tests/py/test_settings.py
+++ b/tests/py/test_settings.py
@@ -97,3 +97,21 @@ class TestUsername(Harness):
         r = self.change_username(username)
         assert r.code == 400
         assert "The username &#39;%s&#39; is too long." % username in r.text, r.text
+
+    def test_change_team_name(self):
+        team = self.make_participant(None, kind='group')
+        team.change_username('team')
+        alice = self.make_participant('alice')
+        team.add_member(alice)
+        bob = self.make_participant('bob')
+        team.add_member(bob)
+        r = self.client.POST('/team/settings/edit', {'username': 'Team'},
+                             auth_as=alice, raise_immediately=False)
+        assert r.code == 302
+        assert r.headers[b'Location'] == b'/Team/edit'
+        team = team.refetch()
+        assert team.username == 'Team'
+        alice = alice.refetch()
+        assert alice.pending_notifs == 0
+        bob = bob.refetch()
+        assert bob.pending_notifs == 1

--- a/www/%username/settings/edit.spt
+++ b/www/%username/settings/edit.spt
@@ -9,11 +9,11 @@ request.allow('POST')
 body = request.body
 out = {}
 
-p = get_participant(state, restrict=True)
-if user != p:
-    raise response.error(403)
+p = get_participant(state, restrict=True, allow_member=True)
 
 if 'new-password' in body:
+    if not p.is_person:
+        raise response.error(403)
     if p.session_token and p.session_token.endswith('.em'):
         pass  # user logged in via email, allow resetting password
     elif not p.password:
@@ -28,6 +28,8 @@ if 'new-password' in body:
     out['msg'] = _("Your password has been changed.")
 
 elif 'privacy' in body:
+    if not p.is_person:
+        raise response.error(403)
     fields = body['privacy'].split()
     for field in fields:
         if field not in PRIVACY_FIELDS:
@@ -44,7 +46,7 @@ elif 'privacy' in body:
     out['msg'] = _("Your privacy settings have been changed.")
 
 elif 'username' in body:
-    p.change_username(body['username'])
+    p.change_username(body['username'], recorder=user)
     response.redirect(p.path('edit'))
 
 if request.headers.get(b'X-Requested-With') != b'XMLHttpRequest':


### PR DESCRIPTION
Closes #705. The first two commits fix small issues in the `change_username()` method.

To keep things simple the notifications are web only, they're not sent via email.