### PR TITLE
 Add visibility of giving and receiving

### DIFF
--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -69,7 +69,14 @@ weekly = total - participant.receiving
         % endif
     </p>
 % else
-    <p>{{ _("You give {0} per week.", participant.giving) }}</p>
+    <p>
+        {{ _("You give {amount} per week ({link_open}{visibility}{link_close}).",
+            amount=participant.giving,
+            link_open='<a href="%s">'|safe % participant.path('settings'),
+            visibility=(_("hidden") if participant['hide_giving'] else _("public")),
+            link_close='</a>'|safe,
+        ) }}
+    </p>
 % endif
 
 % if not freeload and not Liberapay_tip.amount

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -51,6 +51,15 @@ weekly = total - participant.receiving
 
 % block content
 
+<p>
+    {{ _("You give {amount} per week ({link_open}{visibility}{link_close}).",
+        amount=participant.giving,
+        link_open='<a href="%s">'|safe % participant.path('settings'),
+        visibility=(_("hidden") if participant['hide_giving'] else _("public")),
+        link_close='</a>'|safe,
+    ) }}
+</p>
+
 % if weekly > 0
     % set funded = participant.balance // weekly
     <p class="{{ 'text-success' if funded > 3 else 'alert alert-warning' }}">
@@ -67,15 +76,6 @@ weekly = total - participant.receiving
                href="{{ participant.path('wallet/payin/'+b64encode_s(request.path.raw)) }}"
                >{{ _("Add money") }}</a>
         % endif
-    </p>
-% else
-    <p>
-        {{ _("You give {amount} per week ({link_open}{visibility}{link_close}).",
-            amount=participant.giving,
-            link_open='<a href="%s">'|safe % participant.path('settings'),
-            visibility=(_("hidden") if participant['hide_giving'] else _("public")),
-            link_close='</a>'|safe,
-        ) }}
     </p>
 % endif
 

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -55,7 +55,7 @@ weekly = total - participant.receiving
     {{ _("You give {amount} per week ({link_open}{visibility}{link_close}).",
         amount=participant.giving,
         link_open='<a href="%s">'|safe % participant.path('settings'),
-        visibility=(_("hidden") if participant['hide_giving'] else _("public")),
+        visibility=(_("secret") if participant['hide_giving'] else _("public")),
         link_close='</a>'|safe,
     ) }}
 </p>

--- a/www/%username/receiving/index.html.spt
+++ b/www/%username/receiving/index.html.spt
@@ -28,7 +28,7 @@ teams = website.db.all("""
     {{ _("You receive {amount} per week ({link_open}{visibility}{link_close}).",
         amount=receiving,
         link_open='<a href="%s">'|safe % participant.path('settings'),
-        visibility=(_("hidden") if participant['hide_receiving'] else _("public")),
+        visibility=(_("secret") if participant['hide_receiving'] else _("public")),
         link_close='</a>'|safe,
     ) }}
 </p>

--- a/www/%username/receiving/index.html.spt
+++ b/www/%username/receiving/index.html.spt
@@ -24,7 +24,14 @@ teams = website.db.all("""
 
 % set receiving = participant.receiving
 % if participant == user
-<p>{{ _("You receive {0} per week.", receiving) }}</p>
+<p>
+    {{ _("You receive {amount} per week ({link_open}{visibility}{link_close}).",
+        amount=receiving,
+        link_open='<a href="%s">'|safe % participant.path('settings'),
+        visibility=(_("hidden") if participant['hide_receiving'] else _("public")),
+        link_close='</a>'|safe,
+    ) }}
+</p>
 % else
 <p>{{ _("{0} receives {1} per week.", participant.username, receiving) }}</p>
 % endif


### PR DESCRIPTION
Related to https://github.com/liberapay/liberapay.com/issues/800.

This adds a link near the text `You give/receive {amount} per week` mentioning the visibility (`public` or `secret`), with a link to the settings page (to eventually change it).

---
![2017-11-20-153509_2560x1080_scrot](https://user-images.githubusercontent.com/3864879/33023508-b33b4a0c-ce08-11e7-9d9c-e0891afe25ff.png)

---
![2017-11-20-153605_2560x1080_scrot](https://user-images.githubusercontent.com/3864879/33023510-b3592478-ce08-11e7-9b89-f0ca26574efc.png)

---

This is my first actual contribution to liberapay, so please feel free to point out my mistakes or where I could improve the code (especially regarding how the translation should be handled)