### PR TITLE
Improve profile statement excerpts

### DIFF
--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -209,7 +209,13 @@ def log_cursor(f):
 def excerpt_intro(text, length=175):
     if not text:
         return ''
-    text = text.lstrip().split('\n', 1)[0].rstrip()
+    if isinstance(text, Markup):
+        i = text.find('</p>')
+        if i != -1:
+            text = text[:i]
+        text = text.striptags().strip()
+    else:
+        text = text.lstrip().split('\n', 1)[0].rstrip()
     if len(text) > length:
         text = text[:length]
         if text[-1] == '.':

--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -206,12 +206,21 @@ def log_cursor(f):
     return wrapper
 
 
-def excerpt_intro(text, length=175, append='…'):
+def excerpt_intro(text, length=175):
     if not text:
         return ''
-    text = text.lstrip().split('\n', 1)[0]
+    text = text.lstrip().split('\n', 1)[0].rstrip()
     if len(text) > length:
-        return text[:length] + append
+        text = text[:length]
+        if text[-1] == '.':
+            # don't add an ellipsis directly after a dot
+            return text + ' […]'
+        if text[-1] != ' ':
+            # try to avoid cutting a word
+            i = text.rfind(' ')
+            if i > 0.9 * length:
+                text = text[:i+1]
+        return text + '…'
     return text
 
 

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -1,7 +1,7 @@
 # coding: utf8
 from __future__ import print_function, unicode_literals
 
-from liberapay.utils import get_participant, markdown
+from liberapay.utils import excerpt_intro, get_participant, markdown
 from liberapay.utils.i18n import LANGUAGES_2, get_lang_options
 
 [---]
@@ -151,12 +151,16 @@ title = _username
 
             <div class="alert alert-info">{{ _("This is a preview.") }}</div>
 
+            % set rendered_stmt = markdown.render(statement)
             <form action="#statement" method="POST">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="lang" value="{{ lang }}" />
                 <textarea class="hidden" name="statement">{{ statement }}</textarea>
-                <section class="profile-statement">{{ markdown.render(statement) }}</section>
-                <br>
+                <section class="profile-statement">{{ rendered_stmt }}</section>
+                <hr>
+                <h5>{{ _("Excerpt that will be used in social media:") }}</h5>
+                <p>{{ excerpt_intro(rendered_stmt.striptags()) }}</p>
+                <hr>
                 <button class="btn btn-default">{{ _("Edit") }}</button>
                 <button class="btn btn-success" name="save" value="true">{{ _("Save") }}</button>
             </form>

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -159,7 +159,7 @@ title = _username
                 <section class="profile-statement">{{ rendered_stmt }}</section>
                 <hr>
                 <h5>{{ _("Excerpt that will be used in social media:") }}</h5>
-                <p>{{ excerpt_intro(rendered_stmt.striptags()) }}</p>
+                <p>{{ excerpt_intro(rendered_stmt) }}</p>
                 <hr>
                 <button class="btn btn-default">{{ _("Edit") }}</button>
                 <button class="btn btn-success" name="save" value="true">{{ _("Save") }}</button>

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -27,7 +27,7 @@ show_income = not participant.hide_receiving and participant.accepts_tips
 % block head_early
 {{ super() }}
 % if statement
-    <meta property="og:description" content="{{ excerpt_intro(statement.striptags()) }}">
+    <meta property="og:description" content="{{ excerpt_intro(statement) }}">
 % endif
 % endblock
 


### PR DESCRIPTION
Completes #580.

- don't cut words
- don't add an ellipsis (…) directly after a dot (.)
- show the excerpt to the user when editing the profile statement
