### PR TITLE
Document how to close a team account

### DIFF
--- a/www/about/teams.spt
+++ b/www/about/teams.spt
@@ -142,5 +142,11 @@ title = _("Teams")
     "there is consensus on that among the other members."
 ) }}</p>
 
+<h3>{{ _("Closing a team account") }}</h3>
+
+<p>{{ _(
+    "A team account is automatically closed when its last member leaves."
+) }}</p>
+
 </div></div>
 % endblock


### PR DESCRIPTION
We've received a few emails about closing team accounts in the past.