### PR TITLE
Support Libravatar Federation

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function, unicode_literals
 
-from libravatar import libravatar_url
 from base64 import b64decode, b64encode
 from datetime import timedelta
 from email.utils import formataddr
@@ -14,6 +13,7 @@ from six.moves.urllib.parse import quote, urlencode
 import aspen_jinja2_renderer
 from cached_property import cached_property
 from html2text import html2text
+from libravatar import libravatar_url
 import mangopay
 from mangopay.utils import Money
 from markupsafe import escape as htmlescape

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1567,7 +1567,7 @@ class Participant(Model, MixinTeam):
         if platform == 'libravatar' or platform is None and email:
             if not email:
                 return
-            avatar_url = libravatar_url(email)
+            avatar_url = libravatar_url(email, https=True)
             avatar_url += AVATAR_QUERY
 
         elif platform is None:

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function, unicode_literals
 
+from libravatar import libravatar_url
 from base64 import b64decode, b64encode
 from datetime import timedelta
 from email.utils import formataddr
@@ -1566,8 +1567,7 @@ class Participant(Model, MixinTeam):
         if platform == 'libravatar' or platform is None and email:
             if not email:
                 return
-            avatar_id = md5(email.strip().lower().encode('utf8')).hexdigest()
-            avatar_url = 'https://seccdn.libravatar.org/avatar/'+avatar_id
+            avatar_url = libravatar_url(email)
             avatar_url += AVATAR_QUERY
 
         elif platform is None:

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -4,7 +4,7 @@ from libravatar import libravatar_url
 from base64 import b64decode, b64encode
 from datetime import timedelta
 from email.utils import formataddr
-from hashlib import pbkdf2_hmac, md5, sha1
+from hashlib import pbkdf2_hmac, sha1
 from os import urandom
 from time import sleep
 import uuid

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -173,3 +173,10 @@ ipaddress==1.0.18 \
 cached-property==1.3.1 \
     --hash=sha256:6562f0be134957547421dda11640e8cadfa7c23238fc4e0821ab69efdb1095f3 \
     --hash=sha256:fe045921fe75c873064028e9fbbe06121114ccf613227f4ba284fa7d4c9ff27f
+
+pyLibravatar==1.7 \
+    --hash=sha256:f239caae2aed0e2dcdd695ffcde4572958c001b4bdc464a9291d1b0cae0caa8d
+pydns==2.3.6 \
+    --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62
+py3dns==3.1.1 \
+    --hash=sha256:bfea628ea61becb79ef83616069957fd5b49058115e347ca7b77c72053af187c

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -178,5 +178,5 @@ pyLibravatar==1.7 \
     --hash=sha256:f239caae2aed0e2dcdd695ffcde4572958c001b4bdc464a9291d1b0cae0caa8d
 pydns==2.3.6 \
     --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62; python_version < '3.0'
-py3dns==3.1.1 \
+py3dns==3.1.0 \
     --hash=sha256:bfea628ea61becb79ef83616069957fd5b49058115e347ca7b77c72053af187c; python_version >= '3.0'

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -176,7 +176,7 @@ cached-property==1.3.1 \
 
 pyLibravatar==1.7 \
     --hash=sha256:f239caae2aed0e2dcdd695ffcde4572958c001b4bdc464a9291d1b0cae0caa8d
-pydns==2.3.6 \
-    --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62; python_version < '3.0'
-py3dns==3.1.0 \
-    --hash=sha256:124d7833fd0a6fbaebe17d093b028cfa77b155b5feab8e1c6265959a4b9e7fb7; python_version >= '3.0'
+pydns==2.3.6; python_version < '3.0' \
+    --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62
+py3dns==3.1.0; python_version >= '3.0' \
+    --hash=sha256:124d7833fd0a6fbaebe17d093b028cfa77b155b5feab8e1c6265959a4b9e7fb7

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -177,6 +177,6 @@ cached-property==1.3.1 \
 pyLibravatar==1.7 \
     --hash=sha256:f239caae2aed0e2dcdd695ffcde4572958c001b4bdc464a9291d1b0cae0caa8d
 pydns==2.3.6 \
-    --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62
+    --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62; python_version < '3.0'
 py3dns==3.1.1 \
-    --hash=sha256:bfea628ea61becb79ef83616069957fd5b49058115e347ca7b77c72053af187c
+    --hash=sha256:bfea628ea61becb79ef83616069957fd5b49058115e347ca7b77c72053af187c; python_version >= '3.0'

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -179,4 +179,4 @@ pyLibravatar==1.7 \
 pydns==2.3.6 \
     --hash=sha256:f1960d8bff0aafad9252b9e80279748fe7ebe5e719487d132ccb1281523cdb62; python_version < '3.0'
 py3dns==3.1.0 \
-    --hash=sha256:bfea628ea61becb79ef83616069957fd5b49058115e347ca7b77c72053af187c; python_version >= '3.0'
+    --hash=sha256:124d7833fd0a6fbaebe17d093b028cfa77b155b5feab8e1c6265959a4b9e7fb7; python_version >= '3.0'


### PR DESCRIPTION
By using pyLibravatar this PR allows Liberapay to support Libravatar federation.

I had no time for cloning the repo, so I did the changes online using the GitHub editor.

I tested this locally on my notebook, there Python hangs while doing the required DNS request, b/c no TCP DNS is available.
I also tested it on my Webspace, there it works.