### PR TITLE
Disable Mangopay transfers

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -13,6 +13,7 @@ import sys
 from time import sleep
 
 from babel.dates import format_timedelta
+import mangopay
 import pando.utils
 import requests
 
@@ -181,8 +182,14 @@ class Payday(object):
                  , main_currency
                  , accepted_currencies
               FROM participants p
-         LEFT JOIN wallets eur_w ON eur_w.owner = p.id AND eur_w.balance::currency = 'EUR' AND eur_w.is_current
-         LEFT JOIN wallets usd_w ON usd_w.owner = p.id AND usd_w.balance::currency = 'USD' AND usd_w.is_current
+         LEFT JOIN wallets eur_w ON eur_w.owner = p.id
+                                AND eur_w.balance::currency = 'EUR'
+                                AND eur_w.is_current
+                                AND %(use_mangopay)s
+         LEFT JOIN wallets usd_w ON usd_w.owner = p.id
+                                AND usd_w.balance::currency = 'USD'
+                                AND usd_w.is_current
+                                AND %(use_mangopay)s
              WHERE join_time < %(ts_start)s
                AND (mangopay_user_id IS NOT NULL OR kind = 'group')
                AND is_suspended IS NOT true
@@ -343,7 +350,7 @@ class Payday(object):
             END;
         $$ LANGUAGE plpgsql;
 
-        """, dict(ts_start=ts_start))
+        """, dict(ts_start=ts_start, use_mangopay=mangopay.sandbox))
         log("Prepared the DB.")
 
     @staticmethod

--- a/tests/py/test_callbacks.py
+++ b/tests/py/test_callbacks.py
@@ -5,8 +5,7 @@ from mock import patch
 from mangopay.resources import BankWirePayOut, BankWirePayIn, Dispute, PayIn, Refund
 from mangopay.utils import Reason
 
-from liberapay.billing.payday import Payday
-from liberapay.billing.transactions import Money, record_exchange
+from liberapay.billing.transactions import Money, record_exchange, transfer
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.security.csrf import CSRF_TOKEN
 from liberapay.testing import EUR
@@ -51,8 +50,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
         payin = PayIn(tag=str(e_id))
         get_payin.return_value = payin
         # Transfer some of the money to homer
-        self.janet.set_tip_to(self.homer, EUR('3.68'))
-        Payday.start().run()
+        transfer(self.db, self.janet.id, self.homer.id, EUR('3.68'), 'tip')
         # Withdraw some of the money
         self.make_exchange('mango-ba', EUR('-2.68'), 0, self.homer)
         # Add a bit of money that will remain undisputed, to test bundle swapping
@@ -108,8 +106,7 @@ class TestMangopayCallbacks(EmailHarness, FakeTransfersHarness, MangopayHarness)
         payin = PayIn(tag=str(e_id))
         get_payin.return_value = payin
         # Transfer some of the money to homer
-        self.janet.set_tip_to(self.homer, EUR('3.68'))
-        Payday.start().run()
+        transfer(self.db, self.janet.id, self.homer.id, EUR('3.68'), 'tip')
         # Withdraw some of the money
         self.make_exchange('mango-ba', EUR('-2.68'), 0, self.homer)
         # Add money that will remain undisputed, to test bundle swapping

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -51,16 +51,10 @@ class TestClosing(FakeTransfersHarness):
         assert 'Try Again Later' in body
 
     def test_can_post_to_close_page(self):
-        alice = self.make_participant('alice', balance=EUR(7))
-        bob = self.make_participant('bob')
-        alice.set_tip_to(bob, EUR('10.00'))
-
-        data = {'disburse_to': 'downstream'}
-        response = self.client.PxST('/alice/settings/close', auth_as=alice, data=data)
+        alice = self.make_participant('alice')
+        response = self.client.PxST('/alice/settings/close', auth_as=alice)
         assert response.code == 302
         assert response.headers[b'Location'] == b'/alice/'
-        assert Participant.from_username('alice').balance == 0
-        assert Participant.from_username('bob').balance == 7
 
     def test_cant_post_to_close_page_during_payday(self):
         Payday.start()

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -15,6 +15,8 @@ if request.method == 'POST' and not payday_is_running:
                   "choose a disbursement method below or contact support.")
     elif disburse_to == 'payout':
         response.redirect(participant.path('wallet/payout/'+b64encode_s(request.path.raw)))
+    elif disburse_to == 'downstream':
+        raise response.error(403, _("This is no longer possible, sorry."))
     else:
         participant.close(disburse_to)
         participant.sign_out(response.headers.cookie)
@@ -38,6 +40,8 @@ title = _("Close Account")
 subhead = participant.username
 
 [---] text/html
+% from "templates/icons.html" import glyphicon
+
 % extends "templates/base.html"
 
 % block content
@@ -73,18 +77,22 @@ subhead = participant.username
         <div class="paragraph">
             <label>
                 <input type="radio" name="disburse_to" value="downstream"
-                       {{ 'disabled' if not participant.giving else '' }} />
+                       disabled />
                 {{ _("Give it to the {0}people I donate to{1}",
                      '<a href="%s">'|safe % participant.path('giving'), '</a>'|safe) }}
+                <p class="text-danger">
+                    {{ glyphicon('info-sign') }}
+                    {{ _("This is no longer possible, sorry.") }}
+                </p>
             </label><br>
             % if refundable_balances >= balances
             <label>
-                <input type="radio" name="disburse_to" value="payin-refund" />
+                <input type="radio" name="disburse_to" value="payin-refund" checked />
                 {{ _("Refund it to my card or bank account") }}
             </label><br>
             % else
             <label>
-                <input type="radio" name="disburse_to" value="payout" />
+                <input type="radio" name="disburse_to" value="payout" checked />
                 {{ _("Withdraw it to my bank account") }}
             </label>
             % endif

--- a/www/%username/wallet/empty.spt
+++ b/www/%username/wallet/empty.spt
@@ -11,6 +11,7 @@ if request.method == 'POST':
     elif disburse_to == 'payin-refund':
         participant.refund_balances()
     elif disburse_to == 'downstream':
+        raise response.error(403, _("This is no longer possible, sorry."))
         participant.distribute_balances_to_donees(final_gift=False)
     else:
         raise response.error(400, "bad `disburse_to` value %r in body" % disburse_to)
@@ -21,6 +22,8 @@ refundable_balances = participant.get_refundable_balances()
 title = _("Emptying your wallet")
 
 [---] text/html
+% from "templates/icons.html" import glyphicon
+
 % extends "templates/base-thin.html"
 
 % block thin_content
@@ -41,18 +44,22 @@ title = _("Emptying your wallet")
             <div class="paragraph">
                 <label>
                     <input type="radio" name="disburse_to" value="downstream"
-                           {{ 'disabled' if not participant.giving else '' }} />
+                           disabled />
                     {{ _("Give it to the {0}people I donate to{1}",
                          '<a href="%s">'|safe % participant.path('giving'), '</a>'|safe) }}
+                    <p class="text-danger">
+                        {{ glyphicon('info-sign') }}
+                        {{ _("This is no longer possible, sorry.") }}
+                    </p>
                 </label><br>
                 % if refundable_balances >= balances
                 <label>
-                    <input type="radio" name="disburse_to" value="payin-refund" />
+                    <input type="radio" name="disburse_to" value="payin-refund" checked />
                     {{ _("Refund it to my card or bank account") }}
                 </label><br>
                 % else
                 <label>
-                    <input type="radio" name="disburse_to" value="payout" />
+                    <input type="radio" name="disburse_to" value="payout" checked />
                     {{ _("Withdraw it to my bank account") }}
                 </label>
                 % endif


### PR DESCRIPTION
This branch modifies payday to stop processing real money transfers between wallets and prevents users from emptying their wallets by transferring money to others.