### PR TITLE
Fix language error 

### DIFF
--- a/emails/income.spt
+++ b/emails/income.spt
@@ -5,7 +5,7 @@
 % endif
 
 [---] text/html
-<p>{{ _("{0} were given to you personally.", LegacyMoney(personal)) }}</p>
+<p>{{ _("{0} was given to you personally.", LegacyMoney(personal)) }}</p>
 
 % if not by_team
     % set teams = participant.get_teams()
@@ -18,9 +18,9 @@
     % endif
 % elif len(by_team) == 1
     % set team, amount = list(by_team.items())[0]
-    <p>{{ _("{0} were given to you for your role in the {1} team.", LegacyMoney(amount), team) }}</p>
+    <p>{{ _("{0} was given to you for your role in the {1} team.", LegacyMoney(amount), team) }}</p>
 % else
-    <p>{{ _("{0} were given to you for your roles in the following teams:", LegacyMoney(sum(by_team.values()))) }}</p>
+    <p>{{ _("{0} was given to you for your roles in the following teams:", LegacyMoney(sum(by_team.values()))) }}</p>
     <ul>
     % for team, amount in by_team.items()
         <li>{{ _("{0}: {1}", team, LegacyMoney(amount)) }}</li>
@@ -33,7 +33,7 @@
 <p><a href="{{ participant.url('wallet/') }}">{{ _("See your account's transaction logs") }}</a></p>
 
 [---] text/plain
-{{ _("{0} were given to you personally.", LegacyMoney(personal)) }}
+{{ _("{0} was given to you personally.", LegacyMoney(personal)) }}
 
 % if not by_team
     % set teams = participant.get_teams()
@@ -46,9 +46,9 @@
     % endif
 % elif len(by_team) == 1
     % set team, amount = list(by_team.items())[0]
-    {{- _("{0} were given to you for your role in the {1} team.", LegacyMoney(amount), team) }}
+    {{- _("{0} was given to you for your role in the {1} team.", LegacyMoney(amount), team) }}
 % else
-    {{- _("{0} were given to you for your roles in the following teams:", LegacyMoney(sum(by_team.values()))) }}
+    {{- _("{0} was given to you for your roles in the following teams:", LegacyMoney(sum(by_team.values()))) }}
     % for team, amount in by_team.items()
         {{- _("- {0}: {1}", team, LegacyMoney(amount)) }}
     % endfor

--- a/i18n/core/ca.po
+++ b/i18n/core/ca.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Aquesta setmana heu rebut {0}"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} us els van donar personalment."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "No heu rebut diners per la participació en l'equip {0}."
 msgstr[1] "No heu rebut diners per la participació en els {n} dels que sou membre."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Heu rebut {0} per la participació en l'equip {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Heu rebut {0} per la participació en els equips següents:"
 
 #, python-brace-format

--- a/i18n/core/cs.po
+++ b/i18n/core/cs.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Tento týden jste dostal(a) {0}"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} bylo dáno vám osobně."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] "Nezískal(a) jste žádné příspěvky za členství ve {n} týmech.
 msgstr[2] "Nezískal(a) jste žádné příspěvky za členství v {n} týmech."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} jste získal(a) za členství v týmu {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} jste získal(a) za členství v následujících týmech:"
 
 #, python-brace-format

--- a/i18n/core/da.po
+++ b/i18n/core/da.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Du har modtaget {0} denne uge"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} blev givet til dig personligt."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Ingen penge blev givet til dig for din rolle i det {0} team."
 msgstr[1] "Ingen penge blev givet til dig for din rolle i de {n} teams som du er medlem af."
 
 #, fuzzy, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} blev givet til dig for din rolle i {1}-teamet."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} blev givet til dig for din rolle i de følgende teams:"
 
 #, python-brace-format

--- a/i18n/core/de.po
+++ b/i18n/core/de.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Sie haben {0} in dieser Woche bekommen"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} wurden Ihnen persönlich gespendet."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[0] "Ihnen wurde kein Geld für ihre Funktion im {0} Team gegeben."
 msgstr[1] "Ihnen wurde kein Geld für ihre Funktionen in den {n} Teams gespendet, in denen sie Mitglied sind."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Sie haben {0} für Ihre Rolle im Team {1} erhalten."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Sie haben {0} für Ihre Rolle in folgenden Teams erhalten:"
 
 #, python-brace-format

--- a/i18n/core/el.po
+++ b/i18n/core/el.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Λάβατε {0} αυτή τη βδομάδα"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} δόθηκαν σε εσάς προσωπικά."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[0] "Δε δόθηκαν καθόλου λεφτά σε σένα για τ
 msgstr[1] "Δε δόθηκαν καθόλου λεφτά σε σένα για το ρόλο σου στις ομάδες {n} στις οποίες είσαι μέλος."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} δόθηκαν σε σένα για το ρόλο σου στην ομάδα {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} δόθηκαν σε σένα για τους ρόλους σου στις ακόλουθες ομάδες:"
 
 #, python-brace-format

--- a/i18n/core/eo.po
+++ b/i18n/core/eo.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Vi ricevis {0} ĉi-semajne"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} estis donita al vi persone."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[0] "Neniu mono donita al vi por via rolo en la {0} teamo."
 msgstr[1] "Neniu mono estis donita al vi kiel roloj en la {n} teamoj vi estas membro de."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} estis donitaj al vi por via rolo en la {1} teamo."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} estis donitaj al vi por viaj roloj en la sekvaj teamoj:"
 
 #, python-brace-format

--- a/i18n/core/es.po
+++ b/i18n/core/es.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Has recibido {0} esta semana"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} te fueron otorgados personalmente."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "No has recibido dinero por tu papel en el equipo {0}."
 msgstr[1] "No has recibido dinero por tu papel en los {n} equipos de los que eres miembro."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Has recibido {0} por tu papel en el equipo {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Has recibido {0} por tu papel en los equipos siguientes:"
 
 #, python-brace-format

--- a/i18n/core/et.po
+++ b/i18n/core/et.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/fi.po
+++ b/i18n/core/fi.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Olet saanut tällä viikolla {0}"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "Olet saanut {0} henkilökohtaisia lahjoituksia."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[0] "Et ole saanut rahaa liittyen rooliisi {0} ryhmässä."
 msgstr[1] "Et ole saanut rahaa liittyen rooleihisi {n} ryhmässä."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Olet saanut {0} roolistasi ryhmässä {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Olet saanut {0} rooleistasi seuraavissa ryhmissä:"
 
 #, python-brace-format

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Vous avez reçu {0} cette semaine"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "Vous avez personnellement reçu {0}."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Vous n'avez pas reçu d'argent pour votre participation dans l'équip
 msgstr[1] "Vous n'avez pas reçu d'argent pour votre participation dans les {n} équipes dont vous faites partie."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Vous avez reçu {0} pour votre rôle dans l'équipe {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Vous avez reçu {0} pour vos rôles dans les équipes suivantes :"
 
 #, python-brace-format

--- a/i18n/core/fy.po
+++ b/i18n/core/fy.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/ga.po
+++ b/i18n/core/ga.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] ""
 msgstr[2] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/hu.po
+++ b/i18n/core/hu.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Ezen a héten {0} összegű adomány érkezett"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} összeget adományoztak Önnek személyesen."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgid_plural "No money was given to you for your roles in the {n} teams you are 
 msgstr[0] "Nem kapott pénzt a(z) {n} csapatban betöltött szerepéért."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} összeget kapott a(z) {1} csapatban betöltött szerepéért."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} összeget kapott a szerepeiért a következő csapatokban:"
 
 #, python-brace-format

--- a/i18n/core/id.po
+++ b/i18n/core/id.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Anda telah menerima {0} minggu ini"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} diberikan kepada anda secara pribadi."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -48,11 +48,11 @@ msgid_plural "No money was given to you for your roles in the {n} teams you are 
 msgstr[0] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} diberikan kepada anda untuk peran anda di {1} tim."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} diberikan kepada anda untuk peran anda dalam tim berikut:"
 
 #, python-brace-format

--- a/i18n/core/it.po
+++ b/i18n/core/it.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Hai ricevuto {0} questa settimana"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} sono stati donati direttamente a te."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Non hai ricevuto denaro per il tuo ruolo nella squadra {0}."
 msgstr[1] "Non hai ricevuto denaro per il tuo ruolo nelle {n} squadre di cui fai parte."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Ti sono stati dati {0} per il tuo ruolo nella squadra {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Ti sono stati dati {0} per i tuoi ruoli nelle seguenti squadre:"
 
 #, python-brace-format

--- a/i18n/core/ja.po
+++ b/i18n/core/ja.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "あなたは今週{0}を受け取りました"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0}は個人的に与えられました。"
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -48,11 +48,11 @@ msgid_plural "No money was given to you for your roles in the {n} teams you are 
 msgstr[0] "あなたは{n}チーム中からお金は受けなかった。"
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0}は{1}チームのロールを割り当てられました。"
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0}は以下のチームであなたのロールを割り当てました:"
 
 #, python-brace-format

--- a/i18n/core/ko.po
+++ b/i18n/core/ko.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "이 주에 {0}을 얻었습니다"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} 이(가) 개인적으로 지급되었습니다."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -48,11 +48,11 @@ msgid_plural "No money was given to you for your roles in the {n} teams you are 
 msgstr[0] "{n} 팀에서의 역할에 대해 지급된 돈이 없습니다."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{1} 팀에서 {0} 이 지급되었습니다."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} 이(가) 팀에서의 비율에 따라 지급되었습니다:"
 
 #, python-brace-format

--- a/i18n/core/lt.po
+++ b/i18n/core/lt.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Šią savaitę gavote {0}"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} buvo jums suteikta asmeniškai."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] "Jums nebuvo suteikta pinigų už jūsų vaidmenis {n} komandose, kuri
 msgstr[2] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} buvo jums suteikta už jūsų vaidmenį {1} komandoje."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} jums buvo suteikta už jūsų vaidmenis šiose komandose:"
 
 #, python-brace-format

--- a/i18n/core/lv.po
+++ b/i18n/core/lv.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] ""
 msgstr[2] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/ms.po
+++ b/i18n/core/ms.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Anda telah menerima {0} minggu ini"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} telah diberikan kepada anda secara peribadi."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Tiada wang diberikan kepada anda untuk peranan anda dalam kumpulan {0
 msgstr[1] "Tiada wang diberikan kepada anda untuk peranan anda dalam kumpulan {n} yang anda menjadi ahlinya."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} telah diberikan kepada anda untuk peranan anda dalam kumpulan {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} telah diberikan kepada anda untuk peranan dalam kumpulan berikut:"
 
 #, python-brace-format

--- a/i18n/core/nb.po
+++ b/i18n/core/nb.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Du har mottatt {0} denne uken"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} ble gitt til deg personlig."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Du ble ikke tildelt noen penger for deltagelsen din i {0}-laget."
 msgstr[1] "Du ble ikke tildelt noen penger for deltagelsen din i {n}-laget."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} ble tildelt deg for din rolle i {1}-laget."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Du har fått {0} for din rolle i følgende lag:"
 
 #, python-brace-format

--- a/i18n/core/nl.po
+++ b/i18n/core/nl.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "Je hebt deze week {0} gekregen"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} werd persoonlijk aan je gegeven."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[0] "Je hebt geen geld ontvangen voor je rol in het {0} team."
 msgstr[1] "Je hebt geen geld ontvangen voor je rol in de {n} teams."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} werd aan je gegeven voor je rol in het {1} team."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} werd aan je gegeven voor je rol in de volgende teams:"
 
 #, python-brace-format

--- a/i18n/core/pl.po
+++ b/i18n/core/pl.po
@@ -37,7 +37,7 @@ msgid "You have received {0} this week"
 msgstr "W tym tygodniu otrzymałeś {0}"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} zostało przekazane bezpośrednio Tobie."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -51,11 +51,11 @@ msgstr[1] "Nie otrzymałeś żadnych pieniędzy za twój wkład w {n} zespołach
 msgstr[2] "Nie otrzymałeś żadnych pieniędzy za twój wkład w {n} zespołach, do których należysz."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} zostało Ci przekazane za Twój wkład w zespół {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Otrzymałeś {0} za role w następujących zespołach:"
 
 #, python-brace-format

--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Recebeu {0} esta semana"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} foram-lhe dadas pessoalmente."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Não lhe foi dado dinheiro pelo seu papel na equipa {0}."
 msgstr[1] "Não lhe foi dado dinheiro pelo seu papel nas {n} equipas das quais é membro."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Foi-lhe dado {0} pelo seu papel na equipa {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Foi-lhe dado {0} pelo seu papel nas seguintes equipas:"
 
 #, python-brace-format

--- a/i18n/core/ro.po
+++ b/i18n/core/ro.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Ați primit {0} această săptămână"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} vi s-au oferit personal."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] "Nu vi s-a oferit niciun ban pentru rolurile din cele {n} echipe în c
 msgstr[2] "Nu vi s-a oferit niciun ban pentru rolurile din cele {n} de echipe în care sunteți membru."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} vi s-au oferit pentru rolul dumneavoastră în echipa {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} vi s-au oferit pentru rolurile dumneavoastră în următoarele echipe:"
 
 #, python-brace-format

--- a/i18n/core/ru.po
+++ b/i18n/core/ru.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Вы получили {0} за эту неделю"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "Вам лично перечислили {0}."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] "Вы не получили денег за вашу роль в {n} �
 msgstr[2] "Вы не получили денег за вашу роль в {n} командах, в которых вы состоите."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Вы получили {0} за вашу роль в команде {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Вы получили {0} за ваши роли в следующих командах:"
 
 #, python-brace-format

--- a/i18n/core/sk.po
+++ b/i18n/core/sk.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] ""
 msgstr[2] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/sl.po
+++ b/i18n/core/sl.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr ""
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -51,11 +51,11 @@ msgstr[2] ""
 msgstr[3] ""
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr ""
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr ""
 
 #, python-brace-format

--- a/i18n/core/sv.po
+++ b/i18n/core/sv.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Du har mottagit {0} denna vecka"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0} blev givet till dig personligen."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Inga pengar gavs till dig för din roll i {0} team."
 msgstr[1] "Inga pengar gavs till dig för din roll i de {n} teams du är medlem i."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} gavs till dig för din roll i {1} team."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0} gavs till dig för dina roller i de följande teamen:"
 
 #, python-brace-format

--- a/i18n/core/tr.po
+++ b/i18n/core/tr.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Bu hafta {0} alındı"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "Şahsen {0} size verildi"
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -49,11 +49,11 @@ msgstr[0] "Size {0} takımdaki rolünüz için hiç para verilmemişti."
 msgstr[1] "Size üyesi olduğunuz {n} takımdaki rolleriniz için hiç para verilmemişti."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "{0} size, {1} takımındaki rolünüz için verilmişti."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Şu takımlardaki rolleriniz için size {0} verilmişti:"
 
 #, python-brace-format

--- a/i18n/core/uk.po
+++ b/i18n/core/uk.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "Ви отримали {0} за цей тиждень"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "Вам особисто нарахували {0}."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -50,11 +50,11 @@ msgstr[1] "Ви не отримали гроші за вашу роль в {n} �
 msgstr[2] "Ви не отримали гроші за вашу роль в {n} командах, в яких ви перебуваєте."
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "Ви отримали {0} за вашу роль в команді {1}."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "Ви отримали {0} за ваші ролі в наступних командах:"
 
 #, python-brace-format

--- a/i18n/core/zh.po
+++ b/i18n/core/zh.po
@@ -36,7 +36,7 @@ msgid "You have received {0} this week"
 msgstr "您本周已收到{0}个"
 
 #, python-brace-format
-msgid "{0} were given to you personally."
+msgid "{0} was given to you personally."
 msgstr "{0}是指定给你的."
 
 msgid "You are not a member of any team, so you haven't received any money for participation in teams."
@@ -48,11 +48,11 @@ msgid_plural "No money was given to you for your roles in the {n} teams you are 
 msgstr[0] "在您加入的{n}个团队中，您没有获得任何款项。"
 
 #, python-brace-format
-msgid "{0} were given to you for your role in the {1} team."
+msgid "{0} was given to you for your role in the {1} team."
 msgstr "在{1}团队中，{0}已经被授予您的角色."
 
 #, python-brace-format
-msgid "{0} were given to you for your roles in the following teams:"
+msgid "{0} was given to you for your roles in the following teams:"
 msgstr "{0}给了你以下团队的角色："
 
 #, python-brace-format


### PR DESCRIPTION
fixes #950

I executed 
```find . -name *.po -exec sed -i 's/were given/was given/g' {} \;``` 
to update the language catalogs and did the same for the `emails/income.spt` file.

I don't think any translator mistakenly translated the sentence, I hope all of them wisely used singular or plural according to the rules of their languages. At least in the languages I know, no error was made, so I don't think we should mark it as fuzzy.