### PR TITLE
Fix various authentication-related issues

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -268,6 +268,7 @@ RATE_LIMITS = {
     'add_email.source': (5, 60*60*24),  # 5 per day
     'add_email.target': (2, 60*60*24),  # 2 per day
     'change_currency': (4, 60*60*24*7),  # 4 per week
+    'change_password': (7, 60*60*24*7),  # 7 per week
     'change_username': (7, 60*60*24*7),  # 7 per week
     'log-in.email': (10, 60*60*24),  # 10 per day
     'log-in.email.not-verified': (2, 60*60*24),  # 2 per day

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -297,3 +297,13 @@ class TooManyCurrencyChanges(LazyResponseXXX):
             "You've already changed your main currency recently, please retry "
             "later (e.g. in a week) or contact support@liberapay.com."
         )
+
+
+class TooManyAttempts(LazyResponseXXX):
+    code = 429
+    def msg(self, _):
+        return _(
+            "There have been too many attempts to perform this action recently, please "
+            "retry later (e.g. in a week) or contact support@liberapay.com if you "
+            "require assistance."
+        )

--- a/liberapay/security/authentication.py
+++ b/liberapay/security/authentication.py
@@ -70,7 +70,7 @@ def sign_in_with_form_data(body, state):
                 )
             elif p:
                 if not p.get_email(email).verified:
-                    website.db.hit_rate_limit('log-in.email.not-verified', TooManyLoginEmails)
+                    website.db.hit_rate_limit('log-in.email.not-verified', email, TooManyLoginEmails)
                 website.db.hit_rate_limit('log-in.email', p.id, TooManyLoginEmails)
                 p.start_session()
                 qs = {'log-in.id': p.id, 'log-in.token': p.session_token}

--- a/liberapay/security/authentication.py
+++ b/liberapay/security/authentication.py
@@ -47,7 +47,7 @@ def sign_in_with_form_data(body, state):
     _, website = state['_'], state['website']
 
     if body.get('log-in.id'):
-        id = body.pop('log-in.id')
+        id = body.pop('log-in.id').strip()
         password = body.pop('log-in.password', None)
         k = 'email' if '@' in id else 'username'
         if password:

--- a/style/base/utils.scss
+++ b/style/base/utils.scss
@@ -47,6 +47,11 @@
     margin: 10px 10px 10px 0;
 }
 
+.out-of-sight {
+    position: absolute;
+    left: -1000vw;
+}
+
 .space-between {
     justify-content: space-between;
 }

--- a/templates/password-form.html
+++ b/templates/password-form.html
@@ -8,6 +8,8 @@
 <form action="{{ user.path('settings/edit') }}" method="POST" class="form-inline">
     <input name="csrf_token" type="hidden" value="{{ csrf_token }}" />
     <input name="back_to" type="hidden" value="{{ user.path('settings/') }}" />
+    <input name="email" value="{{ user.email or user.get_any_email() }}"
+           aria-hidden="true" class="out-of-sight" tabindex="-1" />
     % if user.password and not (user.session_token or '').endswith('.em')
     <div class="form-group">
     <input type="password" name="cur-password" class="form-control"

--- a/www/%username/settings/edit.spt
+++ b/www/%username/settings/edit.spt
@@ -19,9 +19,10 @@ if 'new-password' in body:
     elif not p.password:
         pass  # user doesn't have a password yet, allow adding one
     else:
-        p = Participant.authenticate('username', 'password',
-                                     request.path['username'],
-                                     body['cur-password'])
+        p = Participant.authenticate(
+            'username', 'password', request.path['username'], body['cur-password'],
+            context='change_password'
+        )
         if not p:
             raise response.error(403, _("Incorrect password"))
     p.update_password(body['new-password'])


### PR DESCRIPTION
- fix rate limiting of email log-ins with an unverified address
- ignore spaces around email addresses received from the log-in form
- add a hidden `<input>` containing the user's email address to the password form, to help password managers detect that the password is for this identifier
- fix rate limiting of password changes
