### PR TITLE
Fix currency sums

### DIFF
--- a/liberapay/utils/currencies.py
+++ b/liberapay/utils/currencies.py
@@ -51,7 +51,7 @@ def _Money_init(self, amount=Decimal('0'), currency=None, rounding=None):
 
 def _Money_eq(self, other):
     if isinstance(other, self.__class__):
-        return self.__dict__ == other.__dict__
+        return self.amount == other.amount and self.currency == other.currency
     if isinstance(other, (Decimal, Number)):
         return self.amount == other
     if isinstance(other, MoneyBasket):

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION currency_amount_fuzzy_sum_sfunc(
+    currency_amount, currency_amount, currency
+) RETURNS currency_amount AS $$
+    BEGIN
+        IF ($2.amount IS NULL OR $2.currency IS NULL) THEN RETURN $1; END IF;
+        RETURN ($1.amount + (convert($2, $3, false)).amount, $3);
+    END;
+$$ LANGUAGE plpgsql STRICT;
+
+CREATE OR REPLACE FUNCTION currency_amount_fuzzy_sum_ffunc(currency_amount)
+RETURNS currency_amount AS $$
+    BEGIN
+        IF ($1.amount IS NULL OR $1.currency IS NULL) THEN RETURN NULL; END IF;
+        RETURN round($1);
+    END;
+$$ LANGUAGE plpgsql;
+
+DROP AGGREGATE sum(currency_amount, currency);
+CREATE AGGREGATE sum(currency_amount, currency) (
+    sfunc = currency_amount_fuzzy_sum_sfunc,
+    finalfunc = currency_amount_fuzzy_sum_ffunc,
+    stype = currency_amount,
+    initcond = '(0,)'
+);
+
+END;
+
+UPDATE tips
+   SET paid_in_advance = NULL
+ WHERE paid_in_advance IS NOT NULL
+   AND (paid_in_advance).amount IS NULL;

--- a/sql/currencies.sql
+++ b/sql/currencies.sql
@@ -528,12 +528,23 @@ $$ LANGUAGE plpgsql STRICT;
 CREATE FUNCTION currency_amount_fuzzy_sum_sfunc(
     currency_amount, currency_amount, currency
 ) RETURNS currency_amount AS $$
-    BEGIN RETURN ($1.amount + (convert($2, $3, false)).amount, $3); END;
+    BEGIN
+        IF ($2.amount IS NULL OR $2.currency IS NULL) THEN RETURN $1; END IF;
+        RETURN ($1.amount + (convert($2, $3, false)).amount, $3);
+    END;
 $$ LANGUAGE plpgsql STRICT;
+
+CREATE FUNCTION currency_amount_fuzzy_sum_ffunc(currency_amount)
+RETURNS currency_amount AS $$
+    BEGIN
+        IF ($1.amount IS NULL OR $1.currency IS NULL) THEN RETURN NULL; END IF;
+        RETURN round($1);
+    END;
+$$ LANGUAGE plpgsql;
 
 CREATE AGGREGATE sum(currency_amount, currency) (
     sfunc = currency_amount_fuzzy_sum_sfunc,
-    finalfunc = round,
+    finalfunc = currency_amount_fuzzy_sum_ffunc,
     stype = currency_amount,
     initcond = '(0,)'
 );

--- a/tests/py/test_currencies.py
+++ b/tests/py/test_currencies.py
@@ -134,9 +134,11 @@ class TestCurrenciesInDB(Harness):
         expected = MoneyBasket()
         actual = self.db.one("SELECT basket_sum(x) FROM unnest(NULL::currency_amount[]) x")
         assert expected == actual
+        actual = self.db.one("SELECT basket_sum(x) FROM unnest(ARRAY[NULL]::currency_amount[]) x")
+        assert expected == actual
         # Non-empty sum
         expected = MoneyBasket(EUR=D('0.33'), USD=D('0.77'))
-        actual = self.db.one("SELECT basket_sum(x) FROM unnest(%s) x", (list(expected),))
+        actual = self.db.one("SELECT basket_sum(x) FROM unnest(%s) x", (list(expected) + [None],))
         assert expected == actual
 
     def test_sums(self):

--- a/tests/py/test_currencies.py
+++ b/tests/py/test_currencies.py
@@ -139,6 +139,28 @@ class TestCurrenciesInDB(Harness):
         actual = self.db.one("SELECT basket_sum(x) FROM unnest(%s) x", (list(expected),))
         assert expected == actual
 
+    def test_sums(self):
+        # Empty sum
+        actual = self.db.one("SELECT sum(x) FROM unnest(NULL::currency_amount[]) x")
+        assert actual is None
+        actual = self.db.one("SELECT sum(x) FROM unnest(ARRAY[NULL]::currency_amount[]) x")
+        assert actual is None
+        # Empty fuzzy sum
+        actual = self.db.one("SELECT sum(x, 'EUR') FROM unnest(NULL::currency_amount[]) x")
+        assert actual is None
+        actual = self.db.one("SELECT sum(x, 'EUR') FROM unnest(ARRAY[NULL]::currency_amount[]) x")
+        assert actual is None
+        # Single-currency sum
+        amounts = [JPY('133'), JPY('977')]
+        expected = sum(amounts)
+        actual = self.db.one("SELECT sum(x, 'JPY') FROM unnest(%s) x", (amounts + [None],))
+        assert expected == actual
+        # Fuzzy sum
+        amounts = [EUR('0.50'), USD('1.20')]
+        expected = MoneyBasket(*amounts).fuzzy_sum('EUR')
+        actual = self.db.one("SELECT sum(x, 'EUR') FROM unnest(%s) x", (amounts + [None],))
+        assert expected == actual, (expected.__dict__, actual.__dict__)
+
 
 class TestCurrenciesSimplate(Harness):
 


### PR DESCRIPTION
This branch fixes the SQL implementation of fuzzy currency sums, and improves the tests of these tricky aggregate functions.

Closes #1313. Fixes [LIBERAPAYCOM-JB](https://sentry.io/share/issue/8cada7d9eca1449f8894baf9e99ba34d/).