### PR TITLE
update Mastodon account_url to better support Pleroma

### DIFF
--- a/liberapay/elsewhere/mastodon.py
+++ b/liberapay/elsewhere/mastodon.py
@@ -16,7 +16,7 @@ class Mastodon(PlatformOAuth2):
     # Platform attributes
     name = 'mastodon'
     display_name = 'Mastodon'
-    account_url = 'https://{domain}/@{user_name}'
+    account_url = 'https://{domain}/users/{user_name}'
     single_domain = False
 
     def example_account_address(self, _):


### PR DESCRIPTION
Unlike Mastodon, Pleroma doesn't support the {domain}/@{user_name} route,
not at the moment at least. However, they both support {domain}/users/{user_name}.