### PR TITLE
Update Debian version from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8
+FROM debian:9
 
 RUN apt-get update && \
     apt-get install -y build-essential wget libpq-dev libffi-dev python-dev postgresql-client && \


### PR DESCRIPTION
Now it uses Debian 9. @MartinDelille, this should fix #1204