### PR TITLE
Elsewhere cleanup - part 2

### DIFF
--- a/liberapay/elsewhere/_base.py
+++ b/liberapay/elsewhere/_base.py
@@ -246,6 +246,8 @@ class Platform(object):
         r.is_team = self.x_is_team(r, info, False)
         r.description = self.x_description(r, info, None)
         r.extra_info = info
+        if hasattr(self, 'x_extra_info_drop'):
+            self.x_extra_info_drop(r.extra_info)
         return r
 
     def get_team_members(self, account, domain, page_url=None):

--- a/liberapay/elsewhere/github.py
+++ b/liberapay/elsewhere/github.py
@@ -44,6 +44,7 @@ class GitHub(PlatformOAuth2):
     x_avatar_url = key('avatar_url')
     x_is_team = key('type', clean=lambda t: t.lower() == 'organization')
     x_description = key('bio')
+    x_extra_info_drop = drop_keys(lambda k: k.endswith('_url'))
 
     # Repo info extractors
     x_repo_id = key('id')

--- a/liberapay/elsewhere/twitter.py
+++ b/liberapay/elsewhere/twitter.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from liberapay.elsewhere._base import PlatformOAuth1
-from liberapay.elsewhere._extractors import key, not_available
+from liberapay.elsewhere._extractors import drop_keys, key, not_available
 from liberapay.elsewhere._paginators import query_param_paginator
 
 
@@ -29,7 +29,7 @@ class Twitter(PlatformOAuth1):
     ratelimit_headers_prefix = 'x-rate-limit-'
 
     # User info extractors
-    x_user_id = key('id')
+    x_user_id = key('id_str')
     x_user_name = key('screen_name')
     x_display_name = key('name')
     x_email = not_available
@@ -37,3 +37,4 @@ class Twitter(PlatformOAuth1):
                        clean=lambda v: v.replace('_normal.', '.'))
     x_friends_count = key('friends_count')
     x_description = key('description')
+    x_extra_info_drop = drop_keys('id')

--- a/liberapay/elsewhere/twitter.py
+++ b/liberapay/elsewhere/twitter.py
@@ -22,10 +22,10 @@ class Twitter(PlatformOAuth1):
                                           prev='previous_cursor',
                                           next='next_cursor')
     api_url = 'https://api.twitter.com/1.1'
-    api_user_info_path = '/users/show.json?user_id={user_id}'
-    api_user_name_info_path = '/users/show.json?screen_name={user_name}'
-    api_user_self_info_path = '/account/verify_credentials.json'
-    api_friends_path = '/friends/list.json?user_id={user_id}&skip_status=true'
+    api_user_info_path = '/users/show.json?user_id={user_id}&include_entities=false'
+    api_user_name_info_path = '/users/show.json?screen_name={user_name}&include_entities=false'
+    api_user_self_info_path = '/account/verify_credentials.json?include_entities=false&skip_status=true'
+    api_friends_path = '/friends/list.json?user_id={user_id}&include_user_entities=false&skip_status=true'
     ratelimit_headers_prefix = 'x-rate-limit-'
 
     # User info extractors

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 UPDATE elsewhere
    SET extra_info = (
            extra_info::jsonb - 'events_url' - 'followers_url' - 'following_url'
@@ -6,3 +8,10 @@ UPDATE elsewhere
        )::json
  WHERE platform = 'github'
    AND json_typeof(extra_info) = 'object';
+
+UPDATE elsewhere
+   SET extra_info = (extra_info::jsonb - 'entities' - 'status')::json
+ WHERE platform = 'twitter'
+   AND json_typeof(extra_info) = 'object';
+
+END;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,8 @@
+UPDATE elsewhere
+   SET extra_info = (
+           extra_info::jsonb - 'events_url' - 'followers_url' - 'following_url'
+           - 'gists_url' - 'html_url' - 'organizations_url' - 'received_events_url'
+           - 'repos_url' - 'starred_url' - 'subscriptions_url'
+       )::json
+ WHERE platform = 'github'
+   AND json_typeof(extra_info) = 'object';

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -10,7 +10,7 @@ UPDATE elsewhere
    AND json_typeof(extra_info) = 'object';
 
 UPDATE elsewhere
-   SET extra_info = (extra_info::jsonb - 'entities' - 'status')::json
+   SET extra_info = (extra_info::jsonb - 'id_str' - 'entities' - 'status')::json
  WHERE platform = 'twitter'
    AND json_typeof(extra_info) = 'object';
 

--- a/tests/py/fixtures/TestElsewhere.yml
+++ b/tests/py/fixtures/TestElsewhere.yml
@@ -7,29 +7,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52TUW+kIBSF/wvPtqi7M92SNP0DTfalT32ZoFK9CQIBtJk1/e89qNO4k80mzpNA
-        7vk4HO+dmLYtGSaYpkp56eSZZYwaJorycMzzx8eMyVFG6U+D1yjrYnRBcL4chvuWYjdUQ1C+tiYq
-        E+9r2/OBX+TP49MPEFu/UhKa4eCK5mglLXLgAt866mKvrxwsN8/128p3q7X9gP7a8H+v4N8yeFvW
-        ZNpbEJBN3MZOITE84zM9nkLcaWeWTDx9TtQkSMA/8KrZZ2kVwdCHgZeJe+XsTBuqUHtykazZae0v
-        KVDWt9LQH3kDCtIAQjK108QsgVSNaLmd2kUzcedplPU5xeFVrWhEurfwrsTAxbNTaPPfm2RS5hTV
-        STZ9Grd3qYPKmJF9KnzZzB762UlzZsIMWmeswnyuY4ep+270ue3B1Laeg7+Uq14SxnTRduSVrDRu
-        WFlkL0s3VJrq0xKjKDK2Hsx9x0R+GQLM0WaH3p53NbgRackIa2VeHO7yw11Zvhal+PkgyuMbnA2u
-        +UfN8bX4JQ4Fyt7Y5xdr+YwtfQQAAA==
+        H4sIAAAAAAAAA51UTW/jIBT8L5yTYqMm2yBVvbTbS7u99LCbS4RtarPFgPhw5LX63/eBncrNoZJz
+        MqA384bhjQckdS0UokiKgltmWI9WSFSI5mSzzbLdboWUrvghHqHn+4f+5X3X78nPwH6bpnqUXfH3
+        of/1+uf4fP++ASjrmGf2EKyE+sZ74yjG46HLr2rhm1AEx22plefKX5W6xQGfmt11t9dAUtuJJnWF
+        gzM6IyamEQ50Ds/1N76VZxLGzql+XvmmpdRHwJ8r/rYF/oSBtnEtVH0JBcAGrH3DwTK4xke8vHB+
+        oZwEGXD8wENFEgePYHm1TNIEAkFHBVoGbLnRiS0UrrTCeKHVQmlfoEClbc2U+McuoAKoA4YoaqGI
+        BAEo72DkFmJHzICNFR0r+2iH5SUXHbh7Cd8ZGOh8bziM+cvMmei58PzAqjaG841JxyGIrI2FT7Ok
+        wjwbpnpEVZByhQpI8yx3n5Oe5h5IpS6T86d63jIBQR3BjbCcFRJaTGRCn5YmFFKUh9FHCv+E6SAN
+        HqLZKQUQpNkOhjvtSuD1YBfzoI1k+WadbdaEvOaEXv+gZLsHZcFUX2q264ykmhtKdjS/2aOP/4XH
+        H1KsBAAA
     headers:
-      access-control-allow-credentials: ['true']
       access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
           X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
           X-Poll-Interval']
       cache-control: ['public, max-age=60, s-maxage=60']
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      etag: [W/"edf8aa2a5f76e98e1d67c6477ace9626"]
-      last-modified: ['Tue, 26 May 2015 18:51:47 GMT']
+      etag: [W/"588eb01cf37d2935135d39d6c9a26dd0"]
+      last-modified: ['Mon, 22 Feb 2016 18:29:18 GMT']
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: [Accept, Accept-Encoding]
+      vary: [Accept]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -39,50 +40,45 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52TwWrDMAyG38XnUq+MwhYYO+wZdiojuI7qCBzb2EpKG/rulZMwuhwG7snB6Pv0
-        W7EPo7DeoBOV+GqVM0p7sRHYiGq3f9vt3182Qg2KVKz7aLmoJQqpknLeTFuD1PbHPkHU3hE42mrf
-        yV4u9Ofw8co+ExdJFgveWMkCLqKZZluSD3Fa6uyq/9x3Kn8oPHlr/Znpddr/GshfioPN3+jMEwam
-        RumpBR4WH+GWD46JysJMxCjzUmOTHYmnH6EpCrQwHOfsOMkoIwQ/yfpj0hEDoXdlwf6QbPLRKIdX
-        VW5iMrEgRyqLMBFMwsAXrQydkVGGiIPSlzyKCBpw4ME+oVuxbKNLAL7b3/zj85iRoFZNlx/WSdkE
-        t587ouWI2WoDAAA=
+        H4sIAAAAAAAAA62VXW+bMBSG/wvXUU0+6EikaKpGLmk0aZ02TVPkgAPuiI2MoWqj/vcdPhwgW1IZ
+        c5XIOu/jF8Mj/zpZCY8os1bWF5xQxnNrYtHQWk1d257PJhbjIdmVC5bvfb3//uMxCZ43C997ePOj
+        9RqGcYElFrtcJDATS5lmK4TqxWx+F1EZ5/s8IyLgTBIm7wJ+RDmq8Z+L9QIQkWgg1T6wcAFLacOp
+        wwDLUNs2lsfkYvt612q6nTvwJOEvkL3segOPziFoVf+nLNIHQOiEuIwJHBTUfy8fmmZSq0oVOKHy
+        B15Iicjg4AUJdeo0ESjzwqDHCQmS8oqV77NA0FRSzrRq9YIA4iLCjL5hbRAEM8iXhbQKVAEIkgI+
+        L61knTihVNACB6/lMQgSEFrAmerTLqIAk68pgQ/6Cd54ecJUkh0Oj6VsB5xk5H3SkS/GLMIBh7nK
+        PsedOkv7in7TrbeZbr89fKTf7Lp+Nd/Ev7bwBwK2g3oGNjkDBfsEIwcVykxCRRnRwjOy6+8gDRVJ
+        20MVHCCiio5kYtukZ7GeiptwWxBxgLtCyejay+XMXV6xES7DP47/HDkwPvgyrDYw0LFX+raQvVEt
+        JdvkcCn/YZho2YEZidnhjKdmF2oqZ4elq2cnqi9oJzyOor02BpJKQfbHPG4MdT/Zjru4/7+g0dz3
+        nhaP3s/h12XDN/Cz7XtbznZOy8wmNlzLPsDESUUyElJBxrPxTDRVUYF0PVQ5fQlVchwD2x66+v3+
+        C2NVtEEtDgAA
     headers:
-      access-control-allow-credentials: ['true']
       access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
           X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
           X-Poll-Interval']
       cache-control: ['public, max-age=60, s-maxage=60']
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      etag: [W/"7e1bcc65d400d193c9e55e41e2c7beaa"]
+      etag: [W/"74ddeae18901f3d8c105b164eca8d397"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      vary: [Accept, Accept-Encoding]
+      vary: [Accept]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers: {}
     method: GET
-    uri: https://api.twitter.com/1.1/users/show.json?screen_name=adhsjakdjsdkjsajdhksda
+    uri: https://bitbucket.org/api/2.0/users/adhsjakdjsdkjsajdhksda
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAKpWSi0qyi8qVrKKrlZKzk9JVbIyNtFRyk0tLk5MB3KUgvOLiip1FEoyEksUCoBC
-        Cin5qcUKefklCqkVmcUlekq1sbUAAAAA//8DALaCUj9FAAAA
+    body: {string: !!python/unicode '{"type": "error", "error": {"message": "adhsjakdjsdkjsajdhksda"}}'}
     headers:
-      cache-control: ['no-cache, no-store, must-revalidate, pre-check=0, post-check=0']
-      content-disposition: [attachment; filename=json.json]
-      content-encoding: [gzip]
-      content-length: ['93']
-      content-type: [application/json;charset=utf-8]
-      expires: ['Tue, 31 Mar 1981 05:00:00 GMT']
-      last-modified: ['Sat, 29 Aug 2015 12:35:34 GMT']
-      pragma: [no-cache]
-      set-cookie: ['guest_id=v1%3A144085173476796921; Domain=.twitter.com; Path=/;
-          Expires=Mon, 28-Aug-2017 12:35:34 UTC']
-      status: [404 Not Found]
-      strict-transport-security: [max-age=631138519]
+      content-length: ['65']
+      content-type: [application/json; charset=utf-8]
+      etag: ['"391bfec2a9c670615650436ed4cb607f"']
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload]
+      vary: [Authorization]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -92,141 +88,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6tWyk0tLk5MT1WyUvLLL1Fwyy/NS1HSUUrJTy7NTc0rSSzJzM+LLy3KAcpnlJQU
-        FFvp66eklqXm5BekFumlZ5ZklCbpJefn6pcZK9UCAP6TTUJNAAAA
+        H4sIAAAAAAAAAxXJMQ7CMAwF0Ksgs5J6YOsBGHsFFJqvNFISV7HdBfXuhfW9LzWoxgyaaRG7vcR7
+        ogclWb2hW7Qi/e2j/n4z23VmTjhQZceYcrHNP9MqjY8nu2Io3zMsxKCl54rwNzovaRNpS2YAAAA=
     headers:
-      access-control-allow-credentials: ['true']
       access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
           X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
           X-Poll-Interval']
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       status: [404 Not Found]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-    status: {code: 404, message: Not Found}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://graph.facebook.com/adhsjakdjsdkjsajdhksda
-  response:
-    body: {string: !!python/unicode '{"error":{"message":"(#803) Some of the aliases
-        you requested do not exist: adhsjakdjsdkjsajdhksda","type":"OAuthException","code":803}}'}
-    headers:
-      access-control-allow-origin: ['*']
-      cache-control: [no-store]
-      content-length: ['136']
-      content-type: [application/json; charset=UTF-8]
-      expires: ['Sat, 01 Jan 2000 00:00:00 GMT']
-      facebook-api-version: [v2.0]
-      pragma: [no-cache]
-      www-authenticate: ['OAuth "Facebook Platform" "not_found" "(#803) Some of the
-          aliases you requested do not exist: adhsjakdjsdkjsajdhksda"']
-    status: {code: 404, message: Not Found}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://bitbucket.org/api/2.0/users/adhsjakdjsdkjsajdhksda
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWSi0qyi9SslKoVspNLS5OTE8FspUSUzKKsxKzU7KKU7KzihOzUjKyi1MSlWpr
-        AfM0plMwAAAA
-    headers:
-      bbuserid: ['4601603']
-      bbusername: [liberapay]
-      content-encoding: [gzip]
-      content-language: [en]
-      content-type: [application/json; charset=utf-8]
-      vary: ['Authorization, Accept-Language, Cookie']
-    status: {code: 404, message: NOT FOUND}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://bitbucket.org/api/2.0/users/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      content-length: ['0']
-      content-type: [text/html; charset=utf-8]
-      etag: ['"d41d8cd98f00b204e9800998ecf8427e"']
-      strict-transport-security: [max-age=31536000; includeSubDomains; preload]
-      www-authenticate: [Basic realm="Bitbucket.org HTTP"]
-    status: {code: 401, message: Unauthorized}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://graph.facebook.com/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAx3NwQrCMAwA0F8J8eAGOxR2kYID0V3dwZsIUttMC9symxQm4r+Lvh94b6SUOKF9
-        40gi7k5osVhtTF3CiUcC7kEfBG6ITkjgxRkSPTOJUoDAMLECLVHUQrNuLthcsjH1Po53kOS3C/D0
-        H7ZuoKSFKRusUF/z7+l2WR/t4mnWyBNW6DkQ2o2pK+xvmpynawxo8RByf+5yezwJfj5fWS8J1LQA
-        AAA=
-    headers:
-      access-control-allow-origin: ['*']
-      cache-control: [no-store]
-      content-encoding: [gzip]
-      content-length: ['173']
-      content-type: [application/json; charset=UTF-8]
-      expires: ['Sat, 01 Jan 2000 00:00:00 GMT']
-      facebook-api-version: [v2.4]
-      pragma: [no-cache]
-      vary: [Accept-Encoding]
-      www-authenticate: ['OAuth "Facebook Platform" "not_found" "(#803) Some of the
-          aliases you requested do not exist: >''>\"><img src=x onerror=alert(0)>"']
-    status: {code: 404, message: Not Found}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.github.com/users/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWyk0tLk5MT1WyUvLLL1Fwyy/NS1HSUUrJTy7NTc0rSSzJzM+LLy3KAcpnlJQU
-        FFvp66eklqXm5BekFumlZ5ZklCbpJefn6pcZK9UCAP6TTUJNAAAA
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['ETag, Link, X-GitHub-OTP, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-          X-Poll-Interval']
-      content-encoding: [gzip]
-      content-security-policy: [default-src 'none']
-      content-type: [application/json; charset=utf-8]
-      status: [404 Not Found]
-      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-    status: {code: 404, message: Not Found}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.twitter.com/1.1/users/show.json?screen_name=%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAKpWSi0qyi8qVrKKrlZKzk9JVbIyNdBRyk0tLk5MB3KUQotTixTy8ksU0vJL81L0
-        lGpjawEAAAD//wMALXKZXjQAAAA=
-    headers:
-      cache-control: ['no-cache, no-store, must-revalidate, pre-check=0, post-check=0']
-      content-disposition: [attachment; filename=json.json]
-      content-encoding: [gzip]
-      content-length: ['77']
-      content-type: [application/json; charset=utf-8]
-      expires: ['Tue, 31 Mar 1981 05:00:00 GMT']
-      last-modified: ['Wed, 02 Aug 2017 10:05:52 GMT']
-      pragma: [no-cache]
-      set-cookie: ['personalization_id="v1_F5AyyusrcruryDw/6ks8jA=="; Expires=Fri,
-          02 Aug 2019 10:05:52 UTC; Path=/; Domain=.twitter.com', 'guest_id=v1%3A150166835243900291;
-          Expires=Fri, 02 Aug 2019 10:05:52 UTC; Path=/; Domain=.twitter.com']
-      status: [404 Not Found]
-      strict-transport-security: [max-age=631138519]
     status: {code: 404, message: Not Found}
 - request:
     body: null
@@ -246,11 +120,107 @@ interactions:
       ratelimit-limit: ['600']
       ratelimit-observed: ['1']
       ratelimit-remaining: ['599']
-      ratelimit-reset: ['1522687244']
-      ratelimit-resettime: ['Tue, 02 Apr 2018 16:40:44 GMT']
+      ratelimit-reset: ['1540799319']
+      ratelimit-resettime: ['Tue, 29 Oct 2018 07:48:39 GMT']
       strict-transport-security: [max-age=31536000]
       vary: [Origin]
     status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode client_secret=o090sc7828d7gljtrqc5n4vcpx3bfx&grant_type=client_credentials&client_id=9ro3g4slh0de5yijy6rqb2p0jgd7hi
+    headers: {}
+    method: POST
+    uri: https://id.twitch.tv/oauth2/token
+  response:
+    body: {string: !!python/unicode '{"access_token":"l5v4ham8prjwrvowu1pd1pue81t1qp","expires_in":5281481,"token_type":"bearer"}
+
+'}
+    headers:
+      access-control-allow-origin: ['*']
+      content-length: ['93']
+      content-type: [application/json]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.twitch.tv/helix/users?login=adhsjakdjsdkjsajdhksda
+  response:
+    body: {string: !!python/unicode '{"data":[]}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: ['no-cache, no-store, must-revalidate, private']
+      content-length: ['11']
+      content-type: [application/json; charset=utf-8]
+      expires: ['0']
+      front-end-https: ['on']
+      pragma: [no-cache]
+      ratelimit-limit: ['800']
+      ratelimit-remaining: ['799']
+      ratelimit-reset: ['1540799264']
+      timing-allow-origin: ['https://www.twitch.tv']
+      twitch-trace-id: [b1907dcd26af1b2ca083092425a05083]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.twitter.com/1.1/users/show.json?screen_name=adhsjakdjsdkjsajdhksda&include_entities=false
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAKpWSi0qyi8qVrKKrlZKzk9JVbIyNdBRyk0tLk5MB3KUQotTixTy8ksU0vJL81L0
+        lGpjawEAAAD//wMALXKZXjQAAAA=
+    headers:
+      cache-control: ['no-cache, no-store, must-revalidate, pre-check=0, post-check=0']
+      content-disposition: [attachment; filename=json.json]
+      content-encoding: [gzip]
+      content-length: ['77']
+      content-type: [application/json; charset=utf-8]
+      expires: ['Tue, 31 Mar 1981 05:00:00 GMT']
+      last-modified: ['Mon, 29 Oct 2018 07:47:44 GMT']
+      pragma: [no-cache]
+      set-cookie: ['personalization_id="v1_MEyRevlqarL+BD50t8eF0A=="; Expires=Wed,
+          28 Oct 2020 07:47:44 GMT; Path=/; Domain=.twitter.com', 'guest_id=v1%3A154079926400922631;
+          Expires=Wed, 28 Oct 2020 07:47:44 GMT; Path=/; Domain=.twitter.com']
+      status: [404 Not Found]
+      strict-transport-security: [max-age=631138519]
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://bitbucket.org/api/2.0/users/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-length: ['0']
+      content-type: [text/html; charset=utf-8]
+      etag: ['"d41d8cd98f00b204e9800998ecf8427e"']
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload]
+      www-authenticate: [OAuth realm="Bitbucket.org HTTP"]
+    status: {code: 401, message: Unauthorized}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.github.com/users/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E?client_id=18891d01e40e5aef93b8&client_secret=46f75669895e96029d57b64832d6f2c8e6291a0e
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAxXJMQ7CMAwF0Ksgs5J6YOsBGHsFFJqvNFISV7HdBfXuhfW9LzWoxgyaaRG7vcR7
+        ogclWb2hW7Qi/e2j/n4z23VmTjhQZceYcrHNP9MqjY8nu2Io3zMsxKCl54rwNzovaRNpS2YAAAA=
+    headers:
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
+          X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+          X-Poll-Interval']
+      content-encoding: [gzip]
+      content-security-policy: [default-src 'none']
+      content-type: [application/json; charset=utf-8]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
+      status: [404 Not Found]
+      strict-transport-security: [max-age=31536000; includeSubdomains; preload]
+    status: {code: 404, message: Not Found}
 - request:
     body: null
     headers: {}
@@ -269,45 +239,10 @@ interactions:
       ratelimit-limit: ['600']
       ratelimit-observed: ['2']
       ratelimit-remaining: ['598']
-      ratelimit-reset: ['1522687245']
-      ratelimit-resettime: ['Tue, 02 Apr 2018 16:40:45 GMT']
+      ratelimit-reset: ['1540799325']
+      ratelimit-resettime: ['Tue, 29 Oct 2018 07:48:45 GMT']
       strict-transport-security: [max-age=31536000]
       vary: [Origin]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode client_secret=o090sc7828d7gljtrqc5n4vcpx3bfx&grant_type=client_credentials&client_id=9ro3g4slh0de5yijy6rqb2p0jgd7hi
-    headers: {}
-    method: POST
-    uri: https://id.twitch.tv/oauth2/token
-  response:
-    body: {string: !!python/unicode '{"access_token":"7a5d9eyq0lqh49c3e181a82ltvukjd","expires_in":4775216}
-
-'}
-    headers:
-      access-control-allow-origin: ['*']
-      content-length: ['71']
-      content-type: [application/json]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers: {}
-    method: GET
-    uri: https://api.twitch.tv/helix/users?login=adhsjakdjsdkjsajdhksda
-  response:
-    body: {string: !!python/unicode '{"data":[]}'}
-    headers:
-      access-control-allow-origin: ['*']
-      cache-control: ['no-cache, no-store, must-revalidate, private']
-      content-length: ['11']
-      content-type: [application/json; charset=utf-8]
-      expires: ['0']
-      front-end-https: ['on']
-      pragma: [no-cache]
-      ratelimit-limit: ['120']
-      ratelimit-remaining: ['119']
-      ratelimit-reset: ['1522748040']
-      timing-allow-origin: ['https://www.twitch.tv']
-      twitch-trace-id: [7322efd13b06536bc68825a652c0bd7c]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -325,10 +260,35 @@ interactions:
       content-type: [application/json; charset=utf-8]
       expires: ['0']
       pragma: [no-cache]
-      ratelimit-limit: ['120']
-      ratelimit-remaining: ['118']
-      ratelimit-reset: ['1522748045']
+      ratelimit-limit: ['800']
+      ratelimit-remaining: ['799']
+      ratelimit-reset: ['1540799266']
       timing-allow-origin: ['https://www.twitch.tv']
-      twitch-trace-id: [4b231f9a03bb260aab1940523ef8a49a]
+      twitch-trace-id: [c9c4c79b589526c43ea917adffba0966]
     status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.twitter.com/1.1/users/show.json?screen_name=%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E&include_entities=false
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAKpWSi0qyi8qVrKKrlZKzk9JVbIyNdBRyk0tLk5MB3KUQotTixTy8ksU0vJL81L0
+        lGpjawEAAAD//wMALXKZXjQAAAA=
+    headers:
+      cache-control: ['no-cache, no-store, must-revalidate, pre-check=0, post-check=0']
+      content-disposition: [attachment; filename=json.json]
+      content-encoding: [gzip]
+      content-length: ['77']
+      content-type: [application/json; charset=utf-8]
+      expires: ['Tue, 31 Mar 1981 05:00:00 GMT']
+      last-modified: ['Mon, 29 Oct 2018 07:47:46 GMT']
+      pragma: [no-cache]
+      set-cookie: ['personalization_id="v1_T5T/15WnGHMKmJbHCbJUTQ=="; Expires=Wed,
+          28 Oct 2020 07:47:46 GMT; Path=/; Domain=.twitter.com', 'guest_id=v1%3A154079926620698884;
+          Expires=Wed, 28 Oct 2020 07:47:46 GMT; Path=/; Domain=.twitter.com']
+      status: [404 Not Found]
+      strict-transport-security: [max-age=631138519]
+    status: {code: 404, message: Not Found}
 version: 1

--- a/tests/py/fixtures/TestFriendFinder.yml
+++ b/tests/py/fixtures/TestFriendFinder.yml
@@ -7,24 +7,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA63Y327aMBQG8HfhumpI0tBSadrFHmHb1TRVbnDBJSSRY0AU9d3nJPbJHw1Xx8dX
-        myp/H98yfir4z3VRVFtRLp4XomlYvudFcVncLcRm8Ryn6fpuwU5MMflylIU+s1Oqbp6jqP9hE99v
-        hdodX48Nl3lVKl6q+7w6RMeozX4/fXvQVVtpKtrOhf7BrKoWpqWP6qommmzZqUMxe/3+ZbvA5Ohb
-        VRTVWTfM97pfJIKcntf/XZRbrw6du0aV2nH9yPQ/5bN9AKJR2EFd5hq1f7yITdvS6P8FyTfIUSal
-        J51LveYaSV5XXd3xtcmlqJWoSuy4SVZ3VXLLSvHBfLp0ttEV7SzsjC6js/yk33fYcB+6RrUUJ5Zf
-        2kciec7FST9ir8JZWvepS831O/63fhu0D1wo/sI2h9baGysa/nk32MsLdlGyKvW5VslDnK6efOl1
-        YYK90Ra3vNFBlDub81c3a6CYgyqSOGgJ522oHEv10QZNWGsQxEuDaBhnoyUTozhlm+rc7IU1tn7K
-        Um9jbZhgDJa4hcExlK8+5a9rkqfYMkUkWaYjnCtbSFVlerCmTAwvygTDeIIVBE2sVELyD8Npla3S
-        xM1pefPTYhcmcBqmuD0N51CgTMxf1LSAQso2kUzZknCooJGqyhZhWdkc3pVNhoE17CDIkooXvDaw
-        4nW2jL/4HpbclNWnCbRgi1sWHEPB6lP+riZ5CitTRFJlOsKhsoVUU6YHS8rE8KJMMAwoWEHw9FPp
-        Lb+Osmx2fG9YJWmSpCv3L6zb1xt9msBqPsmta34ahWwS9rf2vxoKuWkfSd60KhzAWS/V4bQOy3Ga
-        xquc5sPgnG8iGM2ZbKrDpb0paW9AsixbLjM3z9ufJ/s0gedojVvm6CAKpc35e5w1UChCFUkhtIQD
-        OFRS7UETlh0E8eIgGgbbaAnB2XvFL7ypK/u1LX3IHr+4BrntbNWlCc5Ga9zORgdRzmzO39msgeIM
-        qkjOoCWcs6GS6gyasM4giHcG0TDORksIzn7sWLlluXUWZ09xtl66f6E5vsb1cYK00R63tNFBlDSb
-        85c2a6BIgyqSNGgJJ22opEqDJqw0COKlQTSMtNESgrT3zU6drbMkWSeEe30TJziDNW5lcAxlrE/5
-        C5vkKb5MEUmX6QhnyxZSZZkerCsTw6sywTCmYAVB1J7Jw6Xcwk1JvFw/fPEZMb15A5mkXZxAapjj
-        NjWcQ6EyMX9V0wIKK9tEcmVLwsGCRqosW4SlZXN4WzYZBtewg6DrwDbn4RLyMcti30+F+hayjRNo
-        mS1uV+YQClWb8Rc1SlM4dTUkS11DOEh9HVVR14Il1IXwfrpYGDxmAVbO33+cN0MCoygAAA==
+        H4sIAAAAAAAAA63ZXW/aMBQG4P/CdbWQhNBSqZqq0YteQFWNTqumqcqCB4GQoMRAAe2/z05s50Mk
+        6Pj4ompL/b6cBh4lMb/OvShZhHHvvhdmmR+sSRQdeze9cN67t113dNOLkzn54L/2JuPX4Y+f0yhY
+        PZ0mp/UDW+bvfeqnH7s0Yn9fUrrN7i2reDCzvyxCutz92WUkDZKYkph+CZKNtbN48df9w4AVLFJR
+        kT8De6BRtQ1FSxFlVZlVG3RJN1Hj+YunzQO1pX+TKEoOrKE5b/eTWCrHxit+DuOFVgfLna2ELgk7
+        ZOxf+ccPQJhR6EB55mzxb+yV4S0ZexVSMgcOJVJspEPMpjlbKdkmed3uTxak4ZaGSQwdrpZlXUm6
+        8OPw5Ot0sWzGKvhY0DHyDMuSPXvfQcNF6Gxt03DvB0d+SFISkHDPDrFWYSPN+uhxS9g7/o29DfgB
+        Dyn58OcbDvGvH2Xk300JM4j8I02TmK3jSga2O7y77PL1c3J656z0XObNCJiVQbtZVhaCUMqcPslG
+        AwakqkJxVC3mMJaVVcY6FFUTFKIKwhmqqBmElUlqgGEE58khW4cS4OjOc1sAei/jt5M+QN6MAKjG
+        7OanloHwFSl9erU8Bp4oQrETHebQyUIsOdEDBSdicG4iaAabmgJBzY9pmBJuiJ/sht7QdS5be7en
+        qwm/Vu062fVbL0LzZoS1cs5ubOU6kDYR0+dWL8B4k00ocLLEnDjViCUni6DmZA6OTibNqCvnQLBL
+        KYnIVqizR17fbrv386azx8+X14dr939OK72iHmFPDdtNTy0DyStS+vBqeYw7UYRiJzrMqZOFWHSi
+        B2pOxODkRNCMODUFAtx3ymaZ7dI4W5K1cOe4juMOL5/unk+T1fNpurjqrn3fpahHuGvO3M2vuRqk
+        sBbWx3ipBmOy3oeiWa8yJ7TRi4Var4N6rafhbOt5M3qbMyEQB36aJZsj38LhV6ue5/X73mW/bzY7
+        bx6m18+b7ZesRT3Cb2XcbrqVhSC1MqcPttGAsaqqUExVizmhZSUWp2qCulRBOEkVNaOxMgkC4ioh
+        R5JtE3nb6A6825Y9mvfTdPzmTg5XT6TtEId5PQJiZdxuiJWFIIgypw+x0YCBqKpQEFWLOYhlJRai
+        aoJCVEE4RBU1A7EyCQLit6UfL/xAQrS9O9sb9S+fEp/slzH7mj0ibiWLfgTFysDdFCsLQRRlTp9i
+        owFDUVWhKKoWcxTLSixF1QSlqIJwiipqhmJlEgTF1XxJDxKi44yc1o8tno8vs+fBdDa5BrHj3rLo
+        R0BU43YzVMtACIuUPsFaHgNQFKH4iQ5z+GQhlp7ogcITMTg7ETSDTk2BILf2080xXqjtHLs/GrRc
+        hrL9nNmjNx1fNee27qM6bt6PMFfO242uXAdSJ2L67OoFGHeyCQVPlpiTpxqx9GQR1J7MwfHJpBl9
+        5RwIfht/fii3Um89z7584cn3UgO2H/N07XzX/hkG20vl/Qh7YthueGIRSB3P6JOrpDHe8hoUtrzB
+        nLSiDsssb4Eay0NwYHnMjC4xAZTW7/8bpQ9tHyoAAA==
     headers:
       access-control-allow-origin: ['*']
       access-control-expose-headers: ['ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,
@@ -34,7 +37,8 @@ interactions:
       content-encoding: [gzip]
       content-security-policy: [default-src 'none']
       content-type: [application/json; charset=utf-8]
-      etag: [W/"beb521e08e92c1144d99f0d10c9639ae"]
+      etag: [W/"3403bc0844fac0132e4a906dcec91203"]
+      referrer-policy: ['origin-when-cross-origin, strict-origin-when-cross-origin']
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
       vary: [Accept]
@@ -43,116 +47,112 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://api.twitter.com/1.1/friends/list.json?user_id=23608307&skip_status=true
+    uri: https://api.twitter.com/1.1/friends/list.json?user_id=23608307&include_user_entities=false&skip_status=true
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAOyd+VPbyLbH/5V+UPXmvXosvaml9k9jwCQkkAXIZHIvU5QstWwFWfJoYcnU/O/v
-        tORFsixsHHvInYHUvQO9qLX5fPp7+pz2H1tZouJkq/XvP7Z8d6tFDS4ZNfEO/HWdpPFWa2tctLWz
-        FdoDBSVnvtO3A3SVYYIdv2/rXwwJ9YkTKxVej5oNdF0MxUHk2KkfhVD2IbZ7mYIyV0FjfzgqPoZ+
-        KIm89M6OFXLVrQqioYp3kBOFaex3szSKURqhYX949tB2B364g17Zg0GGoPyz6gZ2qpAduuguim/8
-        sIc8KL/4dNHZg6GyOIAh+mk6bF3tX+2ne050te98/UXef3XOgntoocLUT30Ft+GPonX+n+KuLNH7
-        fghDK/d6pmk3iHp7+T2APoOrfX3VfjIM7IdRy2oDqPZD13f0afwb71D625+//Tlzoybn9dufUDWM
-        o1Q5qYLn5tlBona2vCgIojt4oNdOlIUpPE9hQmnsq9CdlBHK4Jn4CXQcF8mdLXh0ti6x0/x5+OjM
-        jhHFiNAWFi1qof/D8AMlWD9pz76NsthP1fSonMCtTp3ryPMSBQUmNN3ZSv2Buv4Whar88Hsqulah
-        3Q1Kp36rYt/zSwVJaqfwck4GMC04y8AOe3AkFcJRSu9GUjucn1ynsR0m8GZE8bxSuJ+1TnBDPT9Q
-        113buenFMKy+QYHuv3WY/2zNbeMP7J6affp2N9lL7/xBr3j4eZsE3p++Gkz+Szi8Jb29nu8tOPC1
-        PmwyOnyytuOn8PdWK42z0rXPvZhhdbBKWxiMSkkIplQIGE8aTpeaxLO6xHaxcBnmhufaJnG6knTl
-        dRjFAzvY+zpUva05w8651M2P3rXDUMWlq3504KK1HnlkGq/2CadYcE4YKx018MObyQuE859SbeK7
-        qmvH190odmHscbvj/GdOO/gjmLTqHOt/pVapuk8ntSz/KdXC56j2Xk3e+r4NH5/7VOU2bNRjUukq
-        z86CdFH5zCELO+Trz2qYBcG44DpWv2cqSa8TpT/RRVUYpfDBLwiRjAsHWVrqDYbSuZn9G062+1CU
-        /LlT0ItRKQzJCeYlfk0LpwQ79bsqtof2Qw1awbhGVcFVQ9a5crI4hutAbhQWJ4/AtqdAnkETdHqd
-        rx0zonF4ugp0qr0boDM5/wbmVOo3ghxRA44xixs8g5uLLATcPCDKEWHAmhZlE9wQYy5ucBU2u9So
-        48Z29IuFLqEM/c+nC/Tf6NAObdf+31URRDcGoKoNnscffNTpHK2bPzkehmFvQ/h5/PBp2Z48ip+Z
-        wZLUd24ervbn2qCkXi7GVr96Kk+4vDWNOAMEix/wxUCoPfm5QDiCRsfiO4FQvIVP40HRpwEHReUz
-        0YAyJpk0DV5RM5PCKQ3aaTRAHdfXH9RZHui6SVWJBxd2iI7hk+z4iRPtoMP2fE2jNQkomRDETRY7
-        CnlZCnZMv05IPyCkxoeea/FvPvuv31n+689fVuFFtXcDL8A6Dfb8qMaJafn6CcGFJEaNEniWEqBT
-        rBlQXGYKHasuIgRR1sK8ZZhTUPC5oKC8SorinSlxoiio8KB4bRfiQBrPKEg6nU67Q/6hQFigCATh
-        2CQG5ZbBBBGCwwz91Ozf9D4PzKezYO2Drao2JqZL6w0GIxIsrCa8CNHm5tr0xlrw8vfTG4RaFhXE
-        qOiNSeGUMOeqG0VpAQxVY0yc115749rHZUfpSAjuxleVoluwG1qI/OQ7PkIzGBh+jKL7Yf/k7kMF
-        M0mpyZc37rn6en96+7A0Z5q710FTtL27u9uLlQvAK97v+Gq/uJjiWuZolUWtK2Rij5GpgZCVW9NE
-        yJso7qpwzw896EHwrkrtoUp2h8CZ3aEfA5zi3cDeLZ7eXj8dBLULeeQQVxnFVFQuhhk7hqmvZjma
-        EsbrPj4+C1M6q7nOojB38TEMNAVKtoi5SHMR9nSULi2tMJnA1Iv/apjWnDMvMJ3wzbCogQ1pcGGa
-        1BTCpFf7b252T7wvr/DaYfr0wVaE6dRK5847UxOcySaYsgPJj+RimDY6+SowrbWqwLRW+w+BKbWE
-        pJhjRspybVJYkmuxb4cKHcKlp7Yf1iVbXl+qfoynZ5F7lWGsrEAlKMrATqXJjnbphXmxnJQqKO7l
-        v4bw4QPaFsU7KIh6gF0VoMDvxmrM2OJayyz9Ps1E6jbeIjXFNMev9i66RVgiIlrcahG8SC4RvmgV
-        5yDOkkTBya9o6Q38jIb+H+1GW2R7Gck1BTHBFJom42Aa38RHx/T1ibN+Q//kwf5xzrPnNcemBVq2
-        7DkrCsprKGAPAnQU+06U1ozwMIiyQdX2vk9TvxeCNdw9BdsJpllPm98pMKM1q/wZbJJextfus9QO
-        8iV9uxtlaeFAU0njuv7ZqXvT+f3+9dGnVVxm1d4NgiC/tL1QpbV5frlmA24z05D1xXxZW8wnUjS4
-        zShGGLcwa3E6Xc4357vNjFU5sKTzDD763HpG/9nR8RE/NJ9AgsYZZbVbbtuYkJJbJrxWd34KAnHv
-        63AFOGxmxPV52TBnxDKFAbYcU4NjebV/cHLnibvdm+k6+7q8bE8ebEVhUJg5EAVMSswtJngTg46O
-        CPwsZhC8afBvEYOOmf73DAz6oTUBFoRQzFhZEozLSgFpNhjF1zUGdeFIXf9blC3QACfhLZx+Hm6m
-        3TEEJv0pGqowUTHKVQDWFRh7PC1EwcYm+YTUDDzjsmbgZ+27Dtd676SIUpjqt/Il9Ok8H6/Zvi87
-        z9cf1xeXzg860zcpNwxhSGFoJYgtaHO/a9nG26MNzPSfOtiq6yNjw6A9OkRIGJXRJuPN25Kww8XG
-        +8Wjs7r1lpxRw8K07NCZlE2t9xtlh7sdkBHo9YMNZ1+z47qBrp9UlwOKwfQnNYt+FDlgRfSaiAoL
-        Ey7B+EQDX40Net4PkT10kekVFFehtF84ghKFWihQKFZAhQxloQ+mDgxhk+Lww4fzDqWDN99WURzV
-        3g2KozgV/d4lKl9FmLNUUm+xfgVi1mO7SG2lgc1ZaNBOKEIRwS0GfCJTONFlgrvWuc7A6Iv36Qdl
-        Etaze2AEJZgJzOjV/uAYX3r2+e/rjxleYbQVqTQxeFpSmJQYQjQv2r+4tTa+ZI+lJaVJykyalJWZ
-        5NUwBCrjph/FprFATlw8JHaRotJT6mYnXxfQFrJx+b19IYevKT0xf11p+b3avWn5PU82+eoNnCge
-        7kVxr4aQOQ2WX2BfliAS1wli1jxYfHax+rKfoTdZiDBFlLQobbHSYjVpEDhyJkS4LnFe6ccLNHBX
-        1Tgyd8m98OQH5AkziCEZFxbT1t7FihLuekwyE3vK8OAj4lAL2zZxGV+75vn+wVdd1h6bMk0bYVgm
-        s/JgjhfaPAttCLckFYRzUcLNtHDKm4u+rwI3KSJuq9gZVV3nVSXunIToAWweOu+0j846NQp9zOzA
-        Tx/QQKW2a6c26touvJt5ZmQ5IjkPIXPSmRWVMl/+Nfjw8Z11aR74K+Gp2r0JT0n5BlTBVKlaP5Jg
-        dlZn0lIZkjmRTIBSi8gWE1MisflL62IGSPAKzBKpY8OgcbhEzsqSyyzmsyZNvvCpWYEICrYaMyYE
-        Jlyaes0huH7Vto4PrQ3onaeP9oKKvxQVHFvwg5kskWJSVgp+SrTt/qy6OgR4oHS+e40Ytm5T40WN
-        EMWh/ATZ6A6O542Ph9K+nSJtROA3hfQtSh7ALA1ydsAz0Je3hy78gc53hFY6Z1+3HNh+iOwUjIWj
-        h2hco7d++fj1k/Hh8N3BKh6zau+mtBZ9bUCMOVHF46qNeMhY3UOmix5Pf9TqJveQYYRJS6/QL1Q3
-        s+mP34WSpdXOc7IE4zYz5AtL5soNIZhlGUTLDY5daRPZ7RqySyzDoWZXeiZl0u1iZph0/Vrnuwdf
-        UetMrGOudSzBQew0pt8fEAPTta33vKTDzF3vMbGwpLDKyz2jovJafQrz+QwdqWQI9qMGr4Edp1Hm
-        Xevg2irALjI/SRQAaKBNfg1np7m4yfJ43TwvX0f03kaAFgRXnf+V6DcWqcEwBnummwztGAU2SjKw
-        rXt7jcASZ29/6f36hUa9VYBV7d0ArNFl7zn9wlV3tR+qu2QOvh5puIEFH7Oep0mkUUvVZLORxzri
-        7Eg5iBjaYcd5yyCLNpCh1FoYkgA8WxVeBn5OT90BPTo+am8k2kxgbFoWpVf7txmYqyy+zm1fqhdA
-        g+tQZU4fzFMQwcm7apjpa9CnncIbv+GotE2c2bq2rGGcWoYhJcV60xjuAawkcT2j63GBAWPUoF1q
-        OAxjrtYvx9Yw+qrLUSODrGMkMByfMlM0MVOytuBLiL5O/rMwwG020fQlwE3nuFPDEoyQcgbptLDs
-        INSG+bIfZb1+mtSoGdfqH1N+lyDW3h8fnxyetE/RZREwimwnt5SFyMszL39KUJ54WT32DgJ6ou4D
-        8tMEDSJ4EbSNTP7rKr4K9f9mt0q7OwnuP7vh3SSAYtmouaa918oHbI6YqKSOJvkVpNO782iiabn1
-        nPxMy9whWC6foGlQUfcw8pqHkZkzDP2s3CJq20REtqhsGcYiFyNfYbODZQFKMCb4P8mZuDyoGGCq
-        mPhTE1sEZj1QZgmPEMM0hCTwu/TANDtd5XQ9m1tdYa+mGp/rnNaGzfFZEYMaxBQExJfjCsOUXWw7
-        jEgK/LKI4UqDcGICXMwNrK6t7SRWhOjUQOdBHTAGPCHShNFlfad/4U4MfzeMwkRGmqKyyjYumiL0
-        wE58B52E8EzrezB0daU/rivBU7OSkiRFh3DqWfxQg+n2wbRr7k0NkT3ISRp5wMdQPaCef6tCvX+p
-        A8j7psJkHFVoB8HDDshPz9MppNBFt4mgBuXng0KlXACuToPy9HZCcESwucAqfcv2UNt1kY3gMfZT
-        u9ea3fih/yZ0BKBi8Gvj0l7CM29w8ZZ9+bDS0l61e9PS3kC5fjYoPkr5Ze1O7vOMtG1u+N1bPVRu
-        RtOsIb3r7gUPOg3s4f4jrp1frXp6VmCOd4jAy08KOJ6z7MgsXgunBMs/x13cHsY6q5eyFuMtvlBb
-        m3lmQdVjrE1oVV7rNxyU2To9xgZ7Tp9xLch7jTleWFoGNwyTUUNQk0lQuV+G4qz/bdipS7V1p3ut
-        Nvgat4RgmJlSwlTEoobB9GriYfDJNC/O4w1sCfHUwVaOnSmIkacPYCYZlo1MXzZ9YDmmkwOLts0X
-        pldzv0wpDCJMXEn+mhROuQ6KLUdwA9njauWjkZt9O9apxqG6Q8MoSZOcvIkKwJgDeAd634cEcN0d
-        aMnsalqfV5Ryaai8PWA+fWh0K5+/fnM+jA5OPn1exa1c7b2cDq7eikdFcLXp+l3LhPE5cTdS064K
-        QDGbUKB3tbhQQx16A7qY8BZjCzcBNDaniwFxLzE2P+a6qIFBJEvDhDkU58xgFIQiG5jet9fn2fo5
-        9eTBVs1zm9jAglSEABu/W32+RO6s7sO1OEwduGAVH+64cAqq4yITrdhwSMb52Oj46F0NWZ7KvapQ
-        7bkzGxid6ETl0d4T1e1m5x3cVei4fYLsJIkcH4q8BO2io6KJpxOckUp1BOggGjcPbKBfpmWAP0p2
-        Rm6G3qm0eceNb1+St0edd565CsWqvRsoprcO9OBW6LSEOUui46rNcMqSc3bdWEwp7b0df4WGpfde
-        MuTCANFF65/tgQ7pce3BrB5bMhiUipdshR+TVNw0KZhx/S0FkoLMETBw/K+vX4Tde792Uj19sApR
-        TCqPD+dpmv8sovzI2odbVJrEqsSCjoqmOGkH6t5P0Fs787wBTA7qGIntgX1jLxA9p3Ye0wkoSFIU
-        RGEvyyM5E40CHT5TlOu97Yq1MHQchS7YuSzWvPg5H0R/dRPaPh3thHeqG2uy/KxjdfxQBVk39nUQ
-        zvZRUfAh6wa+M87FDn7yQSdpPt0qTRuiYvSzO/RgYP/Wbky8bn/tODYP3nK6CniqvZvkU/X8G/gz
-        p9VGUGRgUQ/H4WZtG0AqeEP+HLHyDUIoHGqRy1CwhV/nNEq9X001cfqcu4NscjGRcEkYxbx4fTYd
-        ZLP0cGtjFSUCBI6Zb+QBL3Tih7tgZXZHG0/tplEWRNpMr3sLqO8ad9UY05HVLb7hiRMuSOOWIvhQ
-        MGuJHddfuLi61BKGgYmoZNONiqZc/ND3A384VOjCAeMVhX4NjMNkWlNC4+lDFNaX9zr3QxXnG4m8
-        ywYjdZXDLGciijKEtnVC3Sif7uf38PtR4qMdtG1nE0xeREGW34AcjgnavvzQQdsfzuD/zvvF5lKh
-        agdDXVU62vYQGqejr5faduAFd+FFHeY3TxN2+7PqsqMmQpIL5n6LPuL2+1UIWe3dtBni6GbvjW/p
-        /I0RG1ptIAEDG3VGzvEqUmteuI3eRAsTgGLLIC1j6lbE1lxGWgsjVr+LkURH5z3rFlozrqP1QZKb
-        EhNsWgzmNJaJqcmu9q/fpIfi1WV705E1q429PqknuCmEkCaXOoLEsvTiXXh5fHntbuDLEVcYbdWg
-        mJEhzr+chOvIHP6fFBLzt8vGoMxgzDRNXM7HmBZOeXloB76GVg2TDlRoFl0XguYxEXmgUC+K3EYn
-        4SW7MaPug1hNq1V7P+IkHJ9xg1ArV2+EPpaYs0NWLVuC1L7WCuTZaH9eYrSw2cJk0YrWTAIgwVbN
-        WZj2YRqxKnvyrMWXNa0f0VPIdEijRXX8oQmKRG+c/urDw4G4+GUDnsKnDvay9vSXGnmDCkylNGjJ
-        xk/KSpIoilMbvfPhZtn15IG8dlpZDn4caeqavT+D+Xyq91c8g1vi7x7HYB5An0TFXldo+xYenMrD
-        ycIkj1ZE29kwRtuDKAxtXxXSabu8ayHaRYd9OIyWVqCZtk/tMxg5tZ3+T2D49LKVn+jXAsaBPzpw
-        aAXaKNRtOxcX6Oc26P/0A/zdhKATC/9iHB/KVQBU7tskhPRNDIubOH+PxnktKgjCa3ESztliC2RJ
-        zUlY22Nr/J3vRCDMdboBlov2aaQUb3zJypLPuWNjbVfuNebtmRhzMLAwIYfJsmSWzewuE8SGS4aZ
-        julxbLmupzzD3nhA4XrOZX1xG5yYBigWwaSkjIFEu9o3+1748duxt4G9UZ4+2ooSaWKZ88ANGBXm
-        i43uRNE+pFgshudyGkkaHatz2AjPQyb54h2K/zbuxN/gMPn1Z3GibwDhJsxupCWwZVjcNKjOxyu1
-        mOzcVWuW3zN16wOrJkfDtbJRf7z15/8DAAD//wMA9tn6dHGFAAA=
+        H4sIAAAAAAAAAOxd+3faONr+V7TpOfvNnCVEF0uy+SmBQJu2abNNZjszyx6OMALcGIvxJSnd3f99
+        X5k7hoFk4EvbSTKTEknWa1vS87w3Kf8+yhIdJ0eVf/77KOgcVSSnQrISfG4laXxUORoXHJWOIjXQ
+        8Ptr04/QB50EPShL/FjrqDWp+qTjSXlofJUGJoLCamzMbTiKSujdL1CTxSEU9tN0mFSaJ82TT9Bd
+        flXZNwOo72joMxhOLq7FWqUmRqaLTj/9lul4VEKv1Z26ztugYWx6sRoMdFxCKkv7JrbVQxXpRKN7
+        YzptuJFbFOm4g36wMnOR2W0wMse6bOLejyVoFt8ilaLT276KlK86ejAqw41A36n2Uw3vpKvCRJeO
+        uiYMzT28rJZvsig9qlDuSceFijjQUWdWzJjA8AqCBC6elhFMiCgd+fZ5oFRB0dE1SG3oNsIMUVwh
+        ssIo+huGL/gVS7iFrrozWRykOpl3IwWFl5j6LdPtJhqKoiwMS0dpMNCtLybS04KeNi0dqXZoHyCN
+        M7j/Ox0H3WD+e5KqFAZ/1rnnOtB3qKIe3JyO4AZ8E6Vx0M5gCJJ5b5PXESStNFZREtoRWlcKQ1i4
+        CN5qNwh1q638214Mcu0bCu31R43862htm2Cgero1nzv5OKp2Uk7vg0E+dZoneZukeZL29WD2r9s8
+        affKvaC7pd9WPiOXZuYeuk/h9+nbnlavfZThsqyltiBLYs8RWHoCZhx2CHVJ8+Smzn95Gw9FKzLx
+        QIXlT8Pe0Ropax5s78LaKoIl1lpd2hvkjFtbQTmyNE8I84QnMSXeQp9hEN3OpgalToPThdok6Oi2
+        ilttE3dA8rQdzr/WtINfwvlEo/V6tbrQKtWf07ksab8XamGJFKbMdFD7CtbF5xRWPyzqyQWzud7R
+        XZWF6bbyaY9LKBPYRTheyeOCVqwB/5K0lehotuojk8KKHkNtMi0cZOnC1TkCrv4ON9sezaBjtohb
+        6WhocTzWvSxU8dF/S2NOIEISl5AFUpiUzFnhCp4IXcRB0i+wwhCqWsGkaoEYrlRo0FmYmjWsYK8p
+        T69ZpoQL1Mw6LuvAT9+TCJYhugcQbWYUU4ouxnhuIjTUcddO1sjXJXTagq8w6PWBI2A80V/Raa0f
+        m4E+13c3xoRJGb01gI+WaGCQdXyshsNY+4FFazTIksAvQ99hcKvRyGQllBpTRq9086QfDHZlC+YI
+        LgpsQWGlrbKFKzy8QhY3mUaXKgZqQJRUCK843jaykFywP84Vk8dZJQsqcM5yT8UWdc9+75ktSA7n
+        w6h3GLbY0v2+2MKTlLjCIR6VjpSCS9E8eateX7cu37zfO1s8XNgj2WICOfDB4Vy4nHGxiS7YuVtj
+        Z9vpgtSdKna20UWt2nCr55voglH7/YfoYlz3zbJFZJFkShVMMNAZFqliUjKnihuA9VRF6F2QmrTA
+        FtGkdIko4IolksgnjO3EKvg9q8jDyoJPzZMCXfzjCp117qAzf4R+eD/UEboGmPQtBVzFwR0U/4hO
+        0elv9ypKa2ZQRh8tkiOF2mC2INU2WQpscgzzS4O5kV8AlyZZfKdhklh2KaPfv6XheKFcL1yyG2F4
+        dl0V+IJIzgrWhfBWjYtGHKCzYYywQJYsBAD2VuOCCWujPJQwJre/lTEc4ZG5fdGN/78ZwzurO3X3
+        mTHWqfwE8Bt7VDhUuIy6nmyeHH9S590ExmXv9sWDhT2SMSbIYxlDco9R7MhNjGEXxpLtuYExXFmt
+        OVsZow59eXQTYxSMlD+fgbFMGZS6nFiFd84Zk6IFr5PudmM9Qm90L9TxGs9TXn07rV1gj5qKBzpE
+        tbMig9zf35eXrlzrg9oNrAlxiqo9lwXNfgNME4kwAxOhwvEcpr21MG3V7kNhNGhY4gmV+ho+r9fP
+        v0OIXnn0x2A0cYjLJOaAlupOpYA5E6xcFv0HgHlHCUvASc7PSGMHz0xhZNcC5zk0aohNwMnyr4MA
+        51oV/CvHTYKlJxnD2F10zMwKV3wzb7I4u7PqZwE7P5h+kNo2b5aB82UW95SJSuiVikcqUlP8HN/c
+        YzCSrnF/EMycojq7BiVfg8lACCKs4jgV7s5QkrC1KEkFJwdzfkj2lK6PggLxjJIzDHOt79oljLhC
+        cBf0P9w8wa/Ofv35tb7Zuyb7cGHL2OnVGq7Yjp27ebULrR6jdE5G4E+gdUrXI9x1pSBSMOl52FmM
+        eRYq52ha7xQQtN55D5DRhcdZRtBKhazxbeuOmbQez6qCwvlRt1FH3+nQDHVsnQ3at9g2QrFOtIr9
+        Piiq6D+ocea5CMszjhouE8irCYLO3BpF6KzGqujMOWOI1SRFHq/XERW1xm4o7biuV4RpQVZR2jqX
+        l13U/Qy991ProrbBTHcxnknEepTmgh9Om5XuU8Yzn2H6d5ATS+ExBmY5p7DIHEmbJ63Xl87PvwR/
+        3z9MP1jYYwOaBdiwSrVLHGAGl26kgSos0HXw/kwDh6cBz+WM2ZSKGfZPSuaAP+wHMOmKYc1p8aqn
+        uoQa8cTJu8bfMMYfDTPIDAvIXwd40sNYRzqLSwgm2QDuFT51iBOhPgwT8MF/0E8/Az0kQQ9U807Q
+        C1IVIhWn0D4eDVODAN2GgYJ2N2NRJdTNS0qomWHsi9y0240KJClmt3BSDFeuY4J35g5h0NedCiEV
+        Z6vzWfIDup6JtPT+dExAKZhk+2YCfmAq2NL/3rgAJplDXeJxIbF0OHa95kn4sa+F36kfwPn8UGGP
+        5IIJjFgCEJhQwsXG7BYw1p3qOqfyCgGAcicbchsB1PB5o157Ah/KN4n/xJMcE5eRRffzvHDOApej
+        OFADVAXYsjCqvQIhjFvYBnoHVljnRWkY00HJCKB1gPL7zhNYbCVYATbRBUYxVDAroOxOIw0gZgYj
+        1DxB18YPgAb0An8k/WAINVcmCRZbQ9FZD8YFDVQEAzOAS+bXB1Fk7nKBUFa7/rAbS3BK19gLBZag
+        q77v6yya2QvUhigJ3ubVIcw7IEsI+YThyWff92bUZtJ1c81VUEapx2xKosA+cJTfxp4ParfGrvKF
+        bDONhSaqI7tzNNd74o493sWzD/3rgH8mPCkJZmwpYWVSNgf/MXQnvkJXgX9bQP7utHo4rl3A/noW
+        m+EaU6CXA2Gc9lVUthmLSdEW+DyEIYOHQ31zj4ag4Qd+MLRPMkI960GKrFDkq2jOFcjEPRUFX8bv
+        7Pi4a/wssV0AgyxzRzvr9LR9leg+SPtovgZSmPvNk5uOcd6/7NbZPTp9Ob7VbjAWePo+C677KoZP
+        9SgZBrEKd6MJ5mK+hidwwf1PC8mPH3UHXeshwhJRWmFehSx4lshapnDJI/Lkd2UKRh3vCe2Jc1nH
+        52f7pgp52FT5bf3vz7dEKeWcewR7nIPhx0AJf0e+xDf04wFCAA8W9uhklgkqWYsCS+I4Ht2YAFmr
+        ge2xQ2ThvFr3tjNKXTREw3sCRvkmLQqHezAjhFiMys7K5pTyamxFhPk/bqRRIzQd4IqkwC7ntrRl
+        q5NlbnkLg7RMLcnMzWSng+4E0WRBgj7fXxF43J0IPBZSCI8S1l4Ti7iYWQQoyW0EMCRSFGWDcW9x
+        AC+5BOwUdRSC8f5sa4cmGxzbHyjpmzgtN6OaGVirBJ7ytyyw9XGsdsyaJ27RuHBkgTNWbYtLuGEb
+        McaejRgTZzH9kdC1jAFL5mABY8a8JzQteF023H3vrPpOTAvXcVxBhMcZp2D1Y6vUh93Wb+2f65f7
+        Z4sHC3skW8wAx7KFh6ngLsWb2AJXaZ1Vt7PFV25/fJNsQQiVlJPFAMS0aM4VtVAFsT6+VACD6LL+
+        4eLsp58LNDFudLlCERdv39Z/z+X0zmR3WgFuZ4mdojaIMEb2MeZ3NAoBeqE82IEIcmRHWYSGk07s
+        20SdyWewFNrjq6BFN0uhqY58A4bEINBwB39BL/KXFeRCXqx0/cJuU0YvxoGPXalDFPONXMoL6UaW
+        Tgrsca59m5VpUzJlhfJt8QuGrSFzIPogBPTLpzQ4VvXEZwJZ2ABlNz5xh3rElZgTDhaAFP+40OLN
+        8AC7rR4q7LG7rSYgBJ84ZRiWCGGb+GNXa6OwwXsDfzQatUPGL76n7VaEghbhLcWvp0ULoQvVH5is
+        g16pBBZGUGCOQX9WsUAdN32NPvYNIPY5wA6qqlHRi5WAiWEjCDDrTNwrGA8NkAJs0U3vVawrBSdT
+        yPHo1/5deM7BRLiKg8j6t0JUj3pBpAHsT5NgMLSTTfdUWEKnV2p0ZWPdYTaIsgSuOX3/we6oGl3C
+        bajJARBFMef1SxU67Sx8hZrRx+A2GNrmFXTaVymMkQXBHdNXCS9ux+JOIcefWIpZa41QYjOjwBpZ
+        jIe7a/mEc7aHgx428AknTxsPf86M2hygFg53OBPNk4vLly0sidvy41YCwB5OAf711cs9BcMfKuux
+        ZDKBJHvUg3QdIbDDN5FJ40w6rP6cDfVUZz1IAlOCCMcRLhOSCby4l7dYOWeZtk5VuQfmRLlb3J9V
+        hcqXULdMMWvypMYTaqWvgsmSzMwUeBc2GQqBcXAX+PBhmLXDwE9WLJOkjF5cpypOs2HSqaf2uJ/W
+        +cW764vajrELz27lWj3nxyue8kPXZELZYxsYQdgFZqgQb2tOrDxgJhR70hg3diiW/Bn412cmwdqi
+        BPAYvjmo9zaScKw/Ot2L1gHSoB4q7LEpsQXEyA9w8BywKNyNFsW5R5f9VU9PAn8aj5TjckaY49gI
+        5zyAMStcyIsNPmVhMS3WlrbG1sAC1Bdth7zhWrPhDHUAVcfJqx0EkJYEefwagMqE0/yotgLjw8a1
+        FVgYME42P8qGxhV8HBiYJFAT9gwga38A6F9XyQilBoVaxVEJJaqrS3nbrkrSMqqNMRu1R+h0qFsD
+        nUUBWCC2QQOmiXVjVbVNv90xaiFxkS6KZ8Ktps3aMHduJkhEcIXTCnW2kQVhjzjiZ+cTG+RTbgZu
+        8Ibb2B7lHj/fLsC/seXeMFx40uVYCtdjgHGg57rNk9aXQTt7NbrbO4Y/XNhjgwmzxZ9ns3oYS+xu
+        PErhOZvpyaDbpR6WnuMSj3nSgzmxGIMuVi5AeQbPY7o6T1bqTrXyZWC/MvWZvv67wG7Dz0sdghK/
+        JrJ8aSMP1nmE/CA1Ix0h+A8ADq5Bnf/LIo1+iizu5xlUY1U+jyB3TZzmUQTdte/Tnr/z98wCdWi1
+        fwOSLcgmSA2HOgxt/ypDsR6GgT21B8giKAF5pKlNkIqsKZEHLUJ7uo/5BN0uyUN/2THUIFkxTM28
+        goHACvZBpsdngEp7rBt1Fz1DZH2kwT3g+Q+w0J/QPPgGEd+uKpcxFxPXdYWTe8xrzk8fbz519u/9
+        f7iwRyJ+ESvyjWwulGGHPCP/V4f80nPz0aHEc5jjYrYYEShWzpHf+sMnAVoAxWLyUV6vJ1WbYH+S
+        djRrularn62oj0vtELwuZNH+hY78kR9OsbcTaBt9frFwc5YgXgCfREl+gltpjNxJTgk9HY97McMg
+        pw2QnOaBY4D0cRe+DZBPgD2ngiyCfyzkd0wUjSt2PcoTbNfiHmnpFU/ypHg1FmCVfLs3jgibmcTd
+        Ct26S5q4B/QIUbuP+xnyH5QxxAghYBxhBwvBMG+eNDJ6ff7y7vYQGUMPFPZYR00BJPLUIckYFd+N
+        sr8h9PstIj7jRFAHk0UVf1Y2x/fzzAc4Q6+1io6t+p7DnDRBEek/dTt522Wcr+qwF2SD9Vp+Mcl0
+        oZOVPNIbq193dWJ9OTaa21Vpfo7FC5XvRnthj+acnMz5Igza8Y4xWb4mxQdegruKwzZKW1C8z7Je
+        niDqVKiEFtu2FFDvcCcKUcfhz5vPvk7HvOtIbo90oMJm+TvUaZ4ch7276q+dq/075h8s7FvG4+9J
+        BSfcnjLiyaVj8qdlc0B+pQZfFHrT9/tBVHSyzMsXMPijicOO9ZIEX3Iv7Mr0vR1fw8sDXc5uC8hb
+        M8ddk59pj04/fL5+37hpfEA/nJ5/AqwxpdP3HWN+nB83VEb/rL8DFePDv3bNz8ceK3o+BC4gsM2d
+        KWz/fQ3/2+2/vOLgpe2/eD0CY3rAJEtG2HNSzFcJwS5lgmIXjC4BKo49/r15ApgVis+xfwAvy0OF
+        PTYtZooOeUiUgAqAN4dEWdVzzr3tyP6cF3MIbHco455NnZhD+6RojuxVHZULgN7Wkd9PV1Irw8LG
+        rXy+RFmcBGk50kX1+So0g7aNSPp9/QWdjlt245L1YUw2drV13LO+82TiQLE5+kEy/mw9J6fJMBiW
+        0U2s7pSVP/aKYHQaKt/AuKZj3tlF515z3gOYjwWVe/UUz2kujA1v8or9KyZsWxakPBzcU1e6zxr3
+        Vwn3lHsu6MEenR5EfFy1K2rPOP8AKc869leCwx6FUbPAsnBWz7hojsPvw+DOQmXNxLHqFNPd/XG5
+        WcbkmnUs9+Hh7Vk7xb848ns7a81YoD+Tt4zd+Z+r8uEnjP78c1culHsL5Rgdo8ZEYbd/9jAdxObe
+        NwD1+UkOHZipcIdnFzabpRtEHZT4Ksx3ViUmzPK3b6tqIQxlqlGtDwiny9BlPNBxOEKn11EwTNDp
+        S2N6cNHpRfXyw+Rc0Z01/mJyC3cKW3K5t8blkqe3YIS9CnErmG07655xckCFXzD5vSn87LCHOGzp
+        fn8+F8ntn1WiBDuCU+Jy0Tw50+L9K4/y/ftcHizssQr/BKumKZCCEncjy3xjp4J+F7uq/gX95y8G
+        9Gv7ZgjnYAvCoLlUYOzAiOGlFjM3T6FZ/jL1XWCyZNYbLpRNrretU5OqcIpM9i7/+z8AAAD//wMA
+        eu1NMJp3AAA=
     headers:
       cache-control: ['no-cache, no-store, must-revalidate, pre-check=0, post-check=0']
       content-disposition: [attachment; filename=json.json]
       content-encoding: [gzip]
-      content-length: ['5396']
+      content-length: ['5081']
       content-type: [application/json;charset=utf-8]
       expires: ['Tue, 31 Mar 1981 05:00:00 GMT']
-      last-modified: ['Sat, 29 Aug 2015 12:35:42 GMT']
+      last-modified: ['Mon, 29 Oct 2018 07:47:47 GMT']
       pragma: [no-cache]
-      set-cookie: ['guest_id=v1%3A144085174214476937; Domain=.twitter.com; Path=/;
-          Expires=Mon, 28-Aug-2017 12:35:42 UTC']
+      set-cookie: ['personalization_id="v1_cBUv+kN7DyRBWreeqjq+zQ=="; Expires=Wed,
+          28 Oct 2020 07:47:47 GMT; Path=/; Domain=.twitter.com', 'guest_id=v1%3A154079926736812219;
+          Expires=Wed, 28 Oct 2020 07:47:47 GMT; Path=/; Domain=.twitter.com']
       status: [200 OK]
       strict-transport-security: [max-age=631138519]
     status: {code: 200, message: OK}


### PR DESCRIPTION
This branch deletes some unneeded data from the `elsewhere` table, for GitHub and Twitter accounts. It should reduce the size of that table by approximately 14MB (see #1299).