### PR TITLE
Upgrade urllib3

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -103,9 +103,9 @@ requests==2.21.0 \
         --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
         --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407
 
-    urllib3==1.24.1 \
-        --hash=sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39 \
-        --hash=sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
+    urllib3==1.25.1 \
+        --hash=sha256:904bd981d6371bb95a200c0ec9dba5ba7cc980f2d6b125bd793fefe3293be388 \
+        --hash=sha256:a9645efd62b9fc1c7cad8ed93e162aad4c6bfd90e143966ddd4099b78cd244be
 
 requests-oauthlib==0.8.0 \
     --hash=sha256:883ac416757eada6d3d07054ec7092ac21c7f35cb1d2cf82faf205637081f468 \


### PR DESCRIPTION
Fixes a potential security vulnerability ([CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324)).