### PR TITLE
Implement account descriptions

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -232,6 +232,8 @@ STANDARD_TIPS = (
     make_standard_tip(_("Maximum"), DONATION_WEEKLY_MAX),
 )
 
+SUMMARY_MAX_SIZE = 100
+
 USERNAME_MAX_SIZE = 32
 
 del _

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TYPE stmt_type ADD VALUE IF NOT EXISTS 'summary';

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -191,6 +191,10 @@ img.account-type {
         font-size: 20px;
         margin: 0 0 10px;
     }
+    h4 + p.summary {
+        color: $gray-light;
+        margin-top: -5px;
+    }
     .radio {
         margin-top: 0;
     }

--- a/templates/profile-box.html
+++ b/templates/profile-box.html
@@ -8,9 +8,9 @@
     % endcall
 % endmacro
 
-% macro profile_box_embedded(participant, nmembers=None)
+% macro profile_box_embedded(participant, summary, nmembers=None)
     % call profile_box(participant, embedded=True)
-        {{ profile_box_embedded_col2(participant, nmembers=nmembers) }}
+        {{ profile_box_embedded_col2(participant, summary, nmembers=nmembers) }}
     % endcall
 % endmacro
 
@@ -93,12 +93,16 @@
     % endif
 % endmacro
 
-% macro profile_box_embedded_col2(participant, nmembers=None)
+% macro profile_box_embedded_col2(participant, summary, nmembers=None)
     % set username = participant.username
     % set receiving = participant.receiving
     % set goal = participant.goal
 
     <h4><a href="/{{ username }}/">{{ username }}</a></h4>
+
+    % if summary
+    <p class="summary">{{ summary }}</p>
+    % endif
 
     % if participant.hide_receiving
     % elif goal == None

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -197,7 +197,8 @@ title = _username
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="lang" value="{{ lang }}" />
 
-                <p>{{ _("Current language: {0}", locale.languages.get(lang, lang.upper())) }}</p>
+                <p>{{ _("Current language: {0}",
+                        '<b>%s</b>'|safe % locale.languages.get(lang, lang.upper())) }}</p>
 
                 <div class="form-group">
                 <input name="summary" class="form-control" size=60

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -9,25 +9,36 @@ participant = get_participant(state, restrict=True, allow_member=True)
 
 if request.method == 'POST':
     lang = request.body['lang']
+    summary = request.body.get('summary') or ''
     statement = request.body['statement']
 
     if lang not in LANGUAGES_2:
         raise response.error(400, "unknown lang")
 
+    if len(summary) > constants.SUMMARY_MAX_SIZE:
+        raise response.error(400, _(
+            "The submitted summary is too long ({0} > {1}).",
+            len(summary), constants.SUMMARY_MAX_SIZE)
+        )
+
     if request.body.get('save') == 'true':
-        participant.upsert_statement(lang, statement)
+        participant.upsert_statement(lang, summary, 'summary')
+        participant.upsert_statement(lang, statement, 'profile')
         response.redirect(request.line.uri+'#statement')
 
 else:
     lang = request.qs.get('lang')
     if lang:
+        if lang not in LANGUAGES_2:
+            raise response.error(400, "unknown lang")
         statement = participant.get_statement(lang)
     else:
         statement, lang = participant.get_statement(request.accept_langs)
+        if not lang:
+            lang = locale.language
+    summary = participant.get_statement(lang, 'summary') or ''
 
 select_langs = get_lang_options(request, locale, participant.get_statement_langs())
-lang = lang or locale.language
-stmt_placeholder = _("You don't have a profile statement in this language yet.")
 confirm_discard = _("You haven't saved your changes, are you sure you want to discard them?")
 
 if participant.kind == 'individual':
@@ -155,6 +166,11 @@ title = _username
             <form action="#statement" method="POST">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="lang" value="{{ lang }}" />
+                % if summary
+                <input type="hidden" name="summary" value="{{ summary }}" />
+                <p class="summary">{{ summary }}</p>
+                <hr>
+                % endif
                 <textarea class="hidden" name="statement">{{ statement }}</textarea>
                 <section class="profile-statement">{{ rendered_stmt }}</section>
                 <hr>
@@ -167,26 +183,41 @@ title = _username
 
         % else
 
-            <p>{{ _("Tell us how you're making the world better.") }}</p>
+            <p>{{ _(
+                "Describe your work, why you're asking for donations, etc. We need "
+                "both a short summary and a full statement."
+            ) }}</p>
 
             <p>{{ _(
-                "Liberapay allows you to have profile statements in multiple languages. "
-                "Use the selector below to switch between them."
-            ) }}</p>
+                "Liberapay allows you to internationalize your texts. "
+                "Use the selector below to switch between languages.")
+            }}</p>
 
             <form action="#statement" method="POST" class="statement">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                 <input type="hidden" name="lang" value="{{ lang }}" />
-                {{ _("Current language: {0}", locale.languages.get(lang, lang.upper())) }}
-                <textarea name="statement" rows="15" class="form-control profile-statement vertical-resize"
-                          placeholder="{{ stmt_placeholder }}"
+
+                <p>{{ _("Current language: {0}", locale.languages.get(lang, lang.upper())) }}</p>
+
+                <div class="form-group">
+                <input name="summary" class="form-control" size=60
+                       maxlength="{{ constants.SUMMARY_MAX_SIZE }}"
+                       placeholder="{{ _('Short description') }}"
+                       value="{{ summary }}" />
+                </div>
+
+                <div class="form-group">
+                <textarea name="statement" rows="15"
+                          class="form-control profile-statement vertical-resize"
+                          placeholder="{{ _('Full statement') }}"
                           data-confirm-discard="{{ confirm_discard }}"
                     >{{ statement or '' }}</textarea>
                 <p class="help-block pull-right">{{ _("Markdown supported.") }}
                     <a href="https://daringfireball.net/projects/markdown/basics"
                        target="_blank" rel="noopener noreferrer">{{ _("What is markdown?") }}</a>
                 </p>
-                <p> </p>{# this is for spacing #}
+                </div>
+
                 <button class="preview btn btn-default" name="preview" value="true">{{ _("Preview") }}</button>
                 <button class="save btn btn-success" name="save" value="true">{{ _("Save") }}</button>
             </form>

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -14,6 +14,7 @@ if lang:
 else:
     statement, lang = participant.get_statement(request.accept_langs)
 statement = markdown.render(statement) if statement else None
+summary = participant.get_statement(lang, 'summary')
 
 langs = participant.get_statement_langs()
 
@@ -26,8 +27,8 @@ show_income = not participant.hide_receiving and participant.accepts_tips
 
 % block head_early
 {{ super() }}
-% if statement
-    <meta property="og:description" content="{{ excerpt_intro(statement) }}">
+% if statement or summary
+    <meta property="og:description" content="{{ excerpt_intro(statement) or summary }}">
 % endif
 % endblock
 

--- a/www/explore/individuals.spt
+++ b/www/explore/individuals.spt
@@ -5,8 +5,9 @@ query_cache = website.db_qc5
 [---]
 
 individuals = query_cache.all("""
-    SELECT p
+    SELECT p, s.content AS summary
       FROM participants p
+ LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE p.kind = 'individual'
        AND p.status = 'active'
        AND (p.goal > 0 OR p.goal IS NULL)
@@ -15,7 +16,7 @@ individuals = query_cache.all("""
        AND p.receiving > 0
   ORDER BY p.receiving DESC, p.join_time DESC
      LIMIT 30
-""")
+""", (locale.language,))
 title = _("Explore")
 subhead = _("Individuals")
 
@@ -29,9 +30,9 @@ subhead = _("Individuals")
 % if individuals
 <p>{{ _("The top {0} individuals on Liberapay are:", len(individuals)) }}</p>
 <div class="row">
-    % for p in individuals
+    % for p, summary in individuals
     <div class="col-md-6">
-        {{ profile_box_embedded(p) }}
+        {{ profile_box_embedded(p, summary) }}
     </div>
     % endfor
 </div>

--- a/www/explore/individuals.spt
+++ b/www/explore/individuals.spt
@@ -5,9 +5,15 @@ query_cache = website.db_qc5
 [---]
 
 individuals = query_cache.all("""
-    SELECT p, s.content AS summary
+    SELECT p
+         , ( SELECT s.content
+               FROM statements s
+              WHERE s.participant = p.id
+                AND s.type = 'summary'
+           ORDER BY s.lang = %s DESC, s.id
+              LIMIT 1
+           ) AS summary
       FROM participants p
- LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE p.kind = 'individual'
        AND p.status = 'active'
        AND (p.goal > 0 OR p.goal IS NULL)

--- a/www/explore/individuals.spt
+++ b/www/explore/individuals.spt
@@ -13,7 +13,6 @@ individuals = query_cache.all("""
        AND p.hide_receiving IS NOT TRUE
        AND p.hide_from_lists = 0
        AND p.receiving > 0
-       AND EXISTS (SELECT 1 FROM statements s WHERE s.participant = p.id)
   ORDER BY p.receiving DESC, p.join_time DESC
      LIMIT 30
 """)

--- a/www/explore/organizations.spt
+++ b/www/explore/organizations.spt
@@ -5,8 +5,9 @@ query_cache = website.db_qc5
 [---]
 
 orgs_receiving = query_cache.all("""
-    SELECT p
+    SELECT p, s.content AS summary
       FROM participants p
+ LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE p.kind = 'organization'
        AND p.status = 'active'
        AND (p.goal > 0 OR p.goal IS NULL)
@@ -15,7 +16,7 @@ orgs_receiving = query_cache.all("""
        AND p.receiving > 0
   ORDER BY p.receiving DESC, p.join_time DESC
      LIMIT 30
-""")
+""", (locale.language,))
 title = _("Explore")
 subhead = _("Organizations")
 
@@ -29,9 +30,9 @@ subhead = _("Organizations")
 % if orgs_receiving
 <p>{{ _("The top {0} organizations on Liberapay are:", len(orgs_receiving)) }}</p>
 <div class="row">
-    % for p in orgs_receiving
+    % for p, summary in orgs_receiving
     <div class="col-md-6">
-        {{ profile_box_embedded(p) }}
+        {{ profile_box_embedded(p, summary) }}
     </div>
     % endfor
 </div>

--- a/www/explore/organizations.spt
+++ b/www/explore/organizations.spt
@@ -5,9 +5,15 @@ query_cache = website.db_qc5
 [---]
 
 orgs_receiving = query_cache.all("""
-    SELECT p, s.content AS summary
+    SELECT p
+         , ( SELECT s.content
+               FROM statements s
+              WHERE s.participant = p.id
+                AND s.type = 'summary'
+           ORDER BY s.lang = %s DESC, s.id
+              LIMIT 1
+           ) AS summary
       FROM participants p
- LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE p.kind = 'organization'
        AND p.status = 'active'
        AND (p.goal > 0 OR p.goal IS NULL)

--- a/www/explore/organizations.spt
+++ b/www/explore/organizations.spt
@@ -13,7 +13,6 @@ orgs_receiving = query_cache.all("""
        AND p.hide_receiving IS NOT TRUE
        AND p.hide_from_lists = 0
        AND p.receiving > 0
-       AND EXISTS (SELECT 1 FROM statements s WHERE s.participant = p.id)
   ORDER BY p.receiving DESC, p.join_time DESC
      LIMIT 30
 """)

--- a/www/explore/teams.spt
+++ b/www/explore/teams.spt
@@ -8,17 +8,18 @@ teams = query_cache.all("""
 
     SELECT t.*
          , p.*::participants AS participant
+         , s.content AS summary
       FROM ( SELECT team AS id, count(member) AS nmembers
                FROM current_takes
            GROUP BY team
             ) AS t
-      JOIN participants p
-        ON p.id = t.id
+      JOIN participants p ON p.id = t.id
+ LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE (p.goal >= 0 OR p.goal IS NULL)
        AND p.hide_from_lists = 0
   ORDER BY receiving DESC, join_time DESC
 
-""")
+""", (locale.language,))
 nteams = len(teams)
 title = _("Explore")
 subhead = _("Teams")
@@ -44,7 +45,7 @@ subhead = _("Teams")
 <div class="row">
     % for team in teams
     <div class="col-md-6">
-        {{ profile_box_embedded(team.participant, nmembers=team.nmembers) }}
+        {{ profile_box_embedded(team.participant, team.summary, nmembers=team.nmembers) }}
     </div>
     % endfor
 </div>

--- a/www/explore/teams.spt
+++ b/www/explore/teams.spt
@@ -8,13 +8,18 @@ teams = query_cache.all("""
 
     SELECT t.*
          , p.*::participants AS participant
-         , s.content AS summary
+         , ( SELECT s.content
+               FROM statements s
+              WHERE s.participant = p.id
+                AND s.type = 'summary'
+           ORDER BY s.lang = %s DESC, s.id
+              LIMIT 1
+           ) AS summary
       FROM ( SELECT team AS id, count(member) AS nmembers
                FROM current_takes
            GROUP BY team
             ) AS t
       JOIN participants p ON p.id = t.id
- LEFT JOIN statements s ON s.participant = p.id AND s.type = 'summary' AND s.lang = %s
      WHERE (p.goal >= 0 OR p.goal IS NULL)
        AND p.hide_from_lists = 0
   ORDER BY receiving DESC, join_time DESC

--- a/www/for/%name/edit.spt
+++ b/www/for/%name/edit.spt
@@ -44,7 +44,8 @@ title = _("{0} community settings", c.name)
     "Use the selector below to switch between languages.")
 }}</p>
 
-<p>{{ _("Current language: {0}", locale.languages.get(lang, lang.upper())) }}</p>
+<p>{{ _("Current language: {0}",
+        '<b>%s</b>'|safe % locale.languages.get(lang, lang.upper())) }}</p>
 
 <form action="" class="block-labels" method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />

--- a/www/search.spt
+++ b/www/search.spt
@@ -25,7 +25,7 @@ if query:
         """, locals())
 
     if scope in (None, 'statements'):
-        langs = tuple(l for l in request.accept_langs if l in LANGUAGES_2)
+        langs = tuple(l for l in request.accept_langs[:3] if l in LANGUAGES_2)
         search_confs = list(set(SEARCH_CONFS.get(lang, 'simple') for lang in langs))
         results['statements'] = website.db.all("""
             WITH queries AS (

--- a/www/search.spt
+++ b/www/search.spt
@@ -47,7 +47,7 @@ if query:
                             , ts_rank_cd(search_vector, query) AS rank
                          FROM statements NATURAL JOIN queries
                         WHERE lang IN %(langs)s
-                          AND type = 'profile'
+                          AND type IN ('profile', 'summary')
                           AND search_vector @@ query
                      ORDER BY rank DESC
                         LIMIT 10

--- a/www/search.spt
+++ b/www/search.spt
@@ -40,7 +40,7 @@ if query:
                        SELECT rank
                             , lang
                             , ts_headline(search_conf, content, query,
-                                          'StartSel=**,StopSel=**,MaxFragments=1') AS excerpt
+                                          'StartSel=**,StopSel=**,MaxFragments=1,ShortWord=0') AS excerpt
                    ) a)) AS excerpts
               FROM (
                        SELECT participant, lang, content, search_conf, query


### PR DESCRIPTION
The idea of account descriptions was previously mentioned in #580 and illustrated in #608. This branch implements inputting a short description (called `summary` in the code) when editing a profile, and showing these descriptions in the Explore pages. It also fixes #520 and closes #86.