### PR TITLE
Exclude stub payment accounts

### DIFF
--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -107,6 +107,7 @@ def resolve_destination(db, tippee, provider, payer, payer_country, payin_amount
            AND provider = %s
            AND is_current
            AND verified
+           AND coalesce(charges_enabled, true)
       ORDER BY country = %s DESC
              , default_currency = %s DESC
              , connection_ts
@@ -159,6 +160,7 @@ def resolve_destination(db, tippee, provider, payer, payer_country, payin_amount
                       AND a.provider = %s
                       AND a.is_current
                       AND a.verified
+                      AND coalesce(a.charges_enabled, true)
                )
     """, (tippee.id, provider))
     if not members:

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,55 @@
+CREATE OR REPLACE FUNCTION update_payment_providers() RETURNS trigger AS $$
+    DECLARE
+        rec record;
+    BEGIN
+        rec := (CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END);
+        UPDATE participants
+           SET payment_providers = coalesce((
+                   SELECT sum(DISTINCT array_position(
+                                           enum_range(NULL::payment_providers),
+                                           a.provider::payment_providers
+                                       ))
+                     FROM payment_accounts a
+                    WHERE ( a.participant = rec.participant OR
+                            a.participant IN (
+                                SELECT t.member
+                                  FROM current_takes t
+                                 WHERE t.team = rec.participant
+                            )
+                          )
+                      AND a.is_current IS TRUE
+                      AND a.verified IS TRUE
+                      AND coalesce(a.charges_enabled, true)
+               ), 0)
+         WHERE id = rec.participant
+            OR id IN (
+                   SELECT t.team FROM current_takes t WHERE t.member = rec.participant
+               );
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+UPDATE participants AS p
+   SET payment_providers = coalesce((
+           SELECT sum(DISTINCT array_position(
+                                   enum_range(NULL::payment_providers),
+                                   a.provider::payment_providers
+                               ))
+             FROM payment_accounts a
+            WHERE ( a.participant = p.id OR
+                    a.participant IN (
+                        SELECT t.member
+                          FROM current_takes t
+                         WHERE t.team = p.id
+                    )
+                  )
+              AND a.is_current IS TRUE
+              AND a.verified IS TRUE
+              AND coalesce(a.charges_enabled, true)
+       ), 0)
+ WHERE EXISTS (
+           SELECT a.id
+             FROM payment_accounts a
+            WHERE a.participant = p.id
+              AND a.charges_enabled IS false
+       );


### PR DESCRIPTION
When `charges_enabled` is `false` any payment attempt will fail, so a creator who has connected an unapproved Stripe account should be treated like a creator who doesn't have a Stripe account, i.e. donors should see this creator as "unable to receive new payments".