### PR TITLE
Improve currency selector for team takes

### DIFF
--- a/templates/team-members.html
+++ b/templates/team-members.html
@@ -43,7 +43,7 @@
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                         <div class="input-group">
                             % set take_currency = nominal_take.currency
-                            % set currencies = user.accepted_currencies
+                            % set currencies = set([take_currency, user.main_currency, team.main_currency])
                             % if len(currencies) > 1
                                 <div class="input-group-btn">
                                     <select class="btn btn-default" name="currency">


### PR DESCRIPTION
While writing the announcement for #1013 I realized that a detail of the implementation didn't make sense. The new commit restricts the choice of currencies to those accepted by both the member and the team.