### PR TITLE
Update documentation of payment methods

### DIFF
--- a/www/%username/donate.spt
+++ b/www/%username/donate.spt
@@ -93,15 +93,16 @@ full_title = _("Donate to {0} via Liberapay", participant.username)
         username=participant.username
     ) if participant.payment_providers == 0 else _(
         "Donations to {username} can be paid using a credit or debit card "
-        "(Visa, MasterCard, American Express).",
+        "(Visa, MasterCard, American Express), or by direct debit of a Euro "
+        "bank account (for donations in Euro only).",
         username=participant.username
     ) if participant.payment_providers == 1 else _(
-        "Donations to {username} are processed through PayPal. You can pay with "
-        "a credit or debit card even if you don't have a PayPal account.",
+        "Donations to {username} are processed through PayPal.",
         username=participant.username
     ) if participant.payment_providers == 2 else _(
-        "Donations to {username} can be paid using a credit or debit card "
-        "(Visa, MasterCard, American Express), or through PayPal.",
+        "Donations to {username} can be paid using: a credit or debit card "
+        "(Visa, MasterCard, American Express), a Euro bank account (SEPA Direct "
+        "Debit), or a PayPal account.",
         username=participant.username
     ) }}</p>
 

--- a/www/%username/payment/index.spt
+++ b/www/%username/payment/index.spt
@@ -61,8 +61,9 @@ subhead = _("Payment Processors")
 
     <h3>Stripe</h3>
     <p>{{ _(
-        "With Stripe your donors can pay by card directly from the Liberapay "
-        "website. SEPA Direct Debits will also be supported soon."
+        "With Stripe your donors can pay by card or direct debit directly from the "
+        "Liberapay website. (Direct debits are currently only supported from Euro "
+        "bank accounts.)"
     ) }}</p>
     % set accounts = accounts_by_provider.get('stripe', ())
     % if accounts

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -102,10 +102,9 @@ title = _("Frequently Asked Questions")
         "The available payment methods depend on which payment processors are "
         "supported by the recipient. If a payment is processed by Stripe, then "
         "most credit and debit cards (Visa, MasterCard, American Express) are "
-        "accepted, and in the near future SEPA Direct Debits will be too. If "
-        "a payment is through PayPal, then it's also possible to pay with most "
-        "credit and debit cards even without having a PayPal account, and in "
-        "other ways for users who do have a PayPal account."
+        "accepted, as well as SEPA Direct Debits (for Euro donations only). If "
+        "a payment is through PayPal, then it's possible to pay in various "
+        "ways, however the donor needs to have or create a PayPal account."
     ) }}</dd>
 
 


### PR DESCRIPTION
SEPA Direct Debits have been operational for a while now, but the FAQ still hadn't been updated. In addition it looks like having or creating a PayPal account is now always required to make a payment through PayPal, so this branch updates Liberapay's docs accordingly.