### PR TITLE
Protect community from confusable homoglyphs

### DIFF
--- a/tests/py/test_communities.py
+++ b/tests/py/test_communities.py
@@ -1,6 +1,9 @@
 import json
 
-from liberapay.exceptions import AuthRequired
+from liberapay.exceptions import (
+        AuthRequired,
+        CommunityAlreadyExists,
+)
 from liberapay.models.community import Community
 from liberapay.testing import Harness
 
@@ -100,6 +103,30 @@ class TestCommunityActions(Harness):
 
         communities = self.bob.get_communities()
         assert len(communities) == 0
+
+    def test_create_community_already_taken(self):
+        with self.assertRaises(CommunityAlreadyExists):
+            Community.create('test', self.alice.id)
+
+    def test_create_community_already_taken_is_case_insensitive(self):
+        with self.assertRaises(CommunityAlreadyExists):
+            Community.create('TeSt', self.alice.id)
+
+    def test_unconfusable(self):
+        self.assertEqual('user2', Community._unconfusable('user2'))
+        self.assertEqual('alice', Community._unconfusable('alice'))
+        latin_string = 'AlaskaJazz'
+        mixed_string = 'ΑlaskaJazz'
+        self.assertNotEqual(latin_string, mixed_string)
+        self.assertEqual(latin_string, Community._unconfusable(mixed_string))
+
+    def test_create_community_already_taken_with_confusable_homoglyphs(self):
+        latin_string = 'AlaskaJazz'
+        mixed_string = 'ΑlaskaJazz'
+
+        Community.create(latin_string, self.bob.id)
+        with self.assertRaises(CommunityAlreadyExists):
+            Community.create(mixed_string, self.alice.id)
 
 
 class TestCommunityEdit(Harness):


### PR DESCRIPTION
This PR aims to fix #1469 by protecting the creation of confusable name for community.

I learned how to use the library during the implementation but there is something I don't know very well how to do.

The documentation says that we have to [update the data file](https://confusable-homoglyphs.readthedocs.io/en/latest/usage.html) by executing the two following commands:

```
pip install confusable_homoglyphs[cli]
confusable_homoglyphs update
```

I suppose the call the `confusable_homoglyphs update` has to be added to the `Makefile` during the `make env` step, am I right?