### PR TITLE
Change Twitch OAuth scope to user_read

### DIFF
--- a/liberapay/elsewhere/twitch.py
+++ b/liberapay/elsewhere/twitch.py
@@ -39,7 +39,7 @@ class Twitch(PlatformOAuth2):
     # Auth attributes
     auth_url = 'https://api.twitch.tv/kraken/oauth2/authorize'
     access_token_url = 'https://api.twitch.tv/kraken/oauth2/token'
-    oauth_default_scope = ['channel_read']
+    oauth_default_scope = ['user_read']
     session_class = TwitchOAuthSession
 
     # API attributes


### PR DESCRIPTION
This still provides the email, without a scary warning or exposing the stream key.

Docs: https://dev.twitch.tv/docs/authentication#scopes

Fixes #836 

This is not tested since I don't feel like setting up a development environment complete with Twitch API key, but the change should be obvious enough.