### PR TITLE
Gitlab mirror

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,4 @@
-[lfs]
-	url = git@github.com:liberapay/liberapay.com
+[remote "origin"]
+	lfsurl = git@github.com:liberapay/liberapay.com
+[remote "gitlab"]
+	lfsurl = git@gitlab.com:liberapay/liberapay.com.git


### PR DESCRIPTION
Here is a fix that allowed me to mirror Liberapay to Gitlab: https://gitlab.com/liberapay/liberapay.com

ref #46