### PR TITLE
Install libffi-dev dependency @ Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:8
 
-RUN apt-get update && apt-get install build-essential wget libpq-dev python-dev postgresql-client -y
+RUN apt-get update && \
+    apt-get install -y build-essential wget libpq-dev libffi-dev python-dev postgresql-client
 
 RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && python /tmp/get-pip.py
 


### PR DESCRIPTION
The mikasa python library was failing to compile due to a missing C
library (libffi) when building the docker image for the project.

This commit installs the OS package libffi-dev which contains the
missing dependency, before installing the python dependencies.