### PR TITLE
[WIP] add link to translation platform to language choice menu

### DIFF
--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -14,7 +14,7 @@
             ><a href="{{ l_url }}{{ request.line.uri }}" rel="alternate" hreflang="{{ l_code }}"
                 >{{ _("{0}", l_name) }}</a
             >{% if l_completion <= 99 %}<a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
-                 ><small>{{ _(" ({0} complete)", format_percent(l_completion)) }}</small></a>{% endif %}</li>
+                 ><span style="float:right><small>{{ _(" ({0} complete)", format_percent(l_completion)) }}</small></span></a>{% endif %}</li>
     % endfor
         <li role="separator" class="divider"></li>
         <li><a href="https://hosted.weblate.org/engage/liberapay/?utm_source=liberapay-navbar"

--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -14,7 +14,7 @@
             ><a href="{{ l_url }}{{ request.line.uri }}" rel="alternate" hreflang="{{ l_code }}"
                 >{{ _("{0}", l_name) }}</a
             ><a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
-                 >{{ _(" ({1} complete)", format_percent(l_completion)) }}</a></li>
+                 >{{ _(" ({0} complete)", format_percent(l_completion)) }}</a></li>
     % endfor
         <li role="separator" class="divider"></li>
         <li><a href="https://hosted.weblate.org/engage/liberapay/?utm_source=liberapay-navbar"

--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -12,7 +12,9 @@
     % for l_completion, l_code, l_name, l_url in website.lang_list
         <li {% if l_code == locale.language %} class="active" {% endif %}
             ><a href="{{ l_url }}{{ request.line.uri }}" rel="alternate" hreflang="{{ l_code }}"
-                >{{ _("{0} ({1} complete)", l_name, format_percent(l_completion)) }}</a></li>
+                >{{ _("{0}", l_name) }}</a
+            ><a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
+                 >{{ _(" ({1} complete)", format_percent(l_completion)) }}</a></li>
     % endfor
         <li role="separator" class="divider"></li>
         <li><a href="https://hosted.weblate.org/engage/liberapay/?utm_source=liberapay-navbar"

--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -13,8 +13,8 @@
         <li {% if l_code == locale.language %} class="active" {% endif %}
             ><a href="{{ l_url }}{{ request.line.uri }}" rel="alternate" hreflang="{{ l_code }}"
                 >{{ _("{0}", l_name) }}</a
-            ><a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
-                 >{{ _(" ({0} complete)", format_percent(l_completion)) }}</a></li>
+            >{% if l_completion <= 99 %}<a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
+                 >{{ _(" ({0} complete)", format_percent(l_completion)) }}</a>{% endif %}</li>
     % endfor
         <li role="separator" class="divider"></li>
         <li><a href="https://hosted.weblate.org/engage/liberapay/?utm_source=liberapay-navbar"

--- a/templates/navbar-common.html
+++ b/templates/navbar-common.html
@@ -14,7 +14,7 @@
             ><a href="{{ l_url }}{{ request.line.uri }}" rel="alternate" hreflang="{{ l_code }}"
                 >{{ _("{0}", l_name) }}</a
             >{% if l_completion <= 99 %}<a href="https://hosted.weblate.org/languages/{{ l_code }}/liberapay/"
-                 >{{ _(" ({0} complete)", format_percent(l_completion)) }}</a>{% endif %}</li>
+                 ><small>{{ _(" ({0} complete)", format_percent(l_completion)) }}</small></a>{% endif %}</li>
     % endfor
         <li role="separator" class="divider"></li>
         <li><a href="https://hosted.weblate.org/engage/liberapay/?utm_source=liberapay-navbar"


### PR DESCRIPTION
First step towards #1070

Language selection menu should change from:

![image](https://user-images.githubusercontent.com/6146483/38760471-bad5b236-3f7b-11e8-99c4-0c0c3717f9f5.png)

to
![image](https://user-images.githubusercontent.com/6146483/38760667-41d4fe3a-3f7d-11e8-91da-5b3e112a3e31.png)


- [x] display translation coverage percentage only when <= 99%
- [x] display translation coverage percentage in smaller size
- [x] display translation coverage percentage aligned on the right
