### PR TITLE
Cache longer

### DIFF
--- a/www/%username/public.json.spt
+++ b/www/%username/public.json.spt
@@ -5,7 +5,7 @@ from liberapay.utils import get_participant
 participant = get_participant(state, restrict=False)
 response.headers[b"Access-Control-Allow-Origin"] = b"*"
 
-response.headers[b'Cache-Control'] = b'public, max-age=600'
+response.headers[b'Cache-Control'] = b'public, max-age=3600'
 
 [---] application/json via jsonp_dump
 participant.to_dict(details=True)

--- a/www/%username/widgets/%type.spt
+++ b/www/%username/widgets/%type.spt
@@ -24,7 +24,7 @@ if participant.hide_giving and t_is_giving or \
    participant.hide_receiving and not t_is_giving:
     raise response.error(403)
 
-response.headers[b'Cache-Control'] = b'public, max-age=600'
+response.headers[b'Cache-Control'] = b'public, max-age=3600'
 response.headers[b'Vary'] = b'Accept-Language'
 
 [---] application/javascript via jinja2_html_jswrapped


### PR DESCRIPTION
This branch increases the cache duration for the `public.json` endpoint and the JavaScript widgets, from 10 minutes to 1 hour.

We've been getting a lot of requests for <https://liberapay.com/Changaco/public.json> lately, which are probably all coming from <https://shields.io/>.