### PR TITLE
Support unicode characters in emails

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -704,7 +704,7 @@ class Participant(Model, MixinTeam):
             Returns the number of emails sent.
         """
 
-        # normalize the address: strip it, lowercase the domain name, and
+        # normalize the address: strip it, then lowercase and encode the domain name
         email = email.strip()
         i = email.rfind('@') + 1
         email = email[:i] + email[i:].lower().encode('idna').decode()

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -704,10 +704,10 @@ class Participant(Model, MixinTeam):
             Returns the number of emails sent.
         """
 
-        # normalize the address: strip it, and lowercase the domain name
+        # normalize the address: strip it, lowercase the domain name, and
         email = email.strip()
-        i = email.rfind('@')
-        email = email[:i] + email[i:].lower()
+        i = email.rfind('@') + 1
+        email = email[:i] + email[i:].lower().encode('idna').decode()
 
         if not EMAIL_RE.match(email):
             raise BadEmailAddress(email)

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -48,9 +48,9 @@ class TestEmail(EmailHarness):
         response = self.hit_email_spt('add-email', 'alice@example.com')
         assert response.text == '{}'
 
-    def test_participant_can_add_email_with_special_chars(self):
-        punycode_email = 'alice@' + u'accentué.com'.encode('idna').decode()
-        self.hit_email_spt('add-email', u'alice@accentué.com')
+    def test_participant_can_add_email_with_unicode_domain_name(self):
+        punycode_email = 'alice@' + 'accentué.com'.encode('idna').decode()
+        self.hit_email_spt('add-email', 'alice@accentué.com')
         assert self.alice.get_any_email() == punycode_email
 
     def test_participant_cant_add_bad_email(self):
@@ -145,9 +145,9 @@ class TestEmail(EmailHarness):
         actual = Participant.from_username('alice').email
         assert expected == actual
 
-    def test_verify_email_special_chars(self):
-        punycode_email = 'alice@' + u'accentué.com'.encode('idna').decode()
-        self.hit_email_spt('add-email', u'alice@accentué.com')
+    def test_verify_email_with_unicode_domain(self):
+        punycode_email = 'alice@' + 'accentué.fr'.encode('idna').decode()
+        self.alice.add_email(punycode_email)
         nonce = self.alice.get_email(punycode_email).nonce
         self.hit_verify(punycode_email, nonce)
         actual = Participant.from_username('alice').email

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -53,6 +53,10 @@ class TestEmail(EmailHarness):
         self.hit_email_spt('add-email', 'alice@accentué.com')
         assert self.alice.get_any_email() == punycode_email
 
+    def test_participant_cannot_add_email_with_unicode_local_part(self):
+        r = self.hit_email_spt('add-email', 'tête@exemple.fr', should_fail=True)
+        assert r.code == 400
+
     def test_participant_cant_add_bad_email(self):
         bad = (
             'a\nb@example.net',


### PR DESCRIPTION
I saw that the previous regular expression was the same Mangopay's one, I don't know if the new one is still valid (I couldn't find the regular expression they are using to check emails).

Fixes #766