### PR TITLE
Rate limit log-in attempts per IP address and country

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -275,9 +275,11 @@ RATE_LIMITS = {
     'check_password': (25, 60*60*24*7),  # 25 per week
     'http-unsafe.ip-addr': (10, 10),  # 10 per 10 seconds
     'http-unsafe.user': (10, 10),  # 10 per 10 seconds
+    'log-in.country': (10, 60),  # 10 per minute per country
     'log-in.email': (10, 60*60*24),  # 10 per day
     'log-in.email.not-verified': (2, 60*60*24),  # 2 per day
     'log-in.email.verified': (10, 60*60*24),  # 10 per day
+    'log-in.ip-addr': (5, 5*60),  # 5 per 5 minutes per IP address
     'log-in.password': (3, 60*60),  # 3 per hour
     'make_team': (5, 60*60*24*7),  # 5 per week
     'refetch_elsewhere_data': (1, 60*60*24*7),  # retry after one week

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -171,6 +171,15 @@ class TooManyEmailVerifications(LazyResponseXXX):
         )
 
 
+class TooManyLogInAttempts(LazyResponseXXX):
+    code = 429
+    def msg(self, _):
+        return _(
+            "There have been too many attempts to log in from your IP address or country "
+            "recently. Please try again in an hour and email support@liberapay.com if "
+            "the problem persists."
+        )
+
 class TooManyLoginEmails(LazyResponseXXX):
     code = 429
     def msg(self, _):

--- a/liberapay/utils/state_chain.py
+++ b/liberapay/utils/state_chain.py
@@ -29,6 +29,13 @@ def create_response_object(request, website):
     return {'response': response}
 
 
+def reject_requests_bypassing_proxy(request, response):
+    """Reject requests that bypass Cloudflare, except health checks.
+    """
+    if request.bypasses_proxy and request.path.raw != '/callbacks/health':
+        raise response.error(403, "The request bypassed a proxy.")
+
+
 def canonize(request, website):
     """Enforce a certain scheme and hostname.
 

--- a/tests/py/test_request_source.py
+++ b/tests/py/test_request_source.py
@@ -28,32 +28,40 @@ class Tests(Harness):
         kw['REMOTE_ADDR'] = source
         kw.setdefault('return_after', 'attach_environ_to_request')
         kw.setdefault('want', 'request')
-        return self.client.GET('/', **kw).source
+        return self.client.GET('/', **kw)
 
     def test_request_source_with_invalid_header_from_trusted_proxy(self):
-        source = str(self.request(b'f\xc3\xa9e, \t bar', b'10.0.0.1'))
-        assert source == '10.0.0.1'
+        r = self.request(b'f\xc3\xa9e, \t bar', b'10.0.0.1')
+        assert str(r.source) == '10.0.0.1'
+        assert r.bypasses_proxy is True
 
     def test_request_source_with_invalid_header_from_untrusted_proxy(self):
-        source = str(self.request(b'f\xc3\xa9e, \tbar', b'8.8.8.8'))
-        assert source == '8.8.8.8'
+        r = self.request(b'f\xc3\xa9e, \tbar', b'8.8.8.8')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is True
 
     def test_request_source_with_valid_headers_from_trusted_proxies(self):
-        source = str(self.request(b'8.8.8.8,141.101.69.139', b'10.0.0.1'))
-        assert source == '8.8.8.8'
-        source = str(self.request(b'8.8.8.8', b'10.0.0.2'))
-        assert source == '8.8.8.8'
+        r = self.request(b'8.8.8.8,141.101.69.139', b'10.0.0.1')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is False
+        r = self.request(b'8.8.8.8', b'10.0.0.2')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is True
 
     def test_request_source_with_valid_headers_from_untrusted_proxies(self):
         # 8.8.8.8 claims that the request came from 0.0.0.0, but we don't trust 8.8.8.8
-        source = str(self.request(b'0.0.0.0, 8.8.8.8,141.101.69.140', b'10.0.0.1'))
-        assert source == '8.8.8.8'
-        source = str(self.request(b'0.0.0.0, 8.8.8.8', b'10.0.0.1'))
-        assert source == '8.8.8.8'
+        r = self.request(b'0.0.0.0, 8.8.8.8,141.101.69.140', b'10.0.0.1')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is False
+        r = self.request(b'0.0.0.0, 8.8.8.8', b'10.0.0.1')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is True
 
     def test_request_source_with_forged_headers_from_untrusted_client(self):
         # 8.8.8.8 claims that the request came from a trusted proxy, but we don't trust 8.8.8.8
-        source = str(self.request(b'0.0.0.0,141.101.69.141, 8.8.8.8,141.101.69.142', b'10.0.0.1'))
-        assert source == '8.8.8.8'
-        source = str(self.request(b'0.0.0.0, 141.101.69.143, 8.8.8.8', b'10.0.0.1'))
-        assert source == '8.8.8.8'
+        r = self.request(b'0.0.0.0,141.101.69.141, 8.8.8.8,141.101.69.142', b'10.0.0.1')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is False
+        r = self.request(b'0.0.0.0, 141.101.69.143, 8.8.8.8', b'10.0.0.1')
+        assert str(r.source) == '8.8.8.8'
+        assert r.bypasses_proxy is True


### PR DESCRIPTION
Logging in is a costly operation (because of password hashing or email sending) so it needs to be rate-limited.

To ensure that we get accurate country codes this branch adds a function that rejects requests that hit the origin without going through Cloudflare.