### PR TITLE
Fix one-off payment routes

### DIFF
--- a/liberapay/models/exchange_route.py
+++ b/liberapay/models/exchange_route.py
@@ -40,6 +40,7 @@ class ExchangeRoute(Model):
                AND network::text = %(network)s
                AND status = 'chargeable'
                AND COALESCE(currency::text, '') = COALESCE(%(currency)s::text, '')
+               AND (one_off IS FALSE OR ctime > (current_timestamp - interval '6 hours'))
           ORDER BY r.id DESC
         """, locals())
         for route in r:

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -77,6 +77,14 @@ def update_payin(db, payin_id, remote_id, status, error, amount_settled=None, fe
             VALUES (%s, %s, %s, current_timestamp)
         """, (payin_id, status, error))
 
+        if payin.status in ('pending', 'succeeded'):
+            cursor.run("""
+                UPDATE exchange_routes
+                   SET status = 'consumed'
+                 WHERE id = %s
+                   AND one_off IS TRUE
+            """, (payin.route,))
+
         return payin
 
 

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -234,6 +234,7 @@ else:
          WHERE r.participant = %s
            AND r.status = 'chargeable'
            AND r.network::text LIKE 'stripe-%%'
+           AND (r.one_off IS FALSE OR r.ctime > (current_timestamp - interval '6 hours'))
       ORDER BY r.network = 'stripe-sdd' DESC
              , r.id DESC
          LIMIT 1

--- a/www/%username/wallet/payin/direct-debit/%exchange_id.spt
+++ b/www/%username/wallet/payin/direct-debit/%exchange_id.spt
@@ -51,6 +51,7 @@ else:
            AND remote_user_id = %s
            AND network = 'mango-ba'
            AND status = 'chargeable'
+           AND (one_off IS FALSE OR ctime > (current_timestamp - interval '6 hours'))
       ORDER BY id = %s DESC, mandate IS NOT NULL DESC, id DESC
          LIMIT 1
     """, (participant.id, participant.mangopay_user_id, route_id))


### PR DESCRIPTION
Their status wasn't being changed to `consumed`. Now it will be, and there will also be a limit of 6 hours even if the status isn't changed.