### PR TITLE
Fix CSP parser

### DIFF
--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -77,11 +77,13 @@ class CSP(bytes):
 
     def __new__(cls, x):
         if isinstance(x, dict):
-            self = bytes.__new__(cls, b';'.join(b' '.join(t) for t in x.items()) + b';')
+            self = bytes.__new__(cls, b';'.join(b' '.join(t).rstrip() for t in x.items()) + b';')
             self.directives = dict(x)
         else:
             self = bytes.__new__(cls, x)
-            self.directives = dict(d.split(b' ', 1) for d in self.split(b';') if d)
+            self.directives = dict(
+                (d.split(b' ', 1) + [b''])[:2] for d in self.split(b';') if d
+            )
         return self
 
     def allow(self, directive, value):

--- a/tests/py/test_utils.py
+++ b/tests/py/test_utils.py
@@ -10,6 +10,7 @@ from pando.http.response import Response
 from liberapay import utils
 from liberapay.testing import Harness
 from liberapay.utils import i18n, markdown, b64encode_s, b64decode_s
+from liberapay.wireup import CSP
 
 
 class Tests(Harness):
@@ -198,3 +199,12 @@ class Tests(Harness):
 
     def test_b64decode_s_returns_default_if_passed_on_error(self):
         assert b64decode_s('abcd', default='error') == 'error'
+
+    # CSP
+    # ===
+
+    def test_csp_handles_valueless_directives_correctly(self):
+        csp = b"default-src 'self';upgrade-insecure-requests;"
+        csp2 = CSP(csp)
+        assert csp == csp2
+        assert csp2.directives[b'upgrade-insecure-requests'] == b''


### PR DESCRIPTION
Fixes the CSP class introduced in #947 to properly handle the valueless directive `upgrade-insecure-requests`.