### PR TITLE
Sizes of headings

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -100,11 +100,14 @@ body {
     }
 }
 
+.main-title {
+    margin: 0.25em 0 1em;
+    text-align: center;
+}
+
 .thin-title {
     color: #666;
     font-size: $font-size-h4;
-    margin: 0.5em 0 1.25em;
-    text-align: center;
 }
 
 .btn {
@@ -210,7 +213,7 @@ a.account-link[href="#not-available"] {
         display: inline-block;
     }
     & > h1 {
-        font-size: $font-size-h3;
+        font-size: $font-size-h2;
         margin: 1em 0;
     }
     & > .summary {

--- a/style/variables.scss
+++ b/style/variables.scss
@@ -54,9 +54,9 @@ $font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~20px
 $font-size-medium:        ceil(($font-size-base * 1.12)) !default; // ~18px
 $font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~14px
 
-$font-size-h1:            floor(($font-size-base * 2.5)) !default; // ~40px
-$font-size-h2:            floor(($font-size-base * 2.15)) !default; // ~34px
-$font-size-h3:            ceil(($font-size-base * 1.7)) !default; // ~28px
+$font-size-h1:            floor(($font-size-base * 2)) !default; // ~32px
+$font-size-h2:            floor(($font-size-base * 1.75)) !default; // ~28px
+$font-size-h3:            ceil(($font-size-base * 1.5)) !default; // ~24px
 $font-size-h4:            ceil(($font-size-base * 1.25)) !default; // ~20px
 $font-size-h5:            $font-size-base !default;
 $font-size-h6:            ceil(($font-size-base * 0.85)) !default; // ~14px

--- a/templates/base-thin.html
+++ b/templates/base-thin.html
@@ -5,7 +5,7 @@
 % block content
 <div class="row">
     <div class="col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
-        {% block heading %}<h2 class="thin-title">{{ title }}</h2>{% endblock %}
+        {% block heading %}<h1 class="main-title thin-title">{{ title }}</h1>{% endblock %}
         {% block thin_content %}{% endblock %}
     </div>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -101,7 +101,7 @@
         % block before_content
             % block heading
                 % if title
-                    <h1 class="{{ 'hidden-xs hidden-sm' if subhead }}">{{ title }}</h1>
+                    <h1 class="main-title {{ 'hidden-xs hidden-sm' if subhead else '' }}">{{ title }}</h1>
                 % endif
             % endblock
             <div id="subnav">{% block subnav %}{% endblock %}</div>

--- a/www/explore/elsewhere/%platform.spt
+++ b/www/explore/elsewhere/%platform.spt
@@ -85,7 +85,7 @@ subhead = _("Social Networks")
         % set n_connected_accounts = d['n_connected_accounts']
         % if n_connected_accounts or p in website.friends_platforms
         <div class="card card-default card-md card-narrow text-center">
-            <h3 class="text-info">{{ p.display_name }}</h3>
+            <h2 class="text-info">{{ p.display_name }}</h2>
             <p>{{ ngettext("{n} connected account", "{n} connected accounts", n_connected_accounts) }}</p>
             <a class="btn btn-info btn-lg" href="/explore/elsewhere/{{ p.name }}"
                 >{{ _("Explore {0}", p.display_name) }}</a>

--- a/www/explore/index.html.spt
+++ b/www/explore/index.html.spt
@@ -20,7 +20,7 @@ title = _("Explore")
     <br>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Teams") }}</h3>
+        <h2 class="text-info">{{ _("Teams") }}</h2>
         <p>{{ _(
             "A team is a group of users working on a specific project."
         ) }}</p>
@@ -28,7 +28,7 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Organizations") }}</h3>
+        <h2 class="text-info">{{ _("Organizations") }}</h2>
         <p>{{ _(
             "Great nonprofits and companies trying to improve the world."
         ) }}</p>
@@ -36,7 +36,7 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Individuals") }}</h3>
+        <h2 class="text-info">{{ _("Individuals") }}</h2>
         <p>{{ _(
             "People like you who contribute to the commons (art, knowledge, software, …)."
         ) }}</p>
@@ -44,7 +44,7 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Pledges") }}</h3>
+        <h2 class="text-info">{{ _("Pledges") }}</h2>
         <p>{{ _(
             "Liberapay allows pledging to fund people who haven't joined the site yet."
         ) }}</p>
@@ -52,11 +52,11 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Repositories") }}
+        <h2 class="text-info">{{ _("Repositories") }}
             <small title="{{ _("A repository contains a project's data, for example the source code of an application.") }}"
                    data-toggle="tooltip" data-placement="top"
                    >{{ glyphicon('question-sign') }}</small>
-        </h3>
+        </h2>
         <p>{{ _(
             "See the most popular repositories belonging to Liberapay users, and "
             "browse lists of repos that you've starred on other platforms."
@@ -65,7 +65,7 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Social Networks") }}</h3>
+        <h2 class="text-info">{{ _("Social Networks") }}</h2>
         <p>{{ _(
             "Browse the accounts that Liberapay users have on other platforms. "
             "Find your contacts by connecting your own accounts."
@@ -74,7 +74,7 @@ title = _("Explore")
     </div>
 
     <div class="card card-default card-md text-center">
-        <h3 class="text-info">{{ _("Communities") }}</h3>
+        <h2 class="text-info">{{ _("Communities") }}</h2>
         <p>{{ _(
             "Communities allow you to find people that work on things you care "
             "about. You can also subscribe to their newsletters to stay informed."


### PR DESCRIPTION
This commit reduces the font sizes of the biggest headings.

- `<h1>`: 40px → 32px
- `<h2>`: 34px → 28px
- `<h3>`: 28px → 24px
