### PR TITLE
Mangopay exodus

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -140,7 +140,7 @@ FEE_PAYIN_DIRECT_DEBIT = {
 FEE_PAYOUT = {
     'EUR': {
         'domestic': (SEPA, Fees(0, 0)),
-        'foreign': Fees(0, Money('2.50', 'EUR')),
+        'foreign': Fees(0, 0),
     },
     'GBP': {
         'domestic': ({'GB'}, Fees(0, Money('0.45', 'GBP'))),

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -370,3 +370,11 @@ class TooManyRequests(LazyResponseXXX):
             "You're sending requests at an unusually fast pace. Please retry in a few "
             "seconds, and contact support@liberapay.com if the problem persists."
         )
+
+
+class UnableToDistributeBalance(LazyResponse400):
+    def msg(self, _):
+        return _(
+            "The attempt to distribute all the money in your wallet failed: "
+            "{money_amount} remains.", money_amount=self.args[0]
+        )

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2112,6 +2112,7 @@ class Participant(Model, MixinTeam):
                      , t.mtime
                      , p AS tippee_p
                      , t.is_funded
+                     , t.paid_in_advance
                      , (p.mangopay_user_id IS NOT NULL OR kind = 'group') AS is_identified
                   FROM tips t
                   JOIN participants p ON p.id = t.tippee

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,10 @@
+BEGIN;
+    ALTER TABLE tips ADD COLUMN paid_in_advance currency_amount;
+
+    DROP VIEW current_tips;
+    CREATE VIEW current_tips AS
+        SELECT DISTINCT ON (tipper, tippee) *
+          FROM tips
+      ORDER BY tipper, tippee, mtime DESC;
+    DROP FUNCTION update_tip();
+END;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -11,6 +11,8 @@ BEGIN;
 END;
 
 ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'tip-in-advance';
+ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'take-in-advance';
+
 BEGIN;
     ALTER TABLE transfers ADD COLUMN unit_amount currency_amount;
     ALTER TABLE transfers ADD CONSTRAINT unit_amount_currency_chk CHECK (unit_amount::currency = amount::currency);

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,5 +1,6 @@
 BEGIN;
     ALTER TABLE tips ADD COLUMN paid_in_advance currency_amount;
+    ALTER TABLE tips ADD CONSTRAINT paid_in_advance_currency_chk CHECK (paid_in_advance::currency = amount::currency);
 
     DROP VIEW current_tips;
     CREATE VIEW current_tips AS
@@ -7,4 +8,10 @@ BEGIN;
           FROM tips
       ORDER BY tipper, tippee, mtime DESC;
     DROP FUNCTION update_tip();
+END;
+
+ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'tip-in-advance';
+BEGIN;
+    ALTER TABLE transfers ADD COLUMN unit_amount currency_amount;
+    ALTER TABLE transfers ADD CONSTRAINT unit_amount_currency_chk CHECK (unit_amount::currency = amount::currency);
 END;

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -154,6 +154,16 @@ class TestClosing(FakeTransfersHarness):
         assert bob.refetch().balance == EUR('0.01')
         assert carl.refetch().balance == 0
 
+    def test_dbtd_distributes_to_team_of_one_with_zero_take(self):
+        team = self.make_participant('team', kind='group')
+        alice = self.make_participant('alice', balance=EUR('0.12'))
+        bob = self.make_participant('bob')
+        alice.set_tip_to(team, EUR('3.00'))
+        team.add_member(bob)
+        alice.distribute_balances_to_donees()
+        assert alice.balance == 0
+        assert bob.refetch().balance == EUR('0.12')
+
 
     # ctg - clear_tips_giving
 

--- a/tests/py/test_payio.py
+++ b/tests/py/test_payio.py
@@ -32,7 +32,7 @@ from liberapay.exceptions import (
 )
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.models.participant import Participant
-from liberapay.testing import EUR, Foobar
+from liberapay.testing import EUR, USD, Foobar
 from liberapay.testing.mangopay import FakeTransfersHarness, Harness, MangopayHarness
 from liberapay.utils import NS
 
@@ -64,10 +64,12 @@ class TestPayouts(MangopayHarness):
 
     @mock.patch('mangopay.resources.BankAccount.get')
     def test_payout_amount_under_minimum(self, gba):
-        self.make_exchange('mango-cc', 8, 0, self.homer)
+        usd_user = self.make_participant('usd_user', main_currency='USD')
+        route = ExchangeRoute.insert(usd_user, 'mango-ba', 'fake ID')
+        self.make_exchange('mango-cc', USD(8), 0, usd_user)
         gba.return_value = self.bank_account_outside_sepa
         with self.assertRaises(FeeExceedsAmount):
-            payout(self.db, self.homer_route, EUR('0.10'))
+            payout(self.db, route, USD('0.10'))
 
     @mock.patch('liberapay.billing.transactions.test_hook')
     def test_payout_failure(self, test_hook):
@@ -366,7 +368,7 @@ class TestFees(MangopayHarness):
 
     def test_skim_credit_outside_sepa(self):
         actual = skim_credit(EUR('10.00'), self.bank_account_outside_sepa)
-        assert actual == (EUR('7.07'), EUR('2.93'), EUR('0.43'))
+        assert actual == (EUR('10.00'), EUR('0.00'), EUR('0.00'))
 
 
 class TestRecordExchange(MangopayHarness):

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from pando.utils import utcnow
 
+from liberapay.constants import ZERO
 from liberapay.models.participant import Participant
 from liberapay.utils import get_participant, group_by
 
@@ -39,7 +40,8 @@ tips_by_currency = group_by(tips, lambda t: t.amount.currency)
 tips_by_currency = {
     currency: (
         sorted(tips, key=lambda t: (-t.amount.amount, t.tippee_p.username)),
-        Money.sum((t.amount for t in tips), currency)
+        Money.sum((t.amount for t in tips), currency),
+        Money.sum((t.amount for t in tips if (t.paid_in_advance or ZERO[currency]) > t.amount), currency)
     )
     for currency, tips in tips_by_currency.items()
 }
@@ -107,14 +109,14 @@ if not freeload:
     <h3>{{ _("Donations") }} (N={{ ntips }})</h3>
     <p>{{ _("You give {0} per week.", participant.giving) }}</p>
     % for currency, t in tips_by_currency.items()
-    % set tips, total = t
+    % set tips, total, paid_in_advance = t
     % set currency_name = locale.currencies.get(currency, currency)
     % if n_tip_currencies > 1
     <h4>{{ locale.title(currency_name) }} ({{ locale.currency_symbols.get(currency, currency) }})</h4>
     % endif
     % set receiving = participant.get_receiving_in(currency)
     % set weekly = total - receiving
-    % if weekly > 0
+    % if weekly > paid_in_advance
         % set balance = participant.get_balance_in(currency)
         % set funded = balance // weekly
         <p class="{{ 'text-success' if funded > 3 else 'alert alert-warning' }}">

--- a/www/%username/wallet/empty.spt
+++ b/www/%username/wallet/empty.spt
@@ -1,0 +1,68 @@
+from liberapay.utils import b64encode_s, get_participant
+
+[---]
+
+participant = get_participant(state, restrict=True)
+
+if request.method == 'POST':
+    disburse_to = request.body['disburse_to']
+    if disburse_to == 'payout':
+        response.redirect(participant.path('wallet/payout/'+b64encode_s(request.line.uri)))
+    elif disburse_to == 'payin-refund':
+        participant.refund_balances()
+    elif disburse_to == 'downstream':
+        participant.distribute_balances_to_donees(final_gift=False)
+    else:
+        raise response.error(400, "bad `disburse_to` value %r in body" % disburse_to)
+
+balances = participant.get_balances()
+refundable_balances = participant.get_refundable_balances()
+
+title = _("Emptying your wallet")
+
+[---] text/html
+% extends "templates/base-thin.html"
+
+% block thin_content
+
+    % if balances == 0
+        <div class="alert alert-success">{{ _("Your wallet is empty.") }}</div>
+        % if 'close' in request.qs
+            <a class="btn btn-default btn-lg" href="{{ participant.path('settings/close') }}">{{
+                _("Close Account")
+            }}</a>
+        % endif
+    % else
+        <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+            <p>{{ _("You have {0} in your wallet. What should we do with it?",
+                    balances) }}</p>
+            <div class="paragraph">
+                <label>
+                    <input type="radio" name="disburse_to" value="downstream"
+                           {{ 'disabled' if not participant.giving else '' }} />
+                    {{ _("Give it to the {0}people I donate to{1}",
+                         '<a href="%s">'|safe % participant.path('giving'), '</a>'|safe) }}
+                </label><br>
+                % if refundable_balances >= balances
+                <label>
+                    <input type="radio" name="disburse_to" value="payin-refund" />
+                    {{ _("Refund it to my card or bank account") }}
+                </label><br>
+                % else
+                <label>
+                    <input type="radio" name="disburse_to" value="payout" />
+                    {{ _("Withdraw it to my bank account") }}
+                </label>
+                % endif
+            </div>
+            <p>{{ _(
+                "If neither option works for you, please contact support@liberapay.com."
+            ) }}</p>
+
+            <button class="btn btn-danger btn-lg">{{ _("Proceed") }}</button>
+        </form>
+    % endif
+
+% endblock

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -285,8 +285,16 @@ if user.is_admin:
                      link_close='</a>'|safe,
                      payer=('<a href="/{0}/">{0}</a>'|safe).format(event['username']),
                 ) }}
-            % elif context == 'tip'
+            % elif context in ('tip', 'tip-in-advance')
                 {{ _("anonymous donation") }}
+                % if event['unit_amount']
+                    % set weeks = int(event['amount'] / event['unit_amount'])
+                    ({{ ngettext(
+                        "{n} week of {money_amount}",
+                        "{n} weeks of {money_amount}",
+                        weeks, money_amount=event['unit_amount']
+                    ) }})
+                % endif
             % elif context == 'final-gift'
                 {{ _("one-off donation from someone closing their account") }}
             % elif context == 'chargeback'
@@ -312,8 +320,16 @@ if user.is_admin:
                      link_close='</a>'|safe,
                      payee=to,
                 ) }}
-            % elif context == 'tip'
+            % elif context in ('tip', 'tip-in-advance')
                 {{ _("donation to {0}", to) }}
+                % if event['unit_amount']
+                    % set weeks = int(abs(event['amount'] / event['unit_amount']))
+                    ({{ ngettext(
+                        "{n} week of {money_amount}",
+                        "{n} weeks of {money_amount}",
+                        weeks, money_amount=event['unit_amount']
+                    ) }})
+                % endif
             % elif context == 'chargeback'
                 {{ _("chargeback") }}
             % elif context == 'debt'

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -273,9 +273,17 @@ if user.is_admin:
                 % if event['team']
                     for team <a href="/{{ event['team_name'] }}/">{{ event['team_name'] }}</a>
                 % endif
-            % elif context == 'take'
+            % elif context in ('take', 'take-in-advance')
                 {{ _("anonymous donation for your role in the {0} team",
                      ('<a href="/{0}/">{0}</a>'|safe).format(event['team_name'])) }}
+                % if event['unit_amount']
+                    % set weeks = int(event['amount'] / event['unit_amount'])
+                    ({{ ngettext(
+                        "{n} week of {money_amount}",
+                        "{n} weeks of {money_amount}",
+                        weeks, money_amount=event['unit_amount']
+                    ) }})
+                % endif
             % elif context == 'refund'
                 {{ _("donation refund") }}
             % elif context == 'expense'
@@ -308,9 +316,17 @@ if user.is_admin:
             % set to = ('<a href="/{0}/">{0}</a>'|safe).format(event['username'])
             % if context == 'final-gift'
                 {{ _("final gift to {0}", to) }}
-            % elif context == 'take'
+            % elif context in ('take', 'take-in-advance')
                 {{ _("donation to {0} for their role in the {1} team", to,
                      ('<a href="/{0}/">{0}</a>'|safe).format(event['team_name'])) }}
+                % if event['unit_amount']
+                    % set weeks = int(abs(event['amount'] / event['unit_amount']))
+                    ({{ ngettext(
+                        "{n} week of {money_amount}",
+                        "{n} weeks of {money_amount}",
+                        weeks, money_amount=event['unit_amount']
+                    ) }})
+                % endif
             % elif context == 'refund'
                 {{ _("refund of anonymous donation") }}
             % elif context == 'expense'

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -154,10 +154,8 @@ title = _("Withdrawing Money")
     % endfor
     </p>
     <p>{{ _(
-        "Withdrawing euros to a SEPA bank account is free, transfers to other "
-        "countries cost {0} each. Withdrawing US dollars costs {1} per transfer "
+        "Withdrawing euros is free. Withdrawing US dollars costs {0} per transfer "
         "regardless of the destination country.",
-        constants.FEE_PAYOUT['EUR']['foreign'].with_vat,
         constants.FEE_PAYOUT['USD']['*'].with_vat,
     ) }}</p>
     % endif
@@ -165,9 +163,7 @@ title = _("Withdrawing Money")
     % if show_form
     % if currency == 'EUR'
     <p>{{ _(
-        "Withdrawing euros to a SEPA bank account is free, transfers to other "
-        "countries cost {0} each.",
-        constants.FEE_PAYOUT['EUR']['foreign'].with_vat,
+        "There are no fees when withdrawing euros to your bank account."
     ) }}</p>
     % elif currency == 'USD'
     <p>{{ _(

--- a/www/%username/wallet/statement.spt
+++ b/www/%username/wallet/statement.spt
@@ -193,8 +193,16 @@ output.body = render(globals(), allow_partial_i18n=False)
             <td>
             % set context = event['context']
             % if event['tippee'] == participant.id
-                % if context == 'take'
+                % if context in ('take', 'take-in-advance')
                     {{ _("anonymous donation for your role in the {0} team", event['team_name']) }}
+                    % if event['unit_amount']
+                        % set weeks = int(event['amount'] / event['unit_amount'])
+                        ({{ ngettext(
+                            "{n} week of {money_amount}",
+                            "{n} weeks of {money_amount}",
+                            weeks, money_amount=event['unit_amount']
+                        ) }})
+                    % endif
                 % elif context == 'refund'
                     {{ _("donation refund") }}
                 % elif context == 'expense'
@@ -227,8 +235,16 @@ output.body = render(globals(), allow_partial_i18n=False)
                 % set to = event['username']
                 % if context == 'final-gift'
                     {{ _("final gift to {0}", to) }}
-                % elif context == 'take'
+                % elif context in ('take', 'take-in-advance')
                     {{ _("donation to {0} for their role in the {1} team", to, event['team_name']) }}
+                    % if event['unit_amount']
+                        % set weeks = int(abs(event['amount'] / event['unit_amount']))
+                        ({{ ngettext(
+                            "{n} week of {money_amount}",
+                            "{n} weeks of {money_amount}",
+                            weeks, money_amount=event['unit_amount']
+                        ) }})
+                    % endif
                 % elif context == 'refund'
                     {{ _("refund of anonymous donation") }}
                 % elif context == 'expense'

--- a/www/%username/wallet/statement.spt
+++ b/www/%username/wallet/statement.spt
@@ -204,8 +204,16 @@ output.body = render(globals(), allow_partial_i18n=False)
                          link_close='',
                          payer=event['username'],
                     ) }}
-                % elif context == 'tip'
+                % elif context in ('tip', 'tip-in-advance')
                     {{ _("anonymous donation") }}
+                    % if event['unit_amount']
+                        % set weeks = int(event['amount'] / event['unit_amount'])
+                        ({{ ngettext(
+                            "{n} week of {money_amount}",
+                            "{n} weeks of {money_amount}",
+                            weeks, money_amount=event['unit_amount']
+                        ) }})
+                    % endif
                 % elif context == 'final-gift'
                     {{ _("one-off donation from someone closing their account") }}
                 % elif context == 'chargeback'
@@ -230,8 +238,16 @@ output.body = render(globals(), allow_partial_i18n=False)
                          link_close='',
                          payee=to,
                     ) }}
-                % elif context == 'tip'
+                % elif context in ('tip', 'tip-in-advance')
                     {{ _("donation to {0}", to) }}
+                    % if event['unit_amount']
+                        % set weeks = int(abs(event['amount'] / event['unit_amount']))
+                        ({{ ngettext(
+                            "{n} week of {money_amount}",
+                            "{n} weeks of {money_amount}",
+                            weeks, money_amount=event['unit_amount']
+                        ) }})
+                    % endif
                 % elif context == 'chargeback'
                     {{ _("chargeback") }}
                 % elif context == 'debt'

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -128,10 +128,8 @@ title = _("Frequently Asked Questions")
             <td>{{ _("not supported") }}
     </table>
     <p>{{ _(
-        "Withdrawing euros to a SEPA bank account is free, transfers to other "
-        "countries cost {0} each. Withdrawing US dollars costs {1} per transfer "
+        "Withdrawing euros is free. Withdrawing US dollars costs {0} per transfer "
         "regardless of the destination country.",
-        constants.FEE_PAYOUT['EUR']['foreign'].with_vat,
         constants.FEE_PAYOUT['USD']['*'].with_vat,
     ) }}</p>
     <p>{{ _(


### PR DESCRIPTION
This branch creates a page that allows a user to empty their MangoPay wallets without closing their Liberapay account. It's not really complete, in particular it doesn't include any of the necessary payday modifications, because I haven't completely figured out how to adapt payday yet.