### PR TITLE
Upgrade Jinja

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -34,9 +34,9 @@ aspen-jinja2==0.5 \
     --hash=sha256:b199d34d84cfaab3f5a94c3e28fa04bd453950f7c1187ff92e9fbf2319e1e1fa \
     --hash=sha256:316fad588dc68bb8f86a6bf7cf56d2a666a1e4659d30bf26c29f24685dd2a8e6
 
-    Jinja2==2.10 \
-        --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd \
-        --hash=sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
+    Jinja2==2.10.1 \
+        --hash=sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013 \
+        --hash=sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b
 
         MarkupSafe==1.1.0 \
             --hash=sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6 \


### PR DESCRIPTION
[Jinja 2.10.1 Security Release](https://palletsprojects.com/blog/jinja-2-10-1-released/). As far as I can tell Liberapay isn't affected, but let's upgrade anyway.