### PR TITLE
Change onclick method for income history visualization to disable the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 .tox/
 htmlcov/
 tests/py/fixtures/TestTranslations.yml
+.idea/ 
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -117,6 +117,7 @@ show_income = not participant.hide_receiving and participant.accepts_tips
         <script>
             $(function() {
                 $('[data-charts]').click(function() {
+                    this.disabled = true;
                     Liberapay.charts.load($(this).data('charts'), this);
                 });
             });


### PR DESCRIPTION
Resolving https://github.com/liberapay/liberapay.com/issues/822 by setting button to disabled onClick. I tested this manually locally by giving a team some number of transfers. This is what it looks like after click: 
<img width="577" alt="screen shot 2017-12-08 at 4 36 11 pm" src="https://user-images.githubusercontent.com/8812685/33786129-ece938b4-dc35-11e7-8966-d90400d1c586.png">
