### PR TITLE
Change amount inputs to type "number"

### DIFF
--- a/templates/your-tip.html
+++ b/templates/your-tip.html
@@ -29,7 +29,7 @@
     <div class="input-group">
         % set currency = tip.amount.currency
         <div class="input-group-addon">{{ locale.currency_symbols.get(currency, currency) }}</div>
-        <input type="text" name="amount" id="amount" placeholder="{{ _('Amount') }}"
+        <input type="number" name="amount" id="amount" placeholder="{{ _('Amount') }}"
                class="amount form-control {{ 'input-sm' if small else '' }}"
                value="{{ format_decimal(tip.periodic_amount.amount) if tip.periodic_amount and not hide_amount else '' }}"
                {{ disabled }} />

--- a/www/%username/edit.spt
+++ b/www/%username/edit.spt
@@ -156,7 +156,7 @@ title = _username
             <span>{{ GOAL_PARTS[0] }}</span>
             <div><div class="input-group">
                 <div class="input-group-addon">{{ locale.currency_symbols.get(currency, currency) }}</div>
-                <input type="text" name="goal_custom" id="goal-custom"
+                <input type="number" name="goal_custom" id="goal-custom"
                        class="amount form-control input-sm"
                        value="{{ format_decimal(participant.goal.amount) if participant.goal and participant.goal > 0 else '' }}" />
                 <div class="input-group-addon">{{ _("per week") }}</div>

--- a/www/%username/invoices/new.spt
+++ b/www/%username/invoices/new.spt
@@ -104,7 +104,7 @@ title = _("Invoice {someone}", someone=addressee.username)
 
     <h4>{{ _("Amount") }}</h4>
     <div class="input-group">
-        <input type="text" name="amount" class="amount form-control"
+        <input type="number" name="amount" class="amount form-control"
                placeholder="{{ _('Amount') }}" required
                value="{{ format_decimal(invoice.amount.amount) if invoice else '' }}" />
         <div class="input-group-addon">{{ locale.currency_symbols.get(currency, currency) }}</div>


### PR DESCRIPTION
Input fields that accept a numeric amount should use `type="number"` to enable devices with software keyboards to automatically display a number pad. This also prevents keyboard auto-insertion such as the addition of a space character after pressing `.` when entering decimals.

Using this attribute also introduces a "step" arrow within the input field on devices with pointers. By default, this increases the numeric value +1/-1 which is worth discussing if anyone feels this behavior is unwelcome.

Resolves #786.