### PR TITLE
Collect cardholder name for Stripe

### DIFF
--- a/js/stripe.js
+++ b/js/stripe.js
@@ -62,7 +62,9 @@ Liberapay.stripe_init = function() {
         var tokenData = {};
         if (element_type == 'iban') {
             tokenData.currency = 'EUR';
-            tokenData.account_holder_name = $('#account_holder_name').val();
+            tokenData.account_holder_name = $('input[name="owner.name"]').val();
+        } else if (element_type == 'card') {
+            tokenData.name = $('input[name="owner.name"]').val();
         }
         stripe.createToken(element, tokenData).then(Liberapay.wrap(function(result) {
             if (result.error) {

--- a/style/base/stripe.scss
+++ b/style/base/stripe.scss
@@ -7,6 +7,7 @@
 }
 #stripe-errors {
     display: block;
+    z-index: 1000;
     &:empty {
         display: none;
     }

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -468,7 +468,9 @@ title = _("Funding your donations")
 
         % if payment_method == 'card'
         <fieldset id="card-form" class="form-group {{ 'hidden' if source else '' }}">
-            <p>{{ _("Please input your card number:") }}</p>
+            <p>{{ _("Please input your name and card number:") }}</p>
+            <input name="owner.name" autocomplete="name" required minlength=3
+                   class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
             <div id="stripe-element" data-type="card" class="form-control paragraph"></div>
             <span id="stripe-errors" role="alert" class="invalid-msg"></span>
             <p class="help-block">{{ glyphicon('lock') }} {{ _(
@@ -487,7 +489,7 @@ title = _("Funding your donations")
             <p>{{ _(
                 "Please input your name and your IBAN (International Bank Account Number):"
             ) }}</p>
-            <input id="account_holder_name" autocomplete="name" required minlength=3
+            <input name="owner.name" autocomplete="name" required minlength=3
                    class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
             <div id="stripe-element" data-type="iban" class="form-control paragraph"></div>
             <span id="stripe-errors" role="alert" class="invalid-msg"></span>


### PR DESCRIPTION
We're currently collecting the donor's name for SEPA direct debits but not for card payments. This branch harmonizes the two payment methods.