### PR TITLE
Prepare to payout remaining balances indirectly

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -663,12 +663,15 @@ class Participant(Model, MixinTeam):
     def donate_remaining_balances_to_liberapay(self):
         """Donate what's left in the user's wallets to Liberapay.
         """
+        self.transfer_remaining_balances_to_liberapay(donate=True)
+
+    def transfer_remaining_balances_to_liberapay(self, donate=False):
         LiberapayOrg = self.from_username('LiberapayOrg')
         Liberapay = self.from_username('Liberapay')
         tip = self.get_tip_to(LiberapayOrg)
         if not tip['amount']:
             tip = self.get_tip_to(Liberapay)
-        if tip['amount']:
+        if tip['amount'] and donate:
             if tip['tippee'] == Liberapay.id:
                 context = 'take-in-advance'
                 team = Liberapay.id
@@ -677,7 +680,7 @@ class Participant(Model, MixinTeam):
                 team = None
             unit_amount = tip['amount']
         else:
-            context = 'final-gift'
+            context = 'final-gift' if donate else 'indirect-payout'
             team = None
             unit_amount = None
         from liberapay.billing.transactions import transfer

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'indirect-payout';

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -323,6 +323,9 @@ if user.is_admin:
                 {{ _("currency exchange") }}
             % elif context == 'fee-refund'
                 {{ _("fee refund") }}
+            % elif context == 'indirect-payout'
+                indirect payout for
+                <a href="/{{ event['username'] }}/{{ subpath }}">{{ event['username'] }}</a>
             % endif
         % else
             % set to = ('<a href="/{0}/">{0}</a>'|safe).format(event['username'])
@@ -366,6 +369,8 @@ if user.is_admin:
                 {{ _("currency exchange") }}
             % elif context == 'fee-refund'
                 {{ _("fee refund") }}
+            % elif context == 'indirect-payout'
+                indirect withdrawal
             % endif
         % endif
         % if event['status'] != 'succeeded'

--- a/www/%username/wallet/statement.spt
+++ b/www/%username/wallet/statement.spt
@@ -232,6 +232,8 @@ output.body = render(globals(), allow_partial_i18n=False)
                     {{ _("currency exchange") }}
                 % elif context == 'fee-refund'
                     {{ _("fee refund") }}
+                % elif context == 'indirect-payout'
+                    indirect payout for {{ event['username'] }}
                 % endif
             % else
                 % set to = event['username']
@@ -274,6 +276,8 @@ output.body = render(globals(), allow_partial_i18n=False)
                     {{ _("currency exchange") }}
                 % elif context == 'fee-refund'
                     {{ _("fee refund") }}
+                % elif context == 'indirect-payout'
+                    {{ _("withdrawal") }}
                 % endif
             % endif
             </td>


### PR DESCRIPTION
The idea is to transfer the funds into the LiberapayOrg wallet, then withdraw them to Liberapay's bank account, and finally pull them into PayPal for a MassPay.