### PR TITLE
Fix income amounts of team members

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -604,6 +604,19 @@ class Payday(object):
                       FROM current_tip t2
                      WHERE t.id = t2.id;
                 """, t.__dict__)
+                if t.team:
+                    db.run("""
+                        WITH current_take AS (
+                                 SELECT t.id
+                                   FROM current_takes t
+                                  WHERE t.team = %(team)s
+                                    AND t.member = %(tippee)s
+                             )
+                        UPDATE takes t
+                           SET paid_in_advance = (t.paid_in_advance - %(in_advance)s)
+                          FROM current_take t2
+                         WHERE t.id = t2.id;
+                    """, t.__dict__)
             if t.amount:
                 transfer(db, **t.__dict__)
 

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -515,8 +515,8 @@ class Payday(object):
                 in_advance_amount = min(
                     tip.amount,
                     fuzzy_take_amount,
-                    tip.paid_in_advance,
-                    take.paid_in_advance.convert(tip_currency)
+                    max(tip.paid_in_advance, 0),
+                    max(take.paid_in_advance.convert(tip_currency), 0),
                 )
                 on_time_amount = min(
                     max(tip.amount - in_advance_amount, 0),

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -190,7 +190,12 @@ class MixinTeam(object):
         """
         from liberapay.billing.payday import Payday
         tips = [NS(t._asdict()) for t in cursor.all("""
-            SELECT t.id, t.tipper, t.amount AS full_amount
+            SELECT t.id, t.tipper, t.amount AS full_amount, t.paid_in_advance
+                 , ( SELECT basket_sum(w.balance)
+                       FROM wallets w
+                      WHERE w.owner = t.tipper
+                        AND w.is_current
+                   ) AS balances
                  , coalesce_currency_amount((
                        SELECT sum(tr.amount, t.amount::currency)
                          FROM transfers tr

--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -44,8 +44,8 @@ class MixinTeam(object):
     def remove_all_members(self, cursor=None):
         (cursor or self.db).run("""
             INSERT INTO takes
-                        (ctime, member, team, amount, actual_amount, recorder)
-                 SELECT ctime, member, %(id)s, NULL, NULL, %(id)s
+                        (ctime, member, team, amount, actual_amount, recorder, paid_in_advance)
+                 SELECT ctime, member, %(id)s, NULL, NULL, %(id)s, paid_in_advance
                    FROM current_takes
                   WHERE team=%(id)s
         """, dict(id=self.id))
@@ -131,14 +131,19 @@ class MixinTeam(object):
             # Insert the new take
             cursor.run("""
 
+                WITH old_take AS (
+                         SELECT *
+                           FROM takes
+                          WHERE team = %(team)s
+                            AND member = %(member)s
+                       ORDER BY mtime DESC
+                          LIMIT 1
+                     )
                 INSERT INTO takes
-                            (ctime, member, team, amount, actual_amount, recorder)
+                            (ctime, member, team, amount, actual_amount, recorder, paid_in_advance)
                      SELECT COALESCE((
                                 SELECT ctime
-                                  FROM takes
-                                 WHERE member=%(member)s
-                                   AND team=%(team)s
-                                 LIMIT 1
+                                  FROM old_take
                             ), current_timestamp)
                           , %(member)s
                           , %(team)s
@@ -146,14 +151,11 @@ class MixinTeam(object):
                           , CASE WHEN %(amount)s IS NULL THEN NULL ELSE
                                 COALESCE((
                                     SELECT actual_amount
-                                      FROM takes
-                                     WHERE member=%(member)s
-                                       AND team=%(team)s
-                                  ORDER BY mtime DESC
-                                     LIMIT 1
+                                      FROM old_take
                                 ), empty_currency_basket())
                             END
                           , %(recorder)s
+                          , (SELECT paid_in_advance FROM old_take)
 
             """, dict(member=member.id, team=self.id, amount=take,
                       recorder=recorder.id))

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,43 @@
+BEGIN;
+
+ALTER TABLE takes ADD COLUMN paid_in_advance currency_amount;
+ALTER TABLE takes ADD CONSTRAINT paid_in_advance_currency_chk CHECK (paid_in_advance::currency = amount::currency);
+
+CREATE INDEX takes_team_idx ON takes (team);
+DROP VIEW current_takes;
+CREATE VIEW current_takes AS
+    SELECT *
+      FROM ( SELECT DISTINCT ON (team, member) t.*
+               FROM takes t
+           ORDER BY team, member, mtime DESC
+           ) AS x
+     WHERE amount IS NOT NULL;
+
+UPDATE takes AS take
+   SET paid_in_advance = coalesce_currency_amount((
+           SELECT sum(tr.amount, take.amount::currency)
+             FROM transfers tr
+            WHERE tr.tippee = take.member
+              AND tr.team = take.team
+              AND tr.context = 'take-in-advance'
+              AND tr.status = 'succeeded'
+       ), take.amount::currency) + coalesce_currency_amount((
+           SELECT sum(pt.amount, take.amount::currency)
+             FROM payin_transfers pt
+            WHERE pt.recipient = take.member
+              AND pt.team = take.team
+              AND pt.context = 'team-donation'
+              AND pt.status = 'succeeded'
+       ), take.amount::currency) - coalesce_currency_amount((
+           SELECT sum(tr.amount, take.amount::currency)
+             FROM transfers tr
+            WHERE tr.tippee = take.member
+              AND tr.team = take.team
+              AND tr.context = 'take'
+              AND tr.status = 'succeeded'
+              AND tr.virtual IS TRUE
+       ), take.amount::currency)
+  FROM current_takes ct
+ WHERE take.id = ct.id;
+
+END;

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -6,6 +6,7 @@ import mock
 
 from liberapay.billing.payday import create_payday_issue, main, NoPayday, Payday
 from liberapay.billing.transactions import create_debt
+from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.models.participant import Participant
 from liberapay.testing import EUR, USD, Foobar
 from liberapay.testing.mangopay import FakeTransfersHarness, MangopayHarness
@@ -897,6 +898,41 @@ class TestPaydayForTeams(FakeTransfersHarness):
         }
         actual = self.get_balances()
         assert expected == actual
+
+    # Takes paid in advance
+    # =====================
+
+    def test_takes_paid_in_advance(self):
+        team = self.make_participant(
+            'team', kind='group', accepted_currencies='EUR,USD'
+        )
+        alice = self.make_participant('alice', main_currency='EUR',
+                                      accepted_currencies='EUR,USD')
+        team.set_take_for(alice, EUR('1.00'), team)
+        bob = self.make_participant('bob', main_currency='USD',
+                                    accepted_currencies='EUR,USD')
+        team.set_take_for(bob, EUR('1.00'), team)
+
+        stripe_account_alice = self.add_payment_account(alice, 'stripe', default_currency='EUR')
+        self.add_payment_account(bob, 'stripe', default_currency='USD')
+
+        carl = self.make_participant('carl')
+        carl.set_tip_to(team, EUR('10'))
+
+        donor1_card = ExchangeRoute.insert(
+            carl, 'stripe-card', 'x', 'chargeable', remote_user_id='x'
+        )
+        payin, pt = self.make_payin_and_transfer(donor1_card, team, EUR('10'), 'stripe')
+        assert pt.destination == stripe_account_alice.pk
+
+        Payday.start().run()
+
+        transfers = self.db.all("SELECT * FROM transfers ORDER BY id")
+        assert len(transfers) == 1
+        assert transfers[0].virtual is True
+        assert transfers[0].tipper == carl.id
+        assert transfers[0].tippee == alice.id
+        assert transfers[0].amount == EUR('1')
 
 
 class TestPayday2(EmailHarness, FakeTransfersHarness, MangopayHarness):

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -2,60 +2,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from liberapay.exceptions import MissingPaymentAccount
 from liberapay.models.exchange_route import ExchangeRoute
-from liberapay.models.participant import Participant
-from liberapay.payin.common import (
-    prepare_payin, update_payin,
-    resolve_destination,
-    prepare_payin_transfer, update_payin_transfer,
-)
+from liberapay.payin.common import resolve_destination
 from liberapay.testing import Harness, EUR
 
 
 class TestPayins(Harness):
-
-    def make_payin_and_transfer(
-        self, route, tippee, amount, provider,
-        status='succeeded', error=None, payer_country=None,
-        unit_amount=None, period=None
-    ):
-        payer = route.participant
-        payin = prepare_payin(self.db, payer, amount, route)
-        payin = update_payin(self.db, payin.id, 'fake', status, error)
-        destination = resolve_destination(
-            self.db, tippee, provider, payer, payer_country, amount
-        )
-        recipient = Participant.from_id(destination.participant)
-        if tippee.kind == 'group':
-            context = 'team-donation'
-            team = tippee
-        else:
-            context = 'personal-donation'
-            team = None
-        pt = prepare_payin_transfer(
-            self.db, payin, recipient, destination, context, amount,
-            unit_amount, period, team.id
-        )
-        pt = update_payin_transfer(self.db, pt.id, 'fake', status, error)
-        return payin, pt
-
-    def add_payment_account(self, participant, provider, country='FR', **data):
-        data.setdefault('id', 'x')
-        data.setdefault('default_currency', None)
-        data.setdefault('charges_enabled', None)
-        data.setdefault('verified', True)
-        data.setdefault('display_name', None)
-        data.setdefault('token', None)
-        data.update(p_id=participant.id, provider=provider, country=country)
-        return self.db.one("""
-            INSERT INTO payment_accounts
-                        (participant, provider, country, id,
-                         default_currency, charges_enabled, verified,
-                         display_name, token)
-                 VALUES (%(p_id)s, %(provider)s, %(country)s, %(id)s,
-                         %(default_currency)s, %(charges_enabled)s, %(verified)s,
-                         %(display_name)s, %(token)s)
-              RETURNING *
-        """, data)
 
     def test_resolve_destination(self):
         alice = self.make_participant('alice')


### PR DESCRIPTION
This branch fixes the income amounts of team members. The underlying data is still messed up, but the income amounts should now be accurate.

We have 13 users affected by the bug fixed in this branch.