### PR TITLE
Add a short privacy policy

### DIFF
--- a/www/about/legal.spt
+++ b/www/about/legal.spt
@@ -59,5 +59,9 @@ Amazon Data Services Ireland Ltd<br>Burlington Plaza, Burlington Road<br>Dublin 
 
 <ul>{{ MANGOPAY_TERMS }}</ul>
 
+<h3 id="privacy">{{ _("Privacy Policy") }}</h3>
+
+<p>{{ _("We do our best to protect everyone's privacy: we do not attempt to track people who visit our website, we strive to collect only the personal information we actually need, and we don't sell it to anyone.") }}</p>
+
 </div></div>
 % endblock


### PR DESCRIPTION
Closes #646. Once this is deployed I can fix our Facebook "app", which got deactivated because it doesn't have a privacy policy link.