### PR TITLE
Prevent dropping the entire production database

### DIFF
--- a/sql/prod.sql
+++ b/sql/prod.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION abort_command() RETURNS event_trigger AS $$
+    BEGIN
+        RAISE EXCEPTION 'command % is disabled', tg_tag;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER prevent_schema_drop ON ddl_command_start WHEN TAG IN ('DROP SCHEMA')
+    EXECUTE PROCEDURE abort_command();


### PR DESCRIPTION
This PR adds an [event trigger](https://www.postgresql.org/docs/9.6/static/event-trigger-definition.html) to block the execution of a `DROP SCHEMA` command in the production database. It finally "fixes" <https://github.com/gratipay/gratipay.com/issues/3132>, which is almost 4 years old now.