### PR TITLE
Clean up apt cache in Dockerfile to make the image lighter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:8
 
 RUN apt-get update && \
-    apt-get install -y build-essential wget libpq-dev libffi-dev python-dev postgresql-client
+    apt-get install -y build-essential wget libpq-dev libffi-dev python-dev postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && python /tmp/get-pip.py
 


### PR DESCRIPTION
Let's make the image smaller, no need to package the cache with it.