### PR TITLE
Count team patrons

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -713,18 +713,19 @@ class Payday(object):
                AND p.status <> 'stub';
 
             UPDATE participants p
-               SET npatrons = p2.npatrons
+               SET nteampatrons = p2.nteampatrons
               FROM ( SELECT p2.id
-                          , ( SELECT count(*)
+                          , ( SELECT count(DISTINCT t.tipper)
                                 FROM payday_transfers t
                                WHERE t.tippee = p2.id
-                            ) AS npatrons
+                                 AND t.context = 'take'
+                            ) AS nteampatrons
                        FROM participants p2
+                      WHERE p2.status <> 'stub'
+                        AND p2.kind IN ('individual', 'organization')
                    ) p2
              WHERE p.id = p2.id
-               AND p.npatrons <> p2.npatrons
-               AND p.status <> 'stub'
-               AND p.kind IN ('individual', 'organization');
+               AND p.nteampatrons <> p2.nteampatrons;
 
             UPDATE participants p
                SET npatrons = p2.npatrons
@@ -735,10 +736,10 @@ class Payday(object):
                                  AND t.is_funded
                             ) AS npatrons
                        FROM participants p2
+                      WHERE p2.status <> 'stub'
                    ) p2
              WHERE p.id = p2.id
-               AND p.npatrons <> p2.npatrons
-               AND p.kind = 'group';
+               AND p.npatrons <> p2.npatrons;
 
             """)
         self.clean_up()

--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -18,7 +18,7 @@ from pando.algorithms.website import fill_response_with_output
 from pando.utils import maybe_encode
 
 from liberapay import utils, wireup
-from liberapay.billing.payday import create_payday_issue
+from liberapay.billing.payday import Payday, create_payday_issue
 from liberapay.cron import Cron, Weekly
 from liberapay.models.community import Community
 from liberapay.models.participant import Participant
@@ -99,6 +99,7 @@ if env.run_cron_jobs and conf:
     cron(conf.refetch_repos_every, refetch_repos, True)
     cron(Weekly(weekday=3, hour=2), create_payday_issue, True)
     cron(conf.clean_up_counters_every, website.db.clean_up_counters, True)
+    cron(conf.update_cached_amounts_every, Payday.update_cached_amounts, True)
 
 
 # Website Algorithm

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -40,11 +40,11 @@ class MixinTeam(object):
 
     def remove_all_members(self, cursor=None):
         (cursor or self.db).run("""
-            INSERT INTO takes (ctime, member, team, amount, recorder) (
-                SELECT ctime, member, %(id)s, NULL, %(id)s
-                  FROM current_takes
-                 WHERE team=%(id)s
-            );
+            INSERT INTO takes
+                        (ctime, member, team, amount, recorder)
+                 SELECT ctime, member, %(id)s, NULL, %(id)s
+                   FROM current_takes
+                  WHERE team=%(id)s
         """, dict(id=self.id))
 
     def member_of(self, team):
@@ -132,18 +132,19 @@ class MixinTeam(object):
             # Insert the new take
             cursor.run("""
 
-                INSERT INTO takes (ctime, member, team, amount, recorder)
-                 VALUES ( COALESCE (( SELECT ctime
-                                        FROM takes
-                                       WHERE member=%(member)s
-                                         AND team=%(team)s
-                                       LIMIT 1
-                                     ), CURRENT_TIMESTAMP)
-                        , %(member)s
-                        , %(team)s
-                        , %(amount)s
-                        , %(recorder)s
-                         )
+                INSERT INTO takes
+                            (ctime, member, team, amount, recorder)
+                     SELECT COALESCE((
+                                SELECT ctime
+                                  FROM takes
+                                 WHERE member=%(member)s
+                                   AND team=%(team)s
+                                 LIMIT 1
+                            ), current_timestamp)
+                          , %(member)s
+                          , %(team)s
+                          , %(amount)s
+                          , %(recorder)s
 
             """, dict(member=member.id, team=self.id, amount=take,
                       recorder=recorder.id))

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -3,10 +3,11 @@
 from __future__ import division, print_function, unicode_literals
 
 from collections import OrderedDict
-from decimal import Decimal, ROUND_UP
+from decimal import Decimal
 from statistics import median
 
-from liberapay.constants import D_CENT, D_INF, D_UNIT, D_ZERO
+from liberapay.constants import D_INF, D_UNIT, D_ZERO
+from liberapay.utils import NS
 
 
 class MemberLimitReached(Exception): pass
@@ -32,7 +33,7 @@ class MixinTeam(object):
     def add_member(self, member, cursor=None):
         """Add a member to this team.
         """
-        if len(self.get_current_takes()) == 149:
+        if self.nmembers >= 149:
             raise MemberLimitReached
         if member.status != 'active':
             raise InactiveParticipantAdded
@@ -41,8 +42,8 @@ class MixinTeam(object):
     def remove_all_members(self, cursor=None):
         (cursor or self.db).run("""
             INSERT INTO takes
-                        (ctime, member, team, amount, recorder)
-                 SELECT ctime, member, %(id)s, NULL, %(id)s
+                        (ctime, member, team, amount, actual_amount, recorder)
+                 SELECT ctime, member, %(id)s, NULL, NULL, %(id)s
                    FROM current_takes
                   WHERE team=%(id)s
         """, dict(id=self.id))
@@ -121,10 +122,8 @@ class MixinTeam(object):
         with self.db.get_cursor(cursor) as cursor:
             # Lock to avoid race conditions
             cursor.run("LOCK TABLE takes IN EXCLUSIVE MODE")
-            # Compute the current takes
-            old_takes = self.compute_actual_takes(cursor)
             # Throttle the new take, if there is more than one member
-            if take and check_max and len(old_takes) > 1 and take > 1:
+            if take and check_max and self.nmembers > 1 and take > 1:
                 last_week = self.get_takes_last_week()
                 max_this_week = self.compute_max_this_week(member.id, last_week)
                 if take > max_this_week:
@@ -133,7 +132,7 @@ class MixinTeam(object):
             cursor.run("""
 
                 INSERT INTO takes
-                            (ctime, member, team, amount, recorder)
+                            (ctime, member, team, amount, actual_amount, recorder)
                      SELECT COALESCE((
                                 SELECT ctime
                                   FROM takes
@@ -144,40 +143,26 @@ class MixinTeam(object):
                           , %(member)s
                           , %(team)s
                           , %(amount)s
+                          , CASE WHEN %(amount)s IS NULL THEN NULL ELSE
+                                COALESCE((
+                                    SELECT actual_amount
+                                      FROM takes
+                                     WHERE member=%(member)s
+                                       AND team=%(team)s
+                                  ORDER BY mtime DESC
+                                     LIMIT 1
+                                ), 0)
+                            END
                           , %(recorder)s
 
             """, dict(member=member.id, team=self.id, amount=take,
                       recorder=recorder.id))
-            # Compute the new takes
-            new_takes = self.compute_actual_takes(cursor)
-            # Update receiving amounts in the participants table
-            self.update_taking(old_takes, new_takes, cursor, member)
+            # Recompute the actual takes and update the cached amounts
+            self.recompute_actual_takes(cursor, member=member)
             # Update is_funded on member's tips
             member.update_giving(cursor)
 
         return take
-
-    def update_taking(self, old_takes, new_takes, cursor=None, member=None):
-        """Update `taking` amounts based on the difference between `old_takes`
-        and `new_takes`.
-        """
-        for p_id in set(old_takes.keys()).union(new_takes.keys()):
-            old = old_takes.get(p_id, {}).get('actual_amount', D_ZERO)
-            new = new_takes.get(p_id, {}).get('actual_amount', D_ZERO)
-            diff = new - old
-            if diff != 0:
-                (cursor or self.db).run("""
-                    UPDATE participants
-                       SET taking = (taking + %(diff)s)
-                         , receiving = (receiving + %(diff)s)
-                     WHERE id=%(p_id)s
-                """, dict(p_id=p_id, diff=diff))
-            if member and p_id == member.id:
-                r = (cursor or self.db).one(
-                    "SELECT taking, receiving FROM participants WHERE id = %s",
-                    (p_id,)
-                )
-                member.set_attributes(**r._asdict())
 
     def get_current_takes(self, cursor=None):
         """Return a list of member takes for a team.
@@ -186,7 +171,7 @@ class MixinTeam(object):
         TAKES = """
             SELECT p.id AS member_id, p.username AS member_name, p.avatar_url
                  , (p.mangopay_user_id IS NOT NULL) AS is_identified
-                 , t.amount, t.ctime, t.mtime
+                 , t.amount, t.actual_amount, t.ctime, t.mtime
               FROM current_takes t
               JOIN participants p ON p.id = member
              WHERE t.team=%(team)s
@@ -195,24 +180,67 @@ class MixinTeam(object):
         records = (cursor or self.db).all(TAKES, dict(team=self.id))
         return [r._asdict() for r in records]
 
-    def compute_actual_takes(self, cursor=None):
-        """Get the takes, compute the actual amounts, and return an OrderedDict.
+    def recompute_actual_takes(self, cursor, member=None):
+        """Get the tips and takes for this team and recompute the actual amounts.
         """
-        actual_takes = OrderedDict()
-        nominal_takes = self.get_current_takes(cursor=cursor)
-        balance = self.receiving
-        total_takes = sum(t['amount'] for t in nominal_takes if t['is_identified'])
-        ratio = min(balance / total_takes, 1) if total_takes else 0
-        for take in nominal_takes:
-            nominal = take['nominal_take'] = take.pop('amount')
-            actual = take['actual_amount'] = min(
-                (nominal * ratio).quantize(D_CENT, rounding=ROUND_UP),
-                balance
-            ) if take['is_identified'] else D_ZERO
-            balance -= actual
-            actual_takes[take['member_id']] = take
-        actual_takes.leftover = balance
-        return actual_takes
+        from liberapay.billing.payday import Payday
+        tips = [NS(t._asdict()) for t in cursor.all("""
+            SELECT t.id, t.tipper, t.amount AS full_amount
+                 , COALESCE((
+                       SELECT sum(tr.amount)
+                         FROM transfers tr
+                        WHERE tr.tipper = t.tipper
+                          AND tr.team = %(team_id)s
+                          AND tr.context = 'take'
+                          AND tr.status = 'succeeded'
+                   ), 0) AS past_transfers_sum
+              FROM current_tips t
+             WHERE t.tippee = %(team_id)s
+               AND t.is_funded
+        """, dict(team_id=self.id))]
+        takes = [NS(r._asdict()) for r in (cursor or self.db).all("""
+            SELECT *
+              FROM current_takes
+             WHERE team = %s
+        """, (self.id,))]
+        # Recompute the takes
+        takes_sum = {}
+        transfers, new_leftover = Payday.resolve_takes(tips, takes)
+        for t in transfers:
+            if t.member in takes_sum:
+                takes_sum[t.member] += t.amount
+            else:
+                takes_sum[t.member] = t.amount
+        # Update the leftover
+        cursor.run("UPDATE participants SET leftover = %s WHERE id = %s",
+                   (new_leftover, self.id))
+        self.set_attributes(leftover=new_leftover)
+        # Update the cached amounts (actual_amount, taking, and receiving)
+        for take in takes:
+            member_id = take.member
+            old_amount = take.actual_amount or D_ZERO
+            new_amount = takes_sum.get(take.member, D_ZERO)
+            diff = new_amount - old_amount
+            if diff != 0:
+                take.actual_amount = new_amount
+                cursor.run("""
+                    UPDATE takes
+                       SET actual_amount = %(actual_amount)s
+                     WHERE id = %(id)s
+                """, take.__dict__)
+                cursor.run("""
+                    UPDATE participants
+                       SET taking = (taking + %(diff)s)
+                         , receiving = (receiving + %(diff)s)
+                     WHERE id=%(member_id)s
+                """, dict(member_id=member_id, diff=diff))
+            if member and member.id == member_id:
+                r = cursor.one(
+                    "SELECT taking, receiving FROM participants WHERE id = %s",
+                    (member_id,)
+                )
+                member.set_attributes(**r._asdict())
+        return takes
 
     @property
     def nmembers(self):
@@ -226,15 +254,15 @@ class MixinTeam(object):
     def get_members(self):
         """Return an OrderedDict of member dicts.
         """
-        takes = self.compute_actual_takes()
+        takes = self.get_current_takes()
         last_week = self.get_takes_last_week()
         members = OrderedDict()
-        members.leftover = takes.leftover
-        for take in takes.values():
+        members.leftover = self.leftover
+        for take in takes:
             member = {}
             m_id = member['id'] = take['member_id']
             member['username'] = take['member_name']
-            member['nominal_take'] = take['nominal_take']
+            member['nominal_take'] = take['amount']
             member['actual_amount'] = take['actual_amount']
             member['last_week'] = last_week.get(m_id, D_ZERO)
             x = self.compute_max_this_week(m_id, last_week)

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -182,6 +182,9 @@ class MixinTeam(object):
 
     def recompute_actual_takes(self, cursor, member=None):
         """Get the tips and takes for this team and recompute the actual amounts.
+
+        To avoid deadlocks the given `cursor` should have already acquired an
+        exclusive lock on the `takes` table.
         """
         from liberapay.billing.payday import Payday
         tips = [NS(t._asdict()) for t in cursor.all("""

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1502,26 +1502,28 @@ class Participant(Model, MixinTeam):
         return updated
 
     def update_receiving(self, cursor=None):
-        r = (cursor or self.db).one("""
-            WITH our_tips AS (
-                     SELECT amount
-                       FROM current_tips
-                      WHERE tippee = %(id)s
-                        AND amount > 0
-                        AND is_funded
-                 )
-            UPDATE participants p
-               SET receiving = (COALESCE((
-                       SELECT sum(amount)
-                         FROM our_tips
-                   ), 0) + taking)
-                 , npatrons = COALESCE((SELECT count(*) FROM our_tips), 0)
-             WHERE p.id = %(id)s
-         RETURNING receiving, npatrons
-        """, dict(id=self.id))
-        self.set_attributes(receiving=r.receiving, npatrons=r.npatrons)
-        if self.kind == 'group':
-            with self.db.get_cursor(cursor) as c:
+        with self.db.get_cursor(cursor) as c:
+            if self.kind == 'group':
+                c.run("LOCK TABLE takes IN EXCLUSIVE MODE")
+            r = c.one("""
+                WITH our_tips AS (
+                         SELECT amount
+                           FROM current_tips
+                          WHERE tippee = %(id)s
+                            AND amount > 0
+                            AND is_funded
+                     )
+                UPDATE participants p
+                   SET receiving = (COALESCE((
+                           SELECT sum(amount)
+                             FROM our_tips
+                       ), 0) + taking)
+                     , npatrons = COALESCE((SELECT count(*) FROM our_tips), 0)
+                 WHERE p.id = %(id)s
+             RETURNING receiving, npatrons
+            """, dict(id=self.id))
+            self.set_attributes(receiving=r.receiving, npatrons=r.npatrons)
+            if self.kind == 'group':
                 self.recompute_actual_takes(c)
 
 

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -168,6 +168,7 @@ class AppConf(object):
         twitter_callback=str,
         twitter_id=str,
         twitter_secret=str,
+        update_cached_amounts_every=int,
     )
 
     def __init__(self, d):

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -17,4 +17,10 @@ CREATE OR REPLACE VIEW current_takes AS
        ORDER BY member, team, mtime DESC
     ) AS anon WHERE amount IS NOT NULL;
 
+INSERT INTO app_conf VALUES ('update_cached_amounts_every', '86400'::jsonb);
+
 END;
+
+SELECT 'after deployment';
+
+ALTER TABLE takes ADD CONSTRAINT null_amounts_chk CHECK ((actual_amount IS NULL) = (amount IS NULL));

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,1 +1,20 @@
-ALTER TABLE participants ADD COLUMN nteampatrons int NOT NULL DEFAULT 0;
+BEGIN;
+
+ALTER TABLE takes
+    ADD COLUMN actual_amount numeric(35,2),
+    ADD COLUMN ntippers int;
+
+ALTER TABLE participants
+    ADD COLUMN nteampatrons int NOT NULL DEFAULT 0,
+    ADD COLUMN leftover numeric(35,2) NOT NULL DEFAULT 0 CHECK (leftover >= 0),
+    ADD CONSTRAINT receiving_chk CHECK (receiving >= 0),
+    ADD CONSTRAINT taking_chk CHECK (taking >= 0);
+
+CREATE OR REPLACE VIEW current_takes AS
+    SELECT * FROM (
+         SELECT DISTINCT ON (member, team) t.*
+           FROM takes t
+       ORDER BY member, team, mtime DESC
+    ) AS anon WHERE amount IS NOT NULL;
+
+END;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE participants ADD COLUMN nteampatrons int NOT NULL DEFAULT 0;

--- a/templates/profile-box.html
+++ b/templates/profile-box.html
@@ -30,7 +30,7 @@
     <div class="numbers">
         <dl>
             <dt>{{ _("Patrons") }}</dt>
-            <dd>{{ format_number(participant.npatrons) }}</dd>
+            <dd>{{ format_number(participant.npatrons + participant.nteampatrons) }}</dd>
         </dl>
         % if not participant.hide_receiving
         <dl>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -19,7 +19,7 @@
         <div class="col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
             <div class="flex-row space-between wrap">
                 % set username = participant.username
-                % set npatrons = Bold(participant.npatrons)
+                % set npatrons = Bold(participant.npatrons + participant.nteampatrons)
                 % set receiving = participant.receiving
                 % set goal = participant.goal
                 % set receiving_str = Bold(Money(receiving, 'EUR'))

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -101,15 +101,23 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             emma = Participant.from_username('emma')
             assert alice.giving == D('10.69')
             assert alice.receiving == D('5.00')
+            assert alice.npatrons == 1
+            assert alice.nteampatrons == 0
             assert bob.giving == D('7.00')
             assert bob.receiving == D('7.00')
             assert bob.taking == D('1.00')
+            assert bob.npatrons == 1
+            assert bob.nteampatrons == 1
             assert carl.giving == D('0.00')
             assert carl.receiving == D('0.00')
+            assert carl.npatrons == 0
+            assert carl.nteampatrons == 0
             assert dana.receiving == D('5.00')
             assert dana.npatrons == 2
+            assert dana.nteampatrons == 0
             assert emma.receiving == D('0.50')
             assert emma.npatrons == 1
+            assert emma.nteampatrons == 0
             funded_tips = self.db.all("SELECT amount FROM tips WHERE is_funded ORDER BY id")
             assert funded_tips == [3, 6, 0.5, D('1.20'), D('0.49'), 5, 2]
 
@@ -128,6 +136,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             assert janet.receiving == 0
             assert janet.taking == 0
             assert janet.npatrons == 0
+            assert janet.nteampatrons == 0
 
         # Pre-test check
         check()

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -116,10 +116,12 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
             team = Participant.from_username('team')
             assert team.receiving == D('1.20')
             assert team.npatrons == 1
+            assert team.leftover == D('0.20')
 
             team2 = Participant.from_username('team2')
             assert team2.receiving == D('0.49')
             assert team2.npatrons == 1
+            assert team2.leftover == D('0.49')
 
             janet = self.janet.refetch()
             assert janet.giving == 0


### PR DESCRIPTION
With #728 and #731 we are starting to show the number of patrons (donors) in addition to - or as a substitute for - the income. Unfortunately counting patrons is a little complicated in Liberapay because of teams. This branch creates a column named `nteampatrons` to complement the existing `npatrons` column, and uses it in the new profile boxes and headers.