### PR TITLE
Grammar fix when "etc." before parenthesis

### DIFF
--- a/www/%username/donate.spt
+++ b/www/%username/donate.spt
@@ -79,7 +79,7 @@ full_title = _("Donate to {0} via Liberapay", participant.username)
 
     <h4>{{ _("What payment methods are available?") }}</h4>
     <p>{{ _(
-        "We currently support credit and debit cards (VISA, MasterCard, etc). "
+        "We currently support credit and debit cards (VISA, MasterCard, etc.). "
         "SEPA direct debits will be operational soon. More options will be "
         "added in the future."
     ) }}</p>

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -102,7 +102,7 @@ title = _("Frequently Asked Questions")
     {{ dt(_("What payment methods are available?"), 'payment-methods') }}
 
     <dd>{{ _(
-        "We currently support credit and debit cards (VISA, MasterCard, etc). "
+        "We currently support credit and debit cards (VISA, MasterCard, etc.). "
         "SEPA direct debits will be operational soon. More options will be "
         "added in the future."
     ) }}</dd>

--- a/www/explore/index.html.spt
+++ b/www/explore/index.html.spt
@@ -37,7 +37,7 @@ title = _("Explore")
     <div class="card card-default card-md text-center">
         <h3 class="text-info">{{ _("Individuals") }}</h3>
         <p>{{ _(
-            "People like you who contribute to the commons (art, knowledge, software, etc). "
+            "People like you who contribute to the commons (art, knowledge, software, etc.). "
         ) }}</p>
         <p><a class="btn btn-info btn-lg" href="/explore/individuals">{{ _("Explore Individuals") }}</a></p>
     </div>

--- a/www/migrate.spt
+++ b/www/migrate.spt
@@ -307,7 +307,7 @@ title = _("Migrating from Gratipay")
                 platform=platform
             ) }}</p>
             <ul class="status-list list-yes">
-                <li>{{ _("basic account data (username, avatar, some privacy settings, etc)") }}</li>
+                <li>{{ _("basic account data (username, avatar, some privacy settings, etc.)") }}</li>
                 <li>{{ _("profile descriptions") }}</li>
                 <li>{{ _("teams (we will create them for you)") }}</li>
                 <li>{{ _("ongoing donations (if the donee hasn't joined Liberapay yet a pledge will be created instead)") }}</li>
@@ -318,7 +318,7 @@ title = _("Migrating from Gratipay")
             <ul class="status-list list-no">
                 <li>{{ _("any saved credit card number") }}</li>
                 <li>{{ _("any money currently in the account") }}</li>
-                <li>{{ _("the account's history (ledger, etc)") }}</li>
+                <li>{{ _("the account's history (ledger, etc.)") }}</li>
                 <li>{{ _("any paypal address (our payment processor doesn't support paypal yet)") }}</li>
             </ul>
             % if '@' not in request.body['email_address']


### PR DESCRIPTION
"etc." is an abbreviation, so it should have a dot, even if it's before the
closing parenthesis.