### PR TITLE
Fix notifications

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1321,7 +1321,7 @@ class Participant(Model, MixinTeam):
                          FROM notifications n
                         WHERE n.participant = tip.tipper
                           AND n.event = 'pledgee_joined~v2'
-                          AND n.idem_key = event.payload->>'owner'
+                          AND n.idem_key = tip.tippee::text
                    )
           GROUP BY event.payload
         """)

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1151,6 +1151,17 @@ class Participant(Model, MixinTeam):
             email = self.email_notif_bits & bit > 0
         p_id = self.id
         context = serialize(context)
+        # Check that this notification isn't a duplicate
+        n = self.db.one("""
+            SELECT count(*)
+              FROM notifications
+             WHERE participant = %(p_id)s
+               AND event = %(event)s
+               AND ( idem_key = %(idem_key)s OR
+                     ts::date = current_date AND context = %(context)s )
+        """, locals())
+        assert n == 0
+        # Okay, add the notification to the queue
         n_id = self.db.one("""
             INSERT INTO notifications
                         (participant, event, context, web, email, idem_key)
@@ -1159,6 +1170,7 @@ class Participant(Model, MixinTeam):
         """, locals())
         if not web:
             return n_id
+        # Update the participant's `pending_notifs` count
         pending_notifs = self.db.one("""
             UPDATE participants
                SET pending_notifs = pending_notifs + 1

--- a/tests/py/test_elsewhere.py
+++ b/tests/py/test_elsewhere.py
@@ -218,6 +218,12 @@ class TestElsewhere(EmailHarness):
         assert "to dan" in last_email['text']
         assert "Change your email settings" in last_email['text']
 
+        # check that the notification isn't sent again
+        self.mailer.reset_mock()
+        Participant.notify_patrons()
+        Participant.dequeue_emails()
+        assert self.mailer.call_count == 0
+
 
 class TestConfirmTakeOver(Harness):
 

--- a/tests/py/test_email.py
+++ b/tests/py/test_email.py
@@ -287,7 +287,7 @@ class TestEmail(EmailHarness):
         last_email = self.get_last_email()
         assert last_email['to'][0] == 'larry <larry@example.com>'
         assert last_email['subject'] == "Email address verification - Liberapay"
-        assert self.db.one("SELECT event FROM notifications") is None
+        assert self.db.one("SELECT email_sent FROM notifications") is True
 
     def test_dequeueing_an_email_without_address_just_skips_it(self):
         larry = self.make_participant('larry')
@@ -296,4 +296,4 @@ class TestEmail(EmailHarness):
         assert self.db.one("SELECT event FROM notifications") == "verification"
         Participant.dequeue_emails()
         assert self.mailer.call_count == 0
-        assert self.db.one("SELECT event FROM notifications") is None
+        assert self.db.one("SELECT email_sent FROM notifications") is False

--- a/tests/py/test_notifications.py
+++ b/tests/py/test_notifications.py
@@ -62,8 +62,20 @@ class TestNotifications(Harness):
 
     def test_marking_notifications_as_read_avoids_race_condition(self):
         alice = self.make_participant('alice')
-        n1 = alice.notify('low_balance', email=False)
-        n2 = alice.notify('low_balance', email=False)
+        n1 = alice.notify(
+            'team_invite',
+            email=False,
+            team='team',
+            team_url='fake_url',
+            inviter='bob',
+        )
+        n2 = alice.notify(
+            'team_invite',
+            email=False,
+            team='teamX',
+            team_url='fake_url',
+            inviter='Zarina',
+        )
         assert alice.pending_notifs == 2
 
         data = {'mark_all_as_read': 'true', 'until': str(n1)}

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -371,6 +371,7 @@ class TestPayday(EmailHarness, FakeTransfersHarness, MangopayHarness):
         assert '0.40' in emails[1]['text']
 
         # Now run a second payday and check the results again
+        self.db.run("UPDATE notifications SET ts = ts - interval '1 week'")
         Payday.start().run()
         tips = self.db.all("""
             SELECT *


### PR DESCRIPTION
I messed up in #1431. Last night the new `notify_patrons` cron started sending the same notification over and over again to 3 users. Each of them received 148 identical emails!

This branch fixes the bug and adds a check to prevent similar bugs in the future.