### PR TITLE
Fix the "Giving" page

### DIFF
--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -204,7 +204,7 @@ next_payday = today + timedelta(days=days_till_wednesday)
                     <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
                         "Inactive because the recipient no longer accepts donations."
                     ) }}</p>
-                % elif tip.paid_in_advance and tip.paid_in_advance >= tip.amount and next_payday > today
+                % elif tip.paid_in_advance and tip.paid_in_advance >= tip.amount
                     <p class="text-success">{{ glyphicon('ok-sign') }} {{ _("Active") }}</p>
                     % set weeks_remaning = int(tip.paid_in_advance / tip.amount)
                     <p>


### PR DESCRIPTION
This commit fixes a bug in the code of the Giving page that results in donations being displayed as "awaiting payment" instead of "active", but only on Wednesdays before payday is run.