### PR TITLE
updated link to Snowdrift.coop market-research

### DIFF
--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -48,10 +48,10 @@ title = _("Frequently Asked Questions")
                  "approve it, and we won't kick you out unless you break the "
                  "law or the terms of service.") }}</li>
     </ol>
-    <p>{{ _("If you'd like more details, the snowdrift.coop folks have "
+    <p>{{ _("If you'd like more details, the Snowdrift.coop folks have "
             "compiled {0}a big list{1} of crowdfunding platforms and the "
             "differences between them.",
-            '<a href="https://snowdrift.coop/p/snowdrift/w/en/othercrowdfunding">'|safe,
+            '<a href="https://wiki.snowdrift.coop/market-research/other-crowdfunding">'|safe,
             '</a>'|safe) }}</p>
     </dd>
 


### PR DESCRIPTION
the old one redirects still, but this skips the redirect