### PR TITLE
Improve inclusion of lists in translatable messages

### DIFF
--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -127,7 +127,7 @@ class ValueContainsForbiddenCharacters(LazyResponse400):
     def msg(self, _, locale):
         return _(
             "The value '{0}' contains the following forbidden characters: {1}.",
-            self.args[0], locale.format_list(["'%s'" % c for c in self.args[1]])
+            self.args[0], ["'%s'" % c for c in self.args[1]]
         )
 
 
@@ -341,7 +341,7 @@ class AmbiguousNumber(LazyResponse400):
             return _(
                 '"{0}" is not a properly formatted number. Perhaps you meant {list_of_suggestions}?',
                 self.ambiguous_string,
-                list_of_suggestions=locale.format_list(self.suggestions, 'or')
+                list_of_suggestions=locale.List(self.suggestions, 'or')
             )
         else:
             return _('"{0}" is not a properly formatted number.', self.ambiguous_string)

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -184,14 +184,14 @@ class Locale(babel.core.Locale):
             last = n - 2
             r = l[0]
             for i, item in enumerate(l[1:]):
-                r = escape(self.list_patterns[pattern][
+                r = self.format(escape(self.list_patterns[pattern][
                     'start' if i == 0 else 'end' if i == last else 'middle'
-                ]).format(r, item)
+                ]), r, item)
             return r
         elif n == 2:
-            return escape(self.list_patterns[pattern]['2']).format(*l)
+            return self.format(escape(self.list_patterns[pattern]['2']), *l)
         else:
-            return l[0] if n == 1 else None
+            return self.format(escape('{0}'), l[0]) if n == 1 else None
 
     def format_money_basket(self, basket, sep=','):
         if basket is None:

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -16,6 +16,10 @@ from ..website import website
 from .currencies import Money, MoneyBasket
 
 
+def no_escape(s):
+    return s
+
+
 def LegacyMoney(o):
     return o if isinstance(o, (Money, MoneyBasket)) else Money(o, 'EUR')
 
@@ -38,6 +42,14 @@ class Currency(str):
     __slots__ = ()
 
 
+class List(list):
+    __slots__ = ('pattern',)
+
+    def __init__(self, iterable, pattern='standard'):
+        list.__init__(self, iterable)
+        self.pattern = pattern
+
+
 class Age(timedelta):
 
     def __new__(cls, *a, **kw):
@@ -47,6 +59,8 @@ class Age(timedelta):
 
 
 class Locale(babel.core.Locale):
+
+    List = List
 
     def __init__(self, *a, **kw):
         super(Locale, self).__init__(*a, **kw)
@@ -138,6 +152,10 @@ class Locale(babel.core.Locale):
                     c[k] = self.countries.get(o, o)
                 elif isinstance(o, Currency):
                     c[k] = self.currencies.get(o, o)
+                elif isinstance(o, list):
+                    escape = getattr(s.__class__, 'escape', no_escape)
+                    pattern = getattr(o, 'pattern', 'standard')
+                    c[k] = self.format_list(o, pattern, escape)
                 if wrapper:
                     c[k] = wrapper % (c[k],)
         return s.format(*a, **kw)
@@ -160,7 +178,7 @@ class Locale(babel.core.Locale):
         kw['locale'] = self
         return format_decimal(*a, **kw)
 
-    def format_list(self, l, pattern='standard', escape=lambda a: a):
+    def format_list(self, l, pattern='standard', escape=no_escape):
         n = len(l)
         if n > 2:
             last = n - 2

--- a/www/index.html.spt
+++ b/www/index.html.spt
@@ -188,10 +188,10 @@ recent = query_cache.one("""
                 </dt>
                 <dd>{{ _(
                     "We currently support processing payments through {payment_processors_list}.",
-                    payment_processors_list=locale.format_list([
+                    payment_processors_list=[
                         '<a href="https://stripe.com/">Stripe</a>'|safe,
                         '<a href="https://paypal.com/">PayPal</a>'|safe,
-                    ], escape=escape)
+                    ]
                 ) }}</dd>
             </div>
             <div class="col-sm-4">
@@ -303,7 +303,7 @@ recent = query_cache.one("""
                 ) }}
                 {{ _(
                     "You can also easily list on your profile the repositories you contribute to on {platforms_list}.",
-                    platforms_list=locale.format_list(platforms_with_repos)
+                    platforms_list=platforms_with_repos
                 ) }}
                 </dd>
             </div>


### PR DESCRIPTION
This commit makes it easier to include a variable list of values in a paragraph and prevents the list from being rendered using a different locale than the paragraph.