### PR TITLE
Improve account closing

### DIFF
--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -25,7 +25,7 @@ from liberapay.billing.transactions import check_all_balances
 from liberapay.cron import Cron, Daily, Weekly
 from liberapay.models.account_elsewhere import refetch_elsewhere_data
 from liberapay.models.community import Community
-from liberapay.models.participant import Participant
+from liberapay.models.participant import Participant, clean_up_closed_accounts
 from liberapay.models.repository import refetch_repos
 from liberapay.security import authentication, csrf, set_default_security_headers
 from liberapay.utils import b64decode_s, b64encode_s, erase_cookie, http_caching, i18n, set_cookie
@@ -112,6 +112,7 @@ if conf:
     cron(conf.clean_up_counters_every, website.db.clean_up_counters, True)
     cron(Daily(hour=16), lambda: fetch_currency_exchange_rates(website.db), True)
     cron(Daily(hour=17), Payday.update_cached_amounts, True)
+    cron(Daily(hour=8), clean_up_closed_accounts, True)
 
 
 # Website Algorithm

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -721,7 +721,7 @@ class Participant(Model, MixinTeam):
              WHERE id=%(id)s
          RETURNING *;
 
-        """, dict(id=self.id, email=self.email))
+        """, dict(id=self.id, email=self.email or self.get_any_email()))
         self.set_attributes(**r._asdict())
         self.add_event(self.db, 'erase_personal_information', None)
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1799,15 +1799,15 @@ class Participant(Model, MixinTeam):
         giving = (cursor or self.db).one("""
             UPDATE participants p
                SET giving = coalesce_currency_amount((
-                     SELECT sum(amount, %(currency)s)
-                       FROM current_tips
-                       JOIN participants p2 ON p2.id = tippee
-                      WHERE tipper = %(id)s
+                     SELECT sum(t.amount, %(currency)s)
+                       FROM current_tips t
+                       JOIN participants p2 ON p2.id = t.tippee
+                      WHERE t.tipper = %(id)s
                         AND p2.status = 'active'
                         AND (p2.goal IS NULL OR p2.goal >= 0)
-                        AND (p2.mangopay_user_id IS NOT NULL OR kind = 'group')
-                        AND amount > 0
-                        AND is_funded
+                        AND (p2.mangopay_user_id IS NOT NULL OR p2.kind = 'group')
+                        AND t.amount > 0
+                        AND t.is_funded
                    ), p.main_currency)
              WHERE p.id = %(id)s
          RETURNING giving

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -692,10 +692,10 @@ class Participant(Model, MixinTeam):
              WHERE subscriber = %s
         """, (self.id,))
 
-    def clear_personal_information(self, cursor):
+    def clear_personal_information(self):
         """Clear personal information such as statements and goal.
         """
-        r = cursor.one("""
+        r = self.db.one("""
 
             DELETE FROM community_memberships WHERE participant=%(id)s;
             DELETE FROM subscriptions WHERE subscriber=%(id)s;
@@ -705,9 +705,6 @@ class Participant(Model, MixinTeam):
             UPDATE participants
                SET goal=NULL
                  , avatar_url=NULL
-                 , giving=zero(giving)
-                 , receiving=zero(receiving)
-                 , npatrons=0
              WHERE id=%(id)s
          RETURNING *;
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -692,8 +692,8 @@ class Participant(Model, MixinTeam):
              WHERE subscriber = %s
         """, (self.id,))
 
-    def clear_personal_information(self):
-        """Clear personal information such as statements and goal.
+    def erase_personal_information(self):
+        """Erase forever the user's personal data (statements, goal, etc).
         """
         r = self.db.one("""
 
@@ -2455,4 +2455,4 @@ def clean_up_closed_accounts():
     for p, closed_time in participants:
         sleep(0.1)
         print("Deleting data of account ~%i (closed on %s)..." % (p.id, closed_time))
-        p.clear_personal_information()
+        p.erase_personal_information()

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1769,7 +1769,11 @@ class Participant(Model, MixinTeam):
               JOIN participants p2 ON p2.id = t.tippee
              WHERE t.tipper = %s
                AND t.amount > 0
-          ORDER BY p2.join_time IS NULL, t.ctime ASC
+          ORDER BY ( p2.status = 'active' AND
+                     (p2.goal IS NULL OR p2.goal >= 0) AND
+                     (p2.mangopay_user_id IS NOT NULL OR p2.kind = 'group')
+                   ) DESC
+                 , p2.join_time IS NULL, t.ctime ASC
         """, (self.id,))
         updated = []
         for wallet in self.get_current_wallets(cursor):

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2456,3 +2456,4 @@ def clean_up_closed_accounts():
         sleep(0.1)
         print("Deleting data of account ~%i (closed on %s)..." % (p.id, closed_time))
         p.erase_personal_information()
+    return len(participants)

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -700,11 +700,24 @@ class Participant(Model, MixinTeam):
             DELETE FROM community_memberships WHERE participant=%(id)s;
             DELETE FROM subscriptions WHERE subscriber=%(id)s;
             DELETE FROM emails WHERE participant=%(id)s AND address <> %(email)s;
+            DELETE FROM notifications WHERE participant=%(id)s;
             DELETE FROM statements WHERE participant=%(id)s;
+
+            DELETE FROM events
+             WHERE participant = %(id)s
+               AND (recorder IS NULL OR recorder = participant)
+               AND type NOT IN (
+                       'account-kind-change',
+                       'mangopay-account-change',
+                       'set_status'
+                   );
 
             UPDATE participants
                SET goal=NULL
                  , avatar_url=NULL
+                 , avatar_src=NULL
+                 , avatar_email=NULL
+                 , public_name=NULL
              WHERE id=%(id)s
          RETURNING *;
 

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -545,7 +545,7 @@ class Participant(Model, MixinTeam):
             self.clear_takes(cursor)
             if self.kind == 'group':
                 self.remove_all_members(cursor)
-            self.clear_personal_information(cursor)
+            self.clear_subscriptions(cursor)
             self.final_check(cursor)
             self.update_status('closed', cursor)
 
@@ -681,6 +681,16 @@ class Participant(Model, MixinTeam):
         """, (self.id,))
         for t in teams:
             t.set_take_for(self, None, self, cursor=cursor)
+
+    def clear_subscriptions(self, cursor):
+        """Unsubscribe from all newsletters.
+        """
+        cursor.run("""
+            UPDATE subscriptions
+               SET is_on = false
+                 , mtime = current_timestamp
+             WHERE subscriber = %s
+        """, (self.id,))
 
     def clear_personal_information(self, cursor):
         """Clear personal information such as statements and goal.

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -12,3 +12,9 @@ BEGIN;
     DELETE FROM tips t WHERE EXISTS (SELECT 1 FROM zeroed_tips z WHERE z.id = t.id);
 
 END;
+
+SELECT 'after deployment';
+
+UPDATE events
+   SET recorder = (payload->>'invitee')::int
+ WHERE type IN ('invite_accept', 'invite_refuse');

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+    WITH zeroed_tips AS (
+             SELECT t.id
+               FROM events e
+               JOIN current_tips t ON t.tippee = e.participant
+                                  AND t.mtime = e.ts
+                                  AND t.amount = 0
+              WHERE e.type = 'set_status' AND e.payload = '"closed"'
+                 OR e.type = 'set_goal' AND e.payload::text LIKE '"-%"'
+         )
+    DELETE FROM tips t WHERE EXISTS (SELECT 1 FROM zeroed_tips z WHERE z.id = t.id);
+
+END;

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -260,15 +260,11 @@ class TestClosing(FakeTransfersHarness):
             hide_receiving=True,
             avatar_url='img-url',
             email='alice@example.com',
-            giving=EUR(20),
-            receiving=EUR(40),
-            npatrons=21,
         )
         alice.upsert_statement('en', 'not forgetting to be awesome!')
         alice.add_email('alice@example.net')
 
-        with self.db.get_cursor() as cursor:
-            alice.clear_personal_information(cursor)
+        alice.clear_personal_information()
         new_alice = Participant.from_username('alice')
 
         assert alice.get_statement(['en']) == (None, None)
@@ -277,9 +273,6 @@ class TestClosing(FakeTransfersHarness):
         assert alice.hide_receiving == new_alice.hide_receiving == True
         assert alice.avatar_url == new_alice.avatar_url == None
         assert alice.email == new_alice.email
-        assert alice.giving == new_alice.giving == 0
-        assert alice.receiving == new_alice.receiving == 0
-        assert alice.npatrons == new_alice.npatrons == 0
         emails = alice.get_emails()
         assert len(emails) == 1
         assert emails[0].address == 'alice@example.com'
@@ -294,7 +287,6 @@ class TestClosing(FakeTransfersHarness):
 
         assert Community.from_name('test').nmembers == 2  # sanity check
 
-        with self.db.get_cursor() as cursor:
-            alice.clear_personal_information(cursor)
+        alice.clear_personal_information()
 
         assert Community.from_name('test').nmembers == 1

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -28,7 +28,7 @@ class TestClosing(FakeTransfersHarness):
 
         alice.close('downstream')
 
-        assert carl.get_tip_to(alice)['amount'] == 0
+        assert carl.get_tip_to(alice)['amount'] == EUR(2)
         assert alice.balance == 0
         assert len(team.get_current_takes()) == 1
 

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -40,7 +40,7 @@ class TestClosing(FakeTransfersHarness):
     def test_close_page_is_usually_available(self):
         alice = self.make_participant('alice')
         body = self.client.GET('/alice/settings/close', auth_as=alice).text
-        assert 'Personal Information' in body
+        assert '<h3>Username' in body
 
     def test_close_page_is_not_available_during_payday(self):
         Payday.start()

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -250,9 +250,9 @@ class TestClosing(FakeTransfersHarness):
         assert ntips() == 0
 
 
-    # cpi - clear_personal_information
+    # epi - erase_personal_information
 
-    def test_cpi_clears_personal_information(self):
+    def test_epi_deletes_personal_information(self):
         alice = self.make_participant(
             'alice',
             goal=EUR(100),
@@ -264,7 +264,7 @@ class TestClosing(FakeTransfersHarness):
         alice.upsert_statement('en', 'not forgetting to be awesome!')
         alice.add_email('alice@example.net')
 
-        alice.clear_personal_information()
+        alice.erase_personal_information()
         new_alice = Participant.from_username('alice')
 
         assert alice.get_statement(['en']) == (None, None)
@@ -278,7 +278,7 @@ class TestClosing(FakeTransfersHarness):
         assert emails[0].address == 'alice@example.com'
         assert emails[0].verified
 
-    def test_cpi_clears_communities(self):
+    def test_epi_clears_communities(self):
         alice = self.make_participant('alice')
         c = alice.create_community('test')
         alice.upsert_community_membership(True, c.id)
@@ -287,6 +287,6 @@ class TestClosing(FakeTransfersHarness):
 
         assert Community.from_name('test').nmembers == 2  # sanity check
 
-        alice.clear_personal_information()
+        alice.erase_personal_information()
 
         assert Community.from_name('test').nmembers == 1

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -182,14 +182,19 @@ if not freeload:
             <td class="mtime">{{ to_age_str(tip.mtime, add_direction=True) }}</td>
             <td class="funded {{ 'danger' if inactive else '' }}">
                 % if not tip.is_identified
-                    {{ _("No: the donee hasn't filled the identity form") }}</td>
+                    {{ _("No: the donee hasn't filled the identity form") }}
                 % elif tippee.is_suspended
                     {{ _("No: the donee's account is temporarily suspended") }}
+                % elif tippee.status == 'closed'
+                    {{ _("No: the donee's account is closed") }}
+                % elif not tippee.accepts_tips
+                    {{ _("No: the recipient no longer accepts donations") }}
                 % elif not tip.is_funded
                     {{ _("No: insufficient funds") }}
                 % else
                     {{ _("Yes") }}
                 % endif
+            </td>
         </tr>
         % endfor
         </tbody>

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -83,7 +83,7 @@ elif action == 'leave':
 
 elif action == 'accept':
     with website.db.get_cursor() as c:
-        team.add_event(c, 'invite_accept', dict(invitee=user.id))
+        team.add_event(c, 'invite_accept', dict(invitee=user.id), user.id)
         team.add_member(user)
     msg = _("You are now a member of the team.")
     if notif_id:
@@ -91,7 +91,7 @@ elif action == 'accept':
 
 elif action == 'refuse':
     with website.db.get_cursor() as c:
-        team.add_event(c, 'invite_refuse', dict(invitee=user.id))
+        team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
     if notif_id:
         user.mark_notification_as_read(notif_id)
     response.redirect('/')

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -90,37 +90,26 @@ subhead = participant.username
         % endif
 
 
-        <h3>{{ _("Personal Information") }}</h3>
-
-        <p>{{ _("We immediately clear out most of the information in your profile.") }}</p>
+        <h3>{{ _("Data retention") }}</h3>
 
         <p>{{ _(
-            "Things we clear immediately include your profile statements, any "
-            "funding goal, the donations you're receiving, and those you're "
-            "giving. You'll also be removed from any communities and teams you "
-            "were a part of."
+            "We will start to erase the personal data attached to your account "
+            "7 days after it is closed. This delay is meant to protect your "
+            "account from an accidental or malicious closure."
         ) }}</p>
 
         <p>{{ _(
-            "We specifically {0}don't{1} delete your past giving and receiving "
-            "history on the site, because that information also belongs equally "
-            "to other users (the ones you gave to and received from).",
-            '<em>'|safe, '</em>'|safe
+            "Identity information and transaction records are kept for as long "
+            "as is necessary to comply with all legal obligations."
         ) }}</p>
 
 
-        <h3>{{ _("Username, email and password") }}</h3>
+        <h3>{{ _("Username") }}</h3>
 
         <p>{{ _(
             "We may give your username to someone else if they ask for it, but "
             "not for at least a year after you close your account (unless we "
             "determine that you've been infringing a trademark)."
-        ) }}</p>
-
-        <p>{{ _(
-            "We don't erase your email address and password immediately, so "
-            "for a while you'll be able to reopen your account by simply "
-            "logging in, until your account is definitively archived."
         ) }}</p>
 
 

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -24,7 +24,9 @@ pending_payouts = website.db.one("""
       FROM exchanges
      WHERE participant = %s
        AND amount < 0
-       AND status = 'created'
+       AND ( status = 'created' OR
+             status = 'succeeded' AND timestamp > (current_timestamp - interval '24 hours')
+           )
 """, (participant.id,))
 
 balances = participant.get_balances()

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -1,4 +1,4 @@
-from liberapay.utils import get_participant
+from liberapay.utils import b64encode_s, get_participant
 
 [---]
 
@@ -13,6 +13,8 @@ if request.method == 'POST' and not payday_is_running:
     if participant.balance and disburse_to is None:
         error = _("You still have money in this Liberapay account, please "
                   "choose a disbursement method below or contact support.")
+    elif disburse_to == 'payout':
+        response.redirect(participant.path('wallet/payout/'+b64encode_s(request.path.raw)))
     else:
         participant.close(disburse_to)
         response.redirect('/%s/' % participant.username)
@@ -63,16 +65,18 @@ subhead = participant.username
 
         <p>{{ _("You have {0} in your wallet. What should we do with it?",
                 balances) }}</p>
-        <ul>
-            <li><a href="{{ participant.path('wallet/payout/'+b64encode_s(request.line.uri)) }}"
-                    >{{ _("Withdraw it") }}</a></li>
-            <li><label>
+        <div class="paragraph">
+            <label>
+                <input type="radio" name="disburse_to" value="payout" />
+                {{ _("Withdraw it") }}
+            </label><br>
+            <label>
                 <input type="radio" name="disburse_to" value="downstream"
                        {{ 'disabled' if not participant.giving else '' }} />
                 {{ _("Give it to the {0}people I donate to{1}",
                      '<a href="%s">'|safe % participant.path('giving'), '</a>'|safe) }}
-            </label></li>
-        </ul>
+            </label>
+        </div>
         <p>{{ _(
             "If neither option works for you, please contact support@liberapay.com."
         ) }}</p>

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -126,5 +126,5 @@ subhead = participant.username
         <button class="btn btn-danger btn-lg">{{ _("Yes, close my Liberapay account") }}</button>
     </form>
     % endif
-</div>
+
 % endblock

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -110,6 +110,7 @@ subhead = participant.username
         ) }}</p>
 
 
+        % if participant.username[0] != '~'
         <h3>{{ _("Username") }}</h3>
 
         <p>{{ _(
@@ -117,6 +118,7 @@ subhead = participant.username
             "not for at least a year after you close your account (unless we "
             "determine that you've been infringing a trademark)."
         ) }}</p>
+        % endif
 
 
         <h3>{{ _("Ready?") }}</h3>

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -17,6 +17,7 @@ if request.method == 'POST' and not payday_is_running:
         response.redirect(participant.path('wallet/payout/'+b64encode_s(request.path.raw)))
     else:
         participant.close(disburse_to)
+        participant.sign_out(response.headers.cookie)
         response.redirect('/%s/' % participant.username)
 
 pending_payouts = website.db.one("""


### PR DESCRIPTION
This branch changes what happens when an account is closed:

- incoming donations will no longer be zeroed out, because this is confusing for the donor and it wasn't reversed if the account was reopened
- personal data will no longer be deleted immediately, instead it will happen 7 days later if the account is still closed then
- the `events` and `notifications` tables, which can contain personal data, will also be cleaned up after 7 days
- the payment "routes" will also be invalidated after 7 days (closes #669)
- a user will be logged out after closing their account (this was broken by #1069)