### PR TITLE
Fix small bugs in `Participant.set_tip_to()`

### DIFF
--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -21,6 +21,13 @@ class LazyResponse(Response):
         f = self.lazy_body
         self.body = f(*resolve_dependencies(f, state).as_args)
 
+    def render_in_english(self):
+        f = self.lazy_body
+        fake_state = {}
+        from liberapay.utils.i18n import LOCALE_EN, add_helpers_to_context
+        add_helpers_to_context(fake_state, LOCALE_EN)
+        return f(*resolve_dependencies(f, fake_state).as_args)
+
 
 class AuthRequired(LazyResponse):
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1763,16 +1763,12 @@ class Participant(Model, MixinTeam):
         if self.id == tippee.id:
             raise NoSelfTipping
 
-        amount = periodic_amount * PERIOD_CONVERSION_RATES[period]
+        amount = (periodic_amount * PERIOD_CONVERSION_RATES[period]).round_down()
 
         if periodic_amount != 0:
             limits = DONATION_LIMITS[periodic_amount.currency][period]
             if periodic_amount < limits[0] or periodic_amount > limits[1]:
                 raise BadAmount(periodic_amount, period, limits)
-
-        amount = amount.round_up()
-
-        if amount != 0:
             if not tippee.accepts_tips:
                 raise UserDoesntAcceptTips(tippee.username)
             if amount.currency not in tippee.accepted_currencies:

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1766,8 +1766,8 @@ class Participant(Model, MixinTeam):
         amount = periodic_amount * PERIOD_CONVERSION_RATES[period]
 
         if periodic_amount != 0:
-            limits = DONATION_LIMITS[amount.currency]['weekly']
-            if amount < limits[0] or amount > limits[1]:
+            limits = DONATION_LIMITS[periodic_amount.currency][period]
+            if periodic_amount < limits[0] or periodic_amount > limits[1]:
                 raise BadAmount(periodic_amount, period, limits)
 
         amount = amount.round_up()

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -287,17 +287,21 @@ class Tests(Harness):
         assert t['is_pledge'] is False
         assert t['first_time_tipper'] is True
 
-    def test_stt_works_for_monthly_donations(self):
-        alice = self.make_participant('alice', balance=EUR(100))
-        bob = self.make_participant('bob')
-        t = alice.set_tip_to(bob, EUR('4.33'), 'monthly')
-        assert t['amount'] == 1
+    def test_stt_converts_monthly_and_yearly_amounts_correctly(self):
+        alice = self.make_participant('alice')
+        bob = self.make_participant('bob', accepted_currencies='EUR,USD')
 
-    def test_stt_works_for_yearly_donations(self):
-        alice = self.make_participant('alice', balance=EUR(100))
-        bob = self.make_participant('bob')
-        t = alice.set_tip_to(bob, EUR('104'), 'yearly')
-        assert t['amount'] == 2
+        t = alice.set_tip_to(bob, EUR('0.05'), 'monthly')
+        assert t['amount'] == EUR('0.01')
+
+        t = alice.set_tip_to(bob, USD('433.34'), 'monthly')
+        assert t['amount'] == USD('100.00')
+
+        t = alice.set_tip_to(bob, USD('0.52'), 'yearly')
+        assert t['amount'] == USD('0.01')
+
+        t = alice.set_tip_to(bob, EUR('5200.00'), 'yearly')
+        assert t['amount'] == EUR('100.00')
 
     def test_stt_returns_False_for_second_time_tipper(self):
         alice = self.make_participant('alice', balance=EUR(100))


### PR DESCRIPTION
Fixes incorrect donation limits in error messages (reported in IRC this morning). Also fixes the rounding of monthly and yearly donation amounts (they were rounded up instead of down).