### PR TITLE
Parse integers before passing them to mangopay

### DIFF
--- a/www/%username/identity-docs.spt
+++ b/www/%username/identity-docs.spt
@@ -27,11 +27,13 @@ try:
         r = {"doc_id": doc.Id}
     elif action == 'add_page':
         data = b64encode(body['qqfile'].value)
-        page = Page(document=Document(id=body['doc_id']), user=mp_user, file=data)
+        doc_id = body.get_int('doc_id', minimum=1)
+        page = Page(document=Document(id=doc_id), user=mp_user, file=data)
         page.save()
         r = {"success": True}
     elif action == 'validate_doc':
-        doc = Document(id=body['doc_id'], user=mp_user, status='VALIDATION_ASKED')
+        doc_id = body.get_int('doc_id', minimum=1)
+        doc = Document(id=doc_id, user=mp_user, status='VALIDATION_ASKED')
         doc.save()
         r = {"success": True}
     else:

--- a/www/%username/routes/credit-card.json.spt
+++ b/www/%username/routes/credit-card.json.spt
@@ -25,7 +25,7 @@ if 'Currency' in body:
 
 else:
     try:
-        card = Card.get(body['CardId'])
+        card = Card.get(body.get_int('CardId', minimum=1))
     except Card.DoesNotExist:
         raise response.error(400, "bad CardId")
     if card.UserId != participant.mangopay_user_id:


### PR DESCRIPTION
The mangopay library doesn't do any data validation (<https://github.com/Mangopay/mangopay2-python-sdk/issues/165>), and mangopay's technical team reacts badly when SQL injection attempts hit their API (#1160).