### PR TITLE
Fix modifying validated level 2 identity information

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -78,7 +78,15 @@ Liberapay.forms.jsSubmit = function() {
 };
 
 Liberapay.forms.success = function($form, $inputs, button) { return function(data) {
-    $inputs.prop('disabled', false).filter('[type=password]').val('');
+    $inputs.prop('disabled', false);
+    if (data.confirm) {
+        if (window.confirm(data.confirm)) {
+            $form.append('<input type="hidden" name="confirmed" value="true" />');
+            $form.submit();
+        }
+        return;
+    }
+    $inputs.filter('[type=password]').val('');
     var on_success = $form.data('on-success');
     if (on_success && on_success.substr(0, 8) == 'fadeOut:') {
         var $e = $(button).parents(on_success.substr(8)).eq(0);

--- a/js/identity-docs.js
+++ b/js/identity-docs.js
@@ -90,9 +90,9 @@ Liberapay.identity_docs_init = function () {
         });
     }
 
-    function submit(e) {
+    function submit(e, confirmed) {
         e.preventDefault();
-        if (form.reportValidity && form.reportValidity() == false) return;
+        if (!confirmed && form.reportValidity && form.reportValidity() == false) return;
         var data = $form.serializeArray();
         $inputs.prop('disabled', true);
         jQuery.ajax({
@@ -100,7 +100,15 @@ Liberapay.identity_docs_init = function () {
             type: 'POST',
             data: data,
             dataType: 'json',
-            success: function () {
+            success: function (data) {
+                $inputs.prop('disabled', false);
+                if (data.confirm) {
+                    if (window.confirm(data.confirm)) {
+                        $form.append('<input type="hidden" name="confirmed" value="true" />');
+                        return submit(e, true);
+                    };
+                    return;
+                }
                 var count = 0;
                 $.each(uploaders, function (i, uploader) {
                     console.log(uploader);

--- a/templates/confirm.spt
+++ b/templates/confirm.spt
@@ -12,3 +12,6 @@
         <button class="btn btn-{{ cls }}">{{ _("Confirm") }}</button>
     </form>
 % endblock
+
+[---] application/json
+{"confirm": msg}


### PR DESCRIPTION
We ask the user to confirm this kind of modification, but the JS code didn't support asking for confirmation.