### PR TITLE
Fix team payment providers

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION compute_payment_providers(bigint) RETURNS bigint AS $$
+    SELECT coalesce((
+        SELECT sum(DISTINCT array_position(
+                                enum_range(NULL::payment_providers),
+                                a.provider::payment_providers
+                            ))
+          FROM payment_accounts a
+         WHERE ( a.participant = $1 OR
+                 a.participant IN (
+                     SELECT t.member
+                       FROM current_takes t
+                      WHERE t.team = $1
+                        AND t.amount <> 0
+                 )
+               )
+           AND a.is_current IS TRUE
+           AND a.verified IS TRUE
+           AND coalesce(a.charges_enabled, true)
+    ), 0);
+$$ LANGUAGE SQL STRICT;
+
+UPDATE participants SET payment_providers = compute_payment_providers(id) WHERE kind = 'group';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -602,6 +602,7 @@ CREATE FUNCTION compute_payment_providers(bigint) RETURNS bigint AS $$
                      SELECT t.member
                        FROM current_takes t
                       WHERE t.team = $1
+                        AND t.amount <> 0
                  )
                )
            AND a.is_current IS TRUE


### PR DESCRIPTION
Currently users are that try to donate to the [Manjaro](https://liberapay.com/Manjaro/) team end up getting an error message saying that their donation can't be processed, because the only member who could receive the donation has his take set to zero.