### PR TITLE
Fix Payday

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -192,7 +192,6 @@ class Payday(object):
                                 AND usd_w.is_current
                                 AND %(use_mangopay)s
              WHERE join_time < %(ts_start)s
-               AND (mangopay_user_id IS NOT NULL OR kind = 'group')
                AND is_suspended IS NOT true
                AND status = 'active'
           ORDER BY join_time;


### PR DESCRIPTION
The single-line change in this branch fixes a big bug in payday: the donations to and from users who don't have a Mangopay account were ignored! I'm going to look into creating virtual transfers retroactively to mitigate the effect of this fiasco.