### PR TITLE
Fix actual takes

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -414,7 +414,10 @@ class Payday(object):
         total_income = MoneyBasket(t.full_amount for t in tips)
         if total_income == 0:
             return (), total_income
-        takes = [t for t in takes if t.amount != 0]
+        if mangopay.sandbox:
+            takes = [t for t in takes if t.amount != 0]
+        else:
+            takes = [t for t in takes if t.amount != 0 and t.paid_in_advance]
         if not takes:
             return (), total_income
         fuzzy_income_sum = total_income.fuzzy_sum(ref_currency)


### PR DESCRIPTION
This commit bypasses a problem in `Payday.resolve_takes()` that results in the computed takes being lower than they should be, and consequently in the leftover being higher than it should. I've started work on a proper fix, but it's not ready yet, so I'm thinking of deploying this hack instead before tomorrow's payday.