### PR TITLE
Bolster handling of mangopay dispute callbacks

### DIFF
--- a/www/callbacks/mangopay.spt
+++ b/www/callbacks/mangopay.spt
@@ -64,7 +64,8 @@ elif event == 'DISPUTE':
         dispute = Dispute.get(RessourceId)
     except Dispute.DoesNotExist:
         raise response.error(400, "bad RessourceId: DoesNotExist")
-    status = dispute.Status
+    if status != dispute.Status:
+        raise response.error(400, "status mismatch")
     r = website.db.one("SELECT * FROM disputes WHERE id = %s", (RessourceId,))
     if r and r.status == status:
         raise response.success(200, "already done")
@@ -81,31 +82,31 @@ elif event == 'DISPUTE':
     dispute_amount = dispute.DisputedFunds / 100
     result_code = dispute.ResultCode
     new_dispute = not r
-    with website.db.get_cursor() as cursor:
-        r = cursor.one("""
-            INSERT INTO disputes
-                        (id, creation_date, type, amount, status, result_code, exchange_id, participant)
-                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (id) DO UPDATE
-                    SET status = excluded.status
-                      , result_code = excluded.result_code
-              RETURNING *
-        """, (dispute.Id, dispute.CreationDate, dispute_type, dispute_amount, status, result_code, e_id, p_id))
-        if status == 'CLOSED':
-            if result_code == 'LOST':
-                # Recover as much of the lost money as possible
-                recover_lost_funds(website.db, exchange, dispute_amount, dispute.RepudiationId)
-            else:
-                assert result_code == 'WON'
-                # Unlock the funds
-                cursor.run("""
-                    UPDATE cash_bundles
-                       SET disputed = false
-                     WHERE origin = %s
-                """, (e_id,))
-        else:
-            # Lock the disputed funds
+    if new_dispute:
+        # Lock the disputed funds
+        with website.db.get_cursor() as cursor:
             lock_disputed_funds(cursor, exchange, dispute_amount)
+    if status == 'CLOSED':
+        if result_code == 'LOST':
+            # Recover as much of the lost money as possible
+            recover_lost_funds(website.db, exchange, dispute_amount, dispute.RepudiationId)
+        else:
+            assert result_code == 'WON'
+            # Unlock the funds
+            website.db.run("""
+                UPDATE cash_bundles
+                   SET disputed = false
+                 WHERE origin = %s
+            """, (e_id,))
+    r = website.db.one("""
+        INSERT INTO disputes
+                    (id, creation_date, type, amount, status, result_code, exchange_id, participant)
+             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (id) DO UPDATE
+                SET status = excluded.status
+                  , result_code = excluded.result_code
+          RETURNING *
+    """, (dispute.Id, dispute.CreationDate, dispute_type, dispute_amount, status, result_code, e_id, p_id))
     # Notify admin
     disputed_funds = website.db.render("""
         SELECT owner, withdrawer, sum(amount) AS amount


### PR DESCRIPTION
They can arrive in the wrong order, and a non-contestable dispute can already be `CLOSED` when we receive the callback.