### PR TITLE
Don't fail when `participant.email_lang` is invalid

### DIFF
--- a/www/%username/emails/index.spt
+++ b/www/%username/emails/index.spt
@@ -15,7 +15,7 @@ subhead = _("Email settings")
 emails = participant.get_emails()
 base_path = participant.path('emails/')
 
-email_locale = website.locales[participant.email_lang]
+email_locale = website.locales.get(participant.email_lang) or website.locales['en']
 
 [---] text/html
 % extends "templates/settings.html"


### PR DESCRIPTION
Fixes [LIBERAPAYCOM-9S](https://sentry.io/share/issue/0c6f1b7805714dccb69b344e6a559598/):

```
  File "site-packages/algorithm.py", line 321, in loop
    new_state = function(**deps.as_kwargs)
  File "aspen/request_processor/algorithm.py", line 73, in render_resource
    return {'output': resource.render(state)}
  File "aspen/http/resource.py", line 78, in render
    return super(Dynamic, self).render(available[0], state)
  File "aspen/simplates/simplate.py", line 121, in render
    exec(self.pages[1], context)
  File "www/%username/emails/index.spt", line 18, in <module>
    email_locale = website.locales[participant.email_lang]
KeyError: None
```