### PR TITLE
WIP: Migrate to GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: This webapp is not self-hostable.
 
 You want to chat? [Join us on Gitter](https://gitter.im/liberapay/salon). (If you use IRC, [Gitter has a gateway](https://irc.gitter.im/), and we're also in the #liberapay channel on Freenode.)
 
-Alternatively you can post a message in [our GitHub salon](https://github.com/liberapay/salon).
+Alternatively you can post a message in [our GitHub salon](https://gitlab.com/liberapay/salon).
 
 
 ## Contributing to the translations
@@ -47,7 +47,7 @@ You can help translate Liberapay [via Weblate](https://hosted.weblate.org/engage
 
 [![translation status by language](https://hosted.weblate.org/widgets/liberapay/-/multi-auto.svg)](https://hosted.weblate.org/projects/liberapay/core/?utm_source=widget)
 
-If you have questions about translating Liberapay, you can ask them [in the salon](https://github.com/liberapay/salon/labels/i18n).
+If you have questions about translating Liberapay, you can ask them [in the salon](https://gitlab.com/liberapay/salon/?label_name[]=i18n).
 
 
 ## Contributing to the code
@@ -218,4 +218,4 @@ All arguments are passed to the underlying `py.test` command, so you can use `-x
 
 ## License
 
-[CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/) (See [this discussion](https://github.com/liberapay/liberapay.com/issues/564) for details.)
+[CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/) (See [this discussion](https://gitlab.com/liberapay/liberapay.com/issues/564) for details.)

--- a/i18n/core/ar.po
+++ b/i18n/core/ar.po
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr "للإبلاغ عن مشكلة أو تقديم اقتراح باللغة الإنكليزية :"
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/ca.po
+++ b/i18n/core/ca.po
@@ -2860,8 +2860,8 @@ msgstr "No tenim cap número de telèfon."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Per a informar d'un problema o fer un suggeriment en anglès:"
 
-msgid "Open an issue on GitHub"
-msgstr "Obriu un tema a GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Obriu un tema a GitLab"
 
 msgid "Other communication channels:"
 msgstr "Altres canals de comunicació:"

--- a/i18n/core/cs.po
+++ b/i18n/core/cs.po
@@ -2882,8 +2882,9 @@ msgstr "V současné době nemáme telefonní číslo."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Nahlásit chybu nebo námět v angličtině:"
 
-msgid "Open an issue on GitHub"
-msgstr "Nahlašte problém na Githubu"
+#, fuzzy
+msgid "Open an issue on GitLab"
+msgstr "Nahlašte problém na Gitlabu"
 
 msgid "Other communication channels:"
 msgstr "Další komunikační kanály:"

--- a/i18n/core/da.po
+++ b/i18n/core/da.po
@@ -2864,8 +2864,8 @@ msgstr "Vi har for tiden ikke et telefonnummer."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "For at rapportere et problem eller give et forslag på engelsk:"
 
-msgid "Open an issue on GitHub"
-msgstr "Åbn en problem-forespørgsel på GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Åbn en problem-forespørgsel på GitLab"
 
 msgid "Other communication channels:"
 msgstr "Andre kommunikations-kanaler:"

--- a/i18n/core/de.po
+++ b/i18n/core/de.po
@@ -2861,8 +2861,8 @@ msgstr "Derzeit haben wir keine Telefonnummer."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Melden Sie ein Problem oder machen Sie einen Vorschlag in englischer Sprache:"
 
-msgid "Open an issue on GitHub"
-msgstr "Öffnen Sie ein Thema auf GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Öffnen Sie ein Thema auf GitLab"
 
 msgid "Other communication channels:"
 msgstr "Andere Kommunikationswege:"

--- a/i18n/core/el.po
+++ b/i18n/core/el.po
@@ -2858,7 +2858,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/eo.po
+++ b/i18n/core/eo.po
@@ -2864,8 +2864,8 @@ msgstr "Ni ne havas telefonnumeron nun."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Por raporti problemon aŭ fari sugeston en la Angla:"
 
-msgid "Open an issue on GitHub"
-msgstr "Kreu atentindaĵon en GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Kreu atentindaĵon en GitLab"
 
 msgid "Other communication channels:"
 msgstr "Aliaj komunikaj medioj:"

--- a/i18n/core/es.po
+++ b/i18n/core/es.po
@@ -2860,8 +2860,8 @@ msgstr "En este momento no tenemos un número de teléfono."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Para informar de un problema o hacer una sugerencia en inglés:"
 
-msgid "Open an issue on GitHub"
-msgstr "Abrir un tema en GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Abrir un tema en GitLab"
 
 msgid "Other communication channels:"
 msgstr "Otros canales de comunicación:"

--- a/i18n/core/et.po
+++ b/i18n/core/et.po
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/fi.po
+++ b/i18n/core/fi.po
@@ -2861,7 +2861,7 @@ msgstr "Meillä ei tällä hetkellä ole puhelinnumeroa."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Ilmoittaaksesi ongelmasta tai ehdottaaksesi jotain englanniksi:"
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr "Avaa issue Githubissa"
 
 msgid "Other communication channels:"

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -2860,8 +2860,8 @@ msgstr "Nous n'avons pas encore de numéro de téléphone."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Pour signaler un problème ou faire une suggestion en anglais :"
 
-msgid "Open an issue on GitHub"
-msgstr "Créez un ticket sur GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Créez un ticket sur GitLab"
 
 msgid "Other communication channels:"
 msgstr "Autres canaux de communication :"

--- a/i18n/core/fy.po
+++ b/i18n/core/fy.po
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/ga.po
+++ b/i18n/core/ga.po
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/hu.po
+++ b/i18n/core/hu.po
@@ -2861,7 +2861,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/id.po
+++ b/i18n/core/id.po
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/it.po
+++ b/i18n/core/it.po
@@ -2860,8 +2860,8 @@ msgstr "Al momento non abbiamo un numero di telefono."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Per segnalare un problema o inviare suggerimenti in inglese:"
 
-msgid "Open an issue on GitHub"
-msgstr "Apri un reclamo su GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Apri un reclamo su GitLab"
 
 msgid "Other communication channels:"
 msgstr "Altri canali di comunicazione:"

--- a/i18n/core/ja.po
+++ b/i18n/core/ja.po
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/ko.po
+++ b/i18n/core/ko.po
@@ -2843,8 +2843,8 @@ msgstr "현재는 전화번호가 없습니다."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "영어로 문제를 보고하거나 제안할 사항이 있다면:"
 
-msgid "Open an issue on GitHub"
-msgstr "GitHub에 이슈를 열어 주세요"
+msgid "Open an issue on GitLab"
+msgstr "GitLab에 이슈를 열어 주세요"
 
 msgid "Other communication channels:"
 msgstr "다른 커뮤니케이션 채널:"

--- a/i18n/core/lt.po
+++ b/i18n/core/lt.po
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/lv.po
+++ b/i18n/core/lv.po
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/ms.po
+++ b/i18n/core/ms.po
@@ -2862,8 +2862,8 @@ msgstr "Kami masih belum mempunyai nombor telefon."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Untuk melaporkan masalah atau memberi cadangan dalam bahasa Inggeris:"
 
-msgid "Open an issue on GitHub"
-msgstr "Buka isu di GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Buka isu di GitLab"
 
 msgid "Other communication channels:"
 msgstr "Saluran perhubungan yang lain:"

--- a/i18n/core/nb.po
+++ b/i18n/core/nb.po
@@ -2870,8 +2870,8 @@ msgstr "Vi har foreløpig ikke noe telefonnummer."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "For å rapportere et problem, eller foreslå noe på Engelsk:"
 
-msgid "Open an issue on GitHub"
-msgstr "Innrapporter feil på GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Innrapporter feil på GitLab"
 
 msgid "Other communication channels:"
 msgstr "Andre kommunikasjonskanaler:"

--- a/i18n/core/nl.po
+++ b/i18n/core/nl.po
@@ -2861,8 +2861,8 @@ msgstr "Momenteel hebben wij geen telefoonnummer."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Meld een probleem of een doe een suggestie (alleen in het Engels):"
 
-msgid "Open an issue on GitHub"
-msgstr "Open een issue op GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Open een issue op GitLab"
 
 msgid "Other communication channels:"
 msgstr "Andere communicatiekanalen:"

--- a/i18n/core/pl.po
+++ b/i18n/core/pl.po
@@ -2878,8 +2878,9 @@ msgstr "Aktualnie nie posiadamy numeru telefonu."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "By zgłosić problem lub coś zasugerować w języku angielskim:"
 
-msgid "Open an issue on GitHub"
-msgstr "Zgłoś problem na GitHubie"
+#, fuzzy
+msgid "Open an issue on GitLab"
+msgstr "Zgłoś problem na GitLabie"
 
 msgid "Other communication channels:"
 msgstr "Inne kanały komunikacyjne:"

--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -2860,8 +2860,8 @@ msgstr "Atualmente não temos um número de telefone."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Para relatar um problema ou fazer uma sugestão em inglês:"
 
-msgid "Open an issue on GitHub"
-msgstr "Abra um problema no GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Abra um problema no GitLab"
 
 msgid "Other communication channels:"
 msgstr "Outros canais de comunicação:"

--- a/i18n/core/ro.po
+++ b/i18n/core/ro.po
@@ -2880,8 +2880,8 @@ msgstr "Momentan nu avem un număr de telefon."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Pentru a raporta o promblemă sau a face o sugestie în engleză:"
 
-msgid "Open an issue on GitHub"
-msgstr "Deschideți o problemă pe GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Deschideți o problemă pe GitLab"
 
 msgid "Other communication channels:"
 msgstr "Alte canale de comunicare:"

--- a/i18n/core/ru.po
+++ b/i18n/core/ru.po
@@ -2877,8 +2877,8 @@ msgstr "В данный момент у нас нет номера телефо�
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Чтобы сообщить о проблеме или внести предложение на английском языке:"
 
-msgid "Open an issue on GitHub"
-msgstr "Открыть тему на GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Открыть тему на GitLab"
 
 msgid "Other communication channels:"
 msgstr "Другие способы связи:"

--- a/i18n/core/sk.po
+++ b/i18n/core/sk.po
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/sl.po
+++ b/i18n/core/sl.po
@@ -2891,7 +2891,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/sv.po
+++ b/i18n/core/sv.po
@@ -2862,8 +2862,8 @@ msgstr "Vi har förnuvarande inte något telefonnummer."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "För att rapportera ett problem eller skicka in ett förslag på Engelska:"
 
-msgid "Open an issue on GitHub"
-msgstr "Öppna ett ärende på GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Öppna ett ärende på GitLab"
 
 msgid "Other communication channels:"
 msgstr "Andra kommunikationskanaler:"

--- a/i18n/core/tr.po
+++ b/i18n/core/tr.po
@@ -2860,7 +2860,7 @@ msgstr ""
 msgid "To report a problem or make a suggestion in English:"
 msgstr ""
 
-msgid "Open an issue on GitHub"
+msgid "Open an issue on GitLab"
 msgstr ""
 
 msgid "Other communication channels:"

--- a/i18n/core/uk.po
+++ b/i18n/core/uk.po
@@ -2877,8 +2877,8 @@ msgstr "Наразі у нас немає номера телефону."
 msgid "To report a problem or make a suggestion in English:"
 msgstr "Щоб повідомити про проблему або внести пропозицію на английській мові:"
 
-msgid "Open an issue on GitHub"
-msgstr "Відкрити тему в GitHub"
+msgid "Open an issue on GitLab"
+msgstr "Відкрити тему в GitLab"
 
 msgid "Other communication channels:"
 msgstr "Інші способи зв'язку:"

--- a/i18n/core/zh.po
+++ b/i18n/core/zh.po
@@ -2845,8 +2845,8 @@ msgstr "我們目前沒有電話號碼。"
 msgid "To report a problem or make a suggestion in English:"
 msgstr "要用英文回報問題或是提建議："
 
-msgid "Open an issue on GitHub"
-msgstr "在GitHub發出問題"
+msgid "Open an issue on GitLab"
+msgstr "在GitLab發出問題"
 
 msgid "Other communication channels:"
 msgstr "其它的溝通管道："

--- a/js/avatar-fallback.js
+++ b/js/avatar-fallback.js
@@ -1,6 +1,6 @@
 /* This is a temporary hack. There is no reliable cross-browser way to replace
  * broken images. However we can remove the need for this by proxying images:
- * https://github.com/liberapay/liberapay.com/issues/202
+ * https://gitlab.com/liberapay/liberapay.com/issues/202
  */
 $('img.avatar').on('error', function () {
     this.src = Liberapay.avatar_default_url;

--- a/js/payment-cards.js
+++ b/js/payment-cards.js
@@ -1,4 +1,4 @@
-// https://github.com/liberapay/payment-cards.js
+// https://gitlab.com/liberapay/payment-cards.js
 
 var PaymentCards = function () {
 

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -1031,7 +1031,7 @@ def main(override_payday_checks=False):
     from liberapay.billing.transactions import sync_with_mangopay
     from liberapay.main import website
 
-    # https://github.com/liberapay/salon/issues/19#issuecomment-191230689
+    # https://gitlab.com/liberapay/salon/issues/19#issuecomment-191230689
     from liberapay.billing.payday import Payday
 
     if not website.env.override_payday_checks and not override_payday_checks:

--- a/liberapay/utils/state_chain.py
+++ b/liberapay/utils/state_chain.py
@@ -192,7 +192,7 @@ def turn_socket_error_into_50X(website, exception, _=lambda a: a, response=None)
 def bypass_csp_for_form_redirects(response, state, website, request=None):
     if request is None:
         return
-    # https://github.com/liberapay/liberapay.com/issues/952
+    # https://gitlab.com/liberapay/liberapay.com/issues/952
     if request.method == 'POST' and response.code == 302:
         target = response.headers[b'Location']
         is_internal = (
@@ -228,7 +228,7 @@ def overwrite_status_code_of_gateway_errors(response):
     """This function changes 502 and 504 response codes to 500.
 
     Why? Because CloudFlare masks our error page if we return a 502 or 504:
-    https://github.com/liberapay/liberapay.com/issues/592
+    https://gitlab.com/liberapay/liberapay.com/issues/592
     """
     if response.code in (502, 504):
         response.code = 500

--- a/liberapay/wireup.py
+++ b/liberapay/wireup.py
@@ -433,7 +433,7 @@ def make_sentry_teller(env):
 
         if isinstance(exception, ValueError):
             if 'cannot contain NUL (0x00) characters' in str(exception):
-                # https://github.com/liberapay/liberapay.com/issues/675
+                # https://gitlab.com/liberapay/liberapay.com/issues/675
                 response = state.get('response') or pando.Response()
                 response.code = 400
                 response.body = str(exception)

--- a/release.sh
+++ b/release.sh
@@ -158,6 +158,6 @@ if [ "$run_schema_diff" = 'yes' ]; then
     fi
 fi
 
-# Push to GitHub
+# Push to GitLab
 git push
 git push --tags

--- a/templates/base.html
+++ b/templates/base.html
@@ -122,7 +122,7 @@
             <li><a href="https://medium.com/liberapay-blog">{{ fontawesome('medium', 'Medium') }}</a></li>
             <li><a href="https://mastodon.xyz/@Liberapay">{{ fontawesome('mastodon', 'Mastodon') }}</a></li>
             <li><a href="https://framasphere.org/u/liberapay">{{ fontawesome('diaspora', 'Diaspora*') }}</a></li>
-            <li><a href="https://github.com/liberapay/liberapay.com">{{ fontawesome('github', 'GitHub') }}</a></li>
+            <li><a href="https://gitlab.com/liberapay/liberapay.com">{{ fontawesome('gitlab', 'GitLab') }}</a></li>
             <li><a href="https://twitter.com/liberapay">{{ fontawesome('twitter', 'Twitter') }}</a></li>
             <li><a href="https://www.facebook.com/Liberapay-472128142945598/">{{ fontawesome('facebook', 'Facebook') }}</a></li>
         </ul>

--- a/www/about/contact.spt
+++ b/www/about/contact.spt
@@ -12,8 +12,8 @@ title = _("Contact")
 
     <br>
     <h4>{{ _("To report a problem or make a suggestion in English:") }}</h4>
-    <p><a class="btn btn-default" href="https://github.com/liberapay/liberapay.com/issues/new"
-          >{{ _("Open an issue on GitHub") }}</a></p>
+    <p><a class="btn btn-default" href="https://gitlab.com/liberapay/liberapay.com/issues/new"
+          >{{ _("Open an issue on GitLab") }}</a></p>
 
     <br>
     <h4>{{ _("Other communication channels:") }}</h4>

--- a/www/about/feeds.spt
+++ b/www/about/feeds.spt
@@ -32,9 +32,9 @@ title = _("Feeds")
         "the {2}adventures of the Liberapay legal entity{0}, and the "
         "{3}general discussions of the Liberapay team{0}.",
         '</a>'|safe,
-        '<a href="https://github.com/liberapay/liberapay.com">'|safe,
-        '<a href="https://github.com/liberapay/liberapay.org#readme">'|safe,
-        '<a href="https://github.com/liberapay/salon#readme">'|safe,
+        '<a href="https://gitlab.com/liberapay/liberapay.com">'|safe,
+        '<a href="https://gitlab.com/liberapay/liberapay.org#readme">'|safe,
+        '<a href="https://gitlab.com/liberapay/salon#readme">'|safe,
     ) }}</p>
 
 </div></div>

--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -41,8 +41,8 @@ title = _("Introduction")
         "share of the money that our users donate to keep the service running.",
         '</a>'|safe,
         '<a href="https://hosted.weblate.org/engage/liberapay/">'|safe,
-        '<a href="https://github.com/liberapay/liberapay.com">'|safe,
-        '<a href="https://github.com/liberapay/liberapay.org">'|safe,
+        '<a href="https://gitlab.com/liberapay/liberapay.com">'|safe,
+        '<a href="https://gitlab.com/liberapay/liberapay.org">'|safe,
         '<a href="/Liberapay/">'|safe
     ) }}</p>
 
@@ -67,7 +67,7 @@ title = _("Introduction")
 
     <p>{{ _(
         "Liberapay is a non-profit organization {0}founded in 2015 in France{1} by {2} and {3}.",
-        '<a href="https://github.com/liberapay/liberapay.org/issues/2">'|safe,
+        '<a href="https://gitlab.com/liberapay/liberapay.org/issues/2">'|safe,
         '</a>'|safe,
         '<a href="/Changaco/">Changaco</a>'|safe,
         '<a href="/Zatalyz/">Zatalyz</a>'|safe,

--- a/www/about/money.spt
+++ b/www/about/money.spt
@@ -51,7 +51,7 @@ title = _("Money")
 <p>{{ _(
     "Payday is when donations are actually executed. It's a program ({0}this "
     "one{1}) that we run every Wednesday.",
-    '<a href="https://github.com/liberapay/liberapay.com/blob/master/liberapay/billing/payday.py">'|safe,
+    '<a href="https://github.com/liberapay/liberapay.com/raw/master/liberapay/billing/payday.py">'|safe,
     '</a>'|safe
 ) }}</p>
 

--- a/www/about/security.spt
+++ b/www/about/security.spt
@@ -2,7 +2,7 @@
 
 liberapay_hof_raw = """
 EdOverflow
-https://github.com/liberapay/liberapay.com/pull/467
+https://gitlab.com/liberapay/liberapay.com/merge_requests/467
 """
 
 gratipay_hof_raw = """\
@@ -118,7 +118,7 @@ title = _("Security")
                 <li>out-of-date software</li>
             </ul>
         </li>
-        <li><b>Issues with no security implications</b> (e.g. spelling mistakes), they should be reported publicly <a href="https://github.com/liberapay/liberapay.com/issues/new">on GitHub</a>.</li>
+        <li><b>Issues with no security implications</b> (e.g. spelling mistakes), they should be reported publicly <a href="https://gitlab.com/liberapay/liberapay.com/issues/new">on GitLab</a>.</li>
         <li><b>Issues in third-party services</b>, they should be reported to the respective team.</p>
     </ul>
 

--- a/www/humans.txt
+++ b/www/humans.txt
@@ -1,4 +1,3 @@
 Liberapay is the result of the work of many people.
-The main direct contributors are listed on https://github.com/liberapay/liberapay.com/graphs/contributors?from=2015-05-01
-The contributors to Liberapay's predecessor, Gittip / Gratipay, can be seen on https://github.com/liberapay/liberapay.com/graphs/contributors?to=2015-05-01
+The main contributors are listed on https://github.com/liberapay/liberapay.com/graphs/master
 Indirect contributors include everyone who has ever contributed to a tool that is or has been used to build Liberapay or its predecessors. Obviously that's a very big list.

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -213,12 +213,12 @@ recent = query_cache.one("""
             "Liberapay is run transparently by a {1}non-profit organization{0}, "
             "its {2}source code{0} is public.",
             '</a>'|safe,
-            '<a href="https://github.com/liberapay/liberapay.org">'|safe,
-            '<a href="https://github.com/liberapay/liberapay.com">'|safe,
+            '<a href="https://gitlab.com/liberapay/liberapay.org">'|safe,
+            '<a href="https://gitlab.com/liberapay/liberapay.com">'|safe,
         ) }}</p>
         <p>{{ _(
             "We rely on your support to keep Liberapay running and {link_start}improving{link_end}.",
-            link_start='<a href="https://github.com/liberapay/liberapay.com/issues">'|safe,
+            link_start='<a href="https://gitlab.com/liberapay/liberapay.com/issues">'|safe,
             link_end='</a>'|safe,
         ) }}</p>
         <p><a href="/Liberapay/donate" class="btn btn-donate btn-lg"


### PR DESCRIPTION
Addresses #46

I considered that issue, labels and raw file URLs change, so I adapted them accordingly. However, the URL for graph statistics from `robots.txt` doesn't work on GitLab, you cannot select a time period, so I simplified it, and I remove the mention to Gratipay and that time distinction, since they are Liberapay contributors anyway.

The GitHub logo from the footer was changed as well.

![screenshot at 2018-06-14 12 04 09](https://user-images.githubusercontent.com/14212780/41405867-5d33603c-6fba-11e8-9f01-02a28890c60b.png)


One note: There was a translatable string that mentioned GitHub, so I executed `find . -type f -print0 | xargs -0 sed -i 's/GitHub/GitLab/g'`. Some languages (Czech and Polish) change nouns based on [cases](https://en.wikipedia.org/wiki/Grammatical_case), and I'm not sure about their rules, so I did the best I could and marked those as fuzzy.