### PR TITLE
Include teams in one-to-many payments

### DIFF
--- a/www/%username/giving/pay/%payment_id.spt
+++ b/www/%username/giving/pay/%payment_id.spt
@@ -79,7 +79,11 @@ if tippee_id:
         donations_not_fundable = [tip]
 
 else:
-    donations_not_fundable = donation_groups['no_provider'] + donation_groups['suspended']
+    donations_not_fundable = (
+        donation_groups['no_provider'] +
+        donation_groups['no_taker'] +
+        donation_groups['suspended']
+    )
     self_donations = donation_groups['self_donation']
     if n_payments:
         payment = NS()


### PR DESCRIPTION
Currently donations to teams are never grouped into a single payment even if the teams have European members with Stripe accounts. This branch fixes that.