### PR TITLE
Replace sign-in links with forms

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -962,3 +962,13 @@ ul.list-no > li::before, ul.status-list > li.not-ok-danger::before {
         margin-bottom: 0;
     }
 }
+
+.link {
+    background: transparent;
+    border: none;
+    color: $link-color;
+    &:hover {
+        color: $link-hover-color;
+        text-decoration: $link-hover-decoration;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
     % endif
     {% block head %}{% endblock %}
 </head>
-% from "templates/icons.html" import fontawesome, glyphicon, icon_span
+% from "templates/icons.html" import fontawesome, glyphicon
 % from 'templates/nav.html' import nav, nav_about, nav_explore with context
 % from 'templates/search.html' import search_form with context
 <body id="{{ page_id or '' }}">
@@ -62,8 +62,8 @@
             % if not user.ANON
                 % include "templates/navbar-logged-in.html"
             % elif response.html_template != 'templates/auth-required.html' and not no_navbar_sign_in
-                % set sign_in_icon = icon_span('glyphicon glyphicon-log-in')
-                <li>{% include "templates/sign-in-link.html" %}</li>
+                % from "templates/sign-in-link.html" import sign_in_link with context
+                <li>{{ sign_in_link('glyphicon glyphicon-log-in', 'navbar-btn') }}</li>
             % endif
             </ul>
             <div class="collapse navbar-collapse navbar-left" id="navbar-liberapay-collapse">

--- a/templates/sign-in-link.html
+++ b/templates/sign-in-link.html
@@ -1,3 +1,11 @@
-<a href="/sign-in?back_to={{ urlquote(request.line.uri) }}" rel="nofollow"
-   {% if request.method not in ('GET', 'HEAD') %} target="_blank" {% endif %}
-   >{{ sign_in_icon or '' }}<span class="text">{{ _("Log In or Create Account") }}</span></a>
+% from "templates/icons.html" import icon_span
+
+% macro sign_in_link(icon_cls='', btn_cls='link')
+    <form action="/sign-in" method="GET" {% if request.method not in ('GET', 'HEAD')
+          %} target="_blank" {% endif %}>
+        <button class="{{ btn_cls }}" name="back_to" value="{{ request.line.uri }}">
+            {{- icon_span(icon_cls) if icon_cls else '' -}}
+            <span class="text">{{ _("Log In or Create Account") }}</span>
+        </button>
+    </form>
+% endmacro

--- a/www/on/%platform/%user_name/index.html.spt
+++ b/www/on/%platform/%user_name/index.html.spt
@@ -200,7 +200,8 @@ if is_team:
         % elif not locked
             % if user.ANON
                 <p>{{ _("We never collect money for you unless you join.") }}</p>
-                % include "templates/sign-in-link.html"
+                % from "templates/sign-in-link.html" import sign_in_link with context
+                {{ sign_in_link() }}
                 <br>
             % else
                 <p>{{ _("Connect this {0} account to your Liberapay profile.",

--- a/www/on/%platform/index.spt
+++ b/www/on/%platform/index.spt
@@ -64,7 +64,8 @@ limited = getattr(platform, 'api_friends_limited', False)
 % block content
 
 % if user.ANON
-<p>{% include "templates/sign-in-link.html" %}</p>
+    % from "templates/sign-in-link.html" import sign_in_link with context
+    <p>{{ sign_in_link() }}</p>
 % elif need_reconnect
 <div class="paragraph">
     <p>{{ _(


### PR DESCRIPTION
This branch makes a change that should be invisible to most users, its purpose is to rid us of the ridiculously high number of junk requests for `/sign-in?back_to=$path` that we regularly get from dumb web crawlers.