### PR TITLE
Update tests.yml for postgresql 9.4 to 9.6

### DIFF
--- a/docker/tests.yml
+++ b/docker/tests.yml
@@ -9,4 +9,4 @@ services:
         links:
             - test_db
     test_db:
-        image: postgres:9.4
+        image: postgres:9.6


### PR DESCRIPTION
* Tests passing using `docker-compose -f docker/tests.yml run tests`
  cmd in readme now without having to pull the old 9.4 image down.