### PR TITLE
Improve the payment pages

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -233,9 +233,9 @@ PAYIN_DIRECT_DEBIT_TARGET = {
 }
 PAYIN_DIRECT_DEBIT_MAX = {k: Money('2500.00', k) for k in ('EUR', 'USD')}
 
-PAYIN_PAYPAL_MIN_ACCEPTABLE = {  # fee > 20%
-    'EUR': Money('1.00', 'EUR'),
-    'USD': Money('1.00', 'USD'),
+PAYIN_PAYPAL_MIN_ACCEPTABLE = {  # fee > 10%
+    'EUR': Money('2.00', 'EUR'),
+    'USD': Money('2.00', 'USD'),
 }
 PAYIN_PAYPAL_MIN_RECOMMENDED = {  # fee < 8%
     'EUR': Money('10.00', 'EUR'),
@@ -250,9 +250,9 @@ PAYIN_PAYPAL_MAX_ACCEPTABLE = {
     'USD': Money('5000.00', 'USD'),
 }
 
-PAYIN_STRIPE_MIN_ACCEPTABLE = {  # fee > 20%
-    'EUR': Money('1.00', 'EUR'),
-    'USD': Money('1.00', 'USD'),
+PAYIN_STRIPE_MIN_ACCEPTABLE = {  # fee > 10%
+    'EUR': Money('2.00', 'EUR'),
+    'USD': Money('2.00', 'USD'),
 }
 PAYIN_STRIPE_MIN_RECOMMENDED = {  # fee < 8%
     'EUR': Money('10.00', 'EUR'),

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -1,5 +1,6 @@
 # coding: utf8
 
+from datetime import timedelta
 from math import ceil
 
 from mangopay.exceptions import CurrencyMismatch
@@ -226,6 +227,8 @@ title = _("Funding your donations")
                     % endif
                     </h5>
                     <p class="list-group-item-text">{{ ngettext(
+                        "", "Next payment in {n} weeks ({timedelta}).", n=multiplier, timedelta=timedelta(weeks=multiplier)
+                    ) if tip.period == 'weekly' and multiplier > 7 else ngettext(
                         "Next payment in {n} week.", "Next payment in {n} weeks.", n=multiplier
                     ) if tip.period == 'weekly' else ngettext(
                         "Next payment in {n} month.", "Next payment in {n} months.", n=multiplier

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -120,9 +120,15 @@ if donations:
     tip = donations[0]
     tip_currency = tip.amount.currency
     tip.min_acceptable_amount = constants.PAYIN_STRIPE_MIN_ACCEPTABLE[tip_currency]
-    tip.min_recommended_amount = constants.PAYIN_STRIPE_MIN_RECOMMENDED[tip_currency]
+    tip.min_recommended_amount = min(
+        constants.PAYIN_STRIPE_MIN_RECOMMENDED[tip_currency],
+        tip.periodic_amount * ONE_YEAR[tip.period] * 12
+    )
     tip.low_fee_amount = constants.PAYIN_STRIPE_LOW_FEE[tip_currency]
-    tip.max_acceptable_amount = constants.PAYIN_STRIPE_MAX_ACCEPTABLE[tip_currency]
+    tip.max_acceptable_amount = min(
+        constants.PAYIN_STRIPE_MAX_ACCEPTABLE[tip_currency],
+        tip.periodic_amount * ONE_YEAR[tip.period] * 12
+    )
     min_multiplier = int(ceil(tip.min_acceptable_amount / tip.periodic_amount))
     min_recommended_multiplier = int(ceil(tip.min_recommended_amount / tip.periodic_amount))
     max_recommended_multiplier = min(

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -265,9 +265,6 @@ title = _("Funding your donations")
 
 % if not donations
     % if donations_not_fundable or other_donations or non_paypal_donations
-        % if donations
-            <hr>
-        % endif
         % for tip in donations_not_fundable
         <p>{{ _(
             "Your donation to {recipient} cannot be processed right now because the "

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -250,6 +250,21 @@ title = _("Funding your donations")
             </ul>
         </fieldset>
 
+        % if payer.mangopay_user_id
+        <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
+            "Liberapay no longer stores money in wallets, the entire amount "
+            "of your payment will go immediately to the {payment_provider} "
+            "account of {recipient_name}.",
+            payment_provider='PayPal', recipient_name=tip.tippee_p.username
+        ) }}</p>
+        % else
+        <p>{{ _(
+            "The entire amount of your payment will go immediately to the "
+            "{payment_provider} account of {recipient_name}.",
+            payment_provider='PayPal', recipient_name=tip.tippee_p.username
+        ) }}</p>
+        % endif
+
         <div class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
             "PayPal payments are currently not anonymous, the recipient will "
             "see your name and email address."

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -119,14 +119,14 @@ donations, non_paypal_donations = partition(
 if donations:
     tip = donations[0]
     tip_currency = tip.amount.currency
-    tip.min_acceptable_amount = constants.PAYIN_STRIPE_MIN_ACCEPTABLE[tip_currency]
+    tip.min_acceptable_amount = constants.PAYIN_PAYPAL_MIN_ACCEPTABLE[tip_currency]
     tip.min_recommended_amount = min(
-        constants.PAYIN_STRIPE_MIN_RECOMMENDED[tip_currency],
+        constants.PAYIN_PAYPAL_MIN_RECOMMENDED[tip_currency],
         tip.periodic_amount * ONE_YEAR[tip.period] * 12
     )
-    tip.low_fee_amount = constants.PAYIN_STRIPE_LOW_FEE[tip_currency]
+    tip.low_fee_amount = constants.PAYIN_PAYPAL_LOW_FEE[tip_currency]
     tip.max_acceptable_amount = min(
-        constants.PAYIN_STRIPE_MAX_ACCEPTABLE[tip_currency],
+        constants.PAYIN_PAYPAL_MAX_ACCEPTABLE[tip_currency],
         tip.periodic_amount * ONE_YEAR[tip.period] * 12
     )
     min_multiplier = int(ceil(tip.min_acceptable_amount / tip.periodic_amount))

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -1,5 +1,6 @@
 # coding: utf8
 
+from datetime import timedelta
 from math import ceil
 
 import stripe
@@ -367,6 +368,8 @@ title = _("Funding your donations")
                     % endif
                     </h5>
                     <p class="list-group-item-text">{{ ngettext(
+                        "", "Next payment in {n} weeks ({timedelta}).", n=multiplier, timedelta=timedelta(weeks=multiplier)
+                    ) if tip.period == 'weekly' and multiplier > 7 else ngettext(
                         "Next payment in {n} week.", "Next payment in {n} weeks.", n=multiplier
                     ) if tip.period == 'weekly' else ngettext(
                         "Next payment in {n} month.", "Next payment in {n} months.", n=multiplier

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -431,9 +431,6 @@ title = _("Funding your donations")
 
 % if not donations
     % if donations_not_fundable or other_donations or non_stripe_donations
-        % if donations
-            <hr>
-        % endif
         % for tip in donations_not_fundable
         <p>{{ _(
             "Your donation to {recipient} cannot be processed right now because the "

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -417,9 +417,25 @@ title = _("Funding your donations")
                 <input type="checkbox" name="keep" value="true" checked />
                 {{ _("Remember the card number for next time") }}
             </label>
-            <br><br>
+            <br>
         </div>
 
+        % if payer.mangopay_user_id
+        <div class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
+            "Liberapay no longer stores money in wallets, the entire amount "
+            "of your payment will go immediately to the {payment_provider} "
+            "account of {recipient_name}.",
+            payment_provider='Stripe', recipient_name=tip.tippee_p.username
+        ) }}</div>
+        % else
+        <div>{{ _(
+            "The entire amount of your payment will go immediately to the "
+            "{payment_provider} account of {recipient_name}.",
+            payment_provider='Stripe', recipient_name=tip.tippee_p.username
+        ) }}</div>
+        % endif
+
+        <br>
         <button class="btn btn-primary btn-lg btn-block">{{ _(
             "Initiate the payment"
         ) }}</button>

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -198,9 +198,15 @@ if donations:
     tip = donations[0]
     tip_currency = tip.amount.currency
     tip.min_acceptable_amount = constants.PAYIN_STRIPE_MIN_ACCEPTABLE[tip_currency]
-    tip.min_recommended_amount = constants.PAYIN_STRIPE_MIN_RECOMMENDED[tip_currency]
+    tip.min_recommended_amount = min(
+        constants.PAYIN_STRIPE_MIN_RECOMMENDED[tip_currency],
+        tip.periodic_amount * ONE_YEAR[tip.period] * 12
+    )
     tip.low_fee_amount = constants.PAYIN_STRIPE_LOW_FEE[tip_currency]
-    tip.max_acceptable_amount = constants.PAYIN_STRIPE_MAX_ACCEPTABLE[tip_currency]
+    tip.max_acceptable_amount = min(
+        constants.PAYIN_STRIPE_MAX_ACCEPTABLE[tip_currency],
+        tip.periodic_amount * ONE_YEAR[tip.period] * 12
+    )
     min_multiplier = int(ceil(tip.min_acceptable_amount / tip.periodic_amount))
     min_recommended_multiplier = int(ceil(tip.min_recommended_amount / tip.periodic_amount))
     max_recommended_multiplier = min(


### PR DESCRIPTION
This branch:

- adds a warning for donors who used Mangopay that the money they're about to send is not going into their wallet but in the Stripe or PayPal account of the recipient
- raises the minimum payment amount to 2.00 EUR/USD
- lowers the maximum payment amount to the equivalent of 12 years of the donation
