### PR TITLE
Fix the SQL query of the `low_balance` notification

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -922,7 +922,7 @@ class Payday(object):
                      SELECT t.tipper, sum(t.amount) AS needed
                        FROM current_tips t
                        JOIN participants p2 ON p2.id = t.tippee
-                      WHERE p2.mangopay_user_id IS NOT NULL
+                      WHERE (p2.mangopay_user_id IS NOT NULL OR p2.kind = 'group')
                         AND p2.status = 'active'
                         AND p2.is_suspended IS NOT true
                    GROUP BY t.tipper, t.amount::currency


### PR DESCRIPTION
The current version doesn't count donations to teams.

Thanks to the user who reported this issue in an email to support@.