### PR TITLE
Don't show the "translation incomplete" warning when the HTTP status isn't translated

### DIFF
--- a/error.spt
+++ b/error.spt
@@ -9,7 +9,7 @@ from liberapay.utils.i18n import HTTP_ERRORS
 
 sentry_ident = state.get('sentry_ident')
 code = response.code
-msg = _(HTTP_ERRORS.get(code, status_strings.get(code, '')))
+msg = _(HTTP_ERRORS[code]) if code in HTTP_ERRORS else status_strings.get(code, '')
 try:
     assert msg
 except Exception as e:

--- a/liberapay/utils/i18n.py
+++ b/liberapay/utils/i18n.py
@@ -256,6 +256,8 @@ _ = lambda a: a
 HTTP_ERRORS = {
     403: _("Forbidden"),
     404: _("Not Found"),
+    409: _("Conflict"),
+    410: _("Gone"),
     429: _("Too Many Requests"),
     500: _("Internal Server Error"),
     502: _("Upstream Error"),


### PR DESCRIPTION
This branch fixes #1215.