### PR TITLE
Fix pledges

### DIFF
--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -169,6 +169,7 @@ def resolve_destination(db, tippee, provider, payer, payer_country, payin_amount
     members = sorted(members, key=lambda t: (
         int(t.member == payer.id),
         -t.takes_sum_eur / (t.received_sum_eur + payin_amount_eur),
+        t.received_sum_eur,
         t.ctime
     ))
     member = Participant.from_id(members[0].member)

--- a/tests/py/fixtures/TestPages.yml
+++ b/tests/py/fixtures/TestPages.yml
@@ -115,7 +115,6 @@ interactions:
       last-modified: ['Mon, 22 Feb 2016 18:29:18 GMT']
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      transfer-encoding: [chunked]
       vary: [Accept, Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
@@ -146,7 +145,6 @@ interactions:
       etag: [W/"496ed98f124d8727ef173afda0aee82a"]
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      transfer-encoding: [chunked]
       vary: [Accept, Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
@@ -178,7 +176,6 @@ interactions:
       last-modified: ['Mon, 22 Feb 2016 18:29:18 GMT']
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      transfer-encoding: [chunked]
       vary: [Accept, Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
@@ -209,7 +206,6 @@ interactions:
       etag: [W/"496ed98f124d8727ef173afda0aee82a"]
       status: [200 OK]
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
-      transfer-encoding: [chunked]
       vary: [Accept]
     status: {code: 200, message: OK}
 - request:
@@ -661,5 +657,19 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubdomains; preload]
       transfer-encoding: [chunked]
       vary: [Accept]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://api.sandbox.mangopay.com/v2.01/liberapay-dev/users/20717489
+  response:
+    body: {string: !!python/unicode '{"Address":{"AddressLine1":null,"AddressLine2":null,"City":null,"Region":null,"PostalCode":null,"Country":null},"FirstName":"David","LastName":"Foobar","Birthday":0,"Nationality":"BE","CountryOfResidence":"BE","Occupation":null,"IncomeRange":null,"ProofOfIdentity":null,"ProofOfAddress":null,"PersonType":"NATURAL","Email":"nobody@example.net","KYCLevel":"LIGHT","Id":"20717489","Tag":null,"CreationDate":1491402287}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['416']
+      content-type: [application/json; charset=utf-8]
+      expires: ['-1']
+      pragma: [no-cache]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/py/test_communities.py
+++ b/tests/py/test_communities.py
@@ -4,7 +4,7 @@ import json
 
 from liberapay.exceptions import AuthRequired
 from liberapay.models.community import Community
-from liberapay.testing import EUR, Harness
+from liberapay.testing import Harness
 
 
 class Tests(Harness):
@@ -13,7 +13,7 @@ class Tests(Harness):
         Harness.setUp(self)
 
         # Alice joins a community.
-        self.alice = self.make_participant('alice', balance=EUR(100))
+        self.alice = self.make_participant('alice')
         c = self.alice.create_community('C++')
         self.alice.upsert_community_membership(True, c.id)
 

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -66,13 +66,13 @@ class TestPayins(Harness):
         alice_card = ExchangeRoute.insert(
             alice, 'stripe-card', 'x', 'chargeable', remote_user_id='x'
         )
-        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('2'), 'stripe')
+        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('2'))
         assert pt.destination == stripe_account_carl.pk
-        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('1'), 'stripe')
+        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('1'))
         assert pt.destination == stripe_account_bob.pk
-        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('4'), 'stripe')
+        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('4'))
         assert pt.destination == stripe_account_carl.pk
-        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('10'), 'stripe')
+        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('10'))
         assert pt.destination == stripe_account_carl.pk
-        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('2'), 'stripe')
+        payin, pt = self.make_payin_and_transfer(alice_card, team, EUR('2'))
         assert pt.destination == stripe_account_bob.pk

--- a/tests/py/test_public_json.py
+++ b/tests/py/test_public_json.py
@@ -8,10 +8,12 @@ from liberapay.testing import EUR, Harness
 class Tests(Harness):
 
     def test_anonymous(self):
-        alice = self.make_participant('alice', balance=EUR(100))
+        alice = self.make_participant('alice')
+        alice_card = self.upsert_route(alice, 'stripe-card')
         bob = self.make_participant('bob')
-
+        self.add_payment_account(bob, 'stripe')
         alice.set_tip_to(bob, EUR('1.00'))
+        self.make_payin_and_transfer(alice_card, bob, EUR('10'))
 
         data = json.loads(self.client.GET('/bob/public.json').text)
         assert data['receiving'] == {"amount": "1.00", "currency": "EUR"}


### PR DESCRIPTION
This branch modifies how Liberapay determines if a pledge is "funded" or not. Previously it looked at the amount of money in the donor's wallet, but now that wallets are gone it's going to check that the donor has recently sent money to another creator, which is almost the same thing.