### PR TITLE
Don't encourage to create an account if someone is already logged in

### DIFF
--- a/www/explore/individuals.spt
+++ b/www/explore/individuals.spt
@@ -45,9 +45,7 @@ subhead = _("Individuals")
 % endif
 
 % if user.ANON
-
 <p><a class="btn btn-success btn-lg" href="/sign-up">{{ _("Create your account") }}</a></p>
-
 % endif
 
 % endblock

--- a/www/explore/individuals.spt
+++ b/www/explore/individuals.spt
@@ -44,6 +44,10 @@ subhead = _("Individuals")
 <p>{{ _("Nothing to show.") }}</p>
 % endif
 
+% if user.ANON
+
 <p><a class="btn btn-success btn-lg" href="/sign-up">{{ _("Create your account") }}</a></p>
+
+% endif
 
 % endblock


### PR DESCRIPTION
The `explore/individuals` site is displaying the `Create your account` button even if someone is already logged in. This little tiny modification removes mentioned button if the user is logged in.