### PR TITLE
Revamp the social explorer

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -119,7 +119,17 @@ body {
     background-color: $base-color;
     color: #1a171b;
     &:hover {
+        background-color: lighten($base-color, 15%);
+    }
+}
+
+.btn-pledge {
+    $base-color: #ffee16;
+    background-color: lighten($base-color, 5%);
+    color: #7f6e06;
+    &:hover {
         background-color: lighten($base-color, 20%);
+        color: #5f4e06;
     }
 }
 
@@ -274,13 +284,14 @@ p.summary {
     }
     .summary {
         height: 3 * $line-height-computed;
-        margin: 1em 0 $line-height-computed;
+        margin: 1em 0 0;
         overflow: hidden;
         text-overflow: ellipsis;
     }
     .numbers {
         display: flex;
         justify-content: space-around;
+        margin: $line-height-computed 0 0;
         & > dl {
             margin: 0 10px 0 0;
             & > dt {
@@ -297,6 +308,16 @@ p.summary {
                     font-size: $font-size-small;
                 }
             }
+        }
+    }
+    & > .panel-body > .btn {
+        margin: $line-height-computed 0 0;
+    }
+    .btn-donate {
+        color: #7f6e06;
+        font-weight: bold;
+        &:hover {
+            color: #5f4e06;
         }
     }
 }

--- a/templates/profile-box.html
+++ b/templates/profile-box.html
@@ -1,9 +1,9 @@
 % from 'templates/avatar-url.html' import avatar_img with context
 % from 'templates/elsewhere.html' import platform_icon
 
-% macro profile_box_embedded_wrapper(participant, path)
+% macro profile_box_embedded_wrapper(participant, path, style='default')
 <div class="inline-box">
-    <div class="panel panel-default profile-box-embedded"
+    <div class="panel panel-{{ style }} profile-box-embedded"
          href="{{ path }}">
         <div class="panel-body">
             <a href="{{ path }}" class="avatar-inline">{{
@@ -49,19 +49,33 @@
     </div>
 % endmacro
 
-% macro profile_box_embedded_elsewhere(e)
+% macro profile_box_embedded_elsewhere(
+    e, has_tip=None, show_button=False, show_numbers=True, show_platform_icon=True
+)
+    % set tippee_is_stub = e.participant.status == 'stub'
+    % set panel_style = 'default' if tippee_is_stub else 'primary'
     % set path = e.liberapay_path
-    % call profile_box_embedded_wrapper(e.participant, path)
+    % call profile_box_embedded_wrapper(e.participant, path, style=panel_style)
         % set p = e.participant
 
         <h4><a href="{{ path }}">
-            {{ platform_icon(e.platform_data) }}
+            {{ platform_icon(e.platform_data) if show_platform_icon else '' }}
             <span>{{ e.friendly_name }}</span>
             <span class="sr-only">({{ e.platform_data.display_name }})</span>
         </a></h4>
 
         <p class="summary">{{ e.get_excerpt() or '' }}</p>
 
+        % if show_button
+        <a class="btn btn-{{ 'primary' if has_tip else 'pledge' if tippee_is_stub else 'donate' }}"
+           href="{{ path if tippee_is_stub else e.participant.path('donate') }}">{{
+            (_("Modify your pledge") if has_tip else _("Pledge"))
+            if tippee_is_stub else
+            (_("Modify your donation") if has_tip else _("Donate"))
+        }}</a>
+        % endif
+
+        % if show_numbers
         <div class="numbers">
             <dl>
                 <dt>{{ _("Pledges") }}</dt>
@@ -75,5 +89,6 @@
             </dl>
             % endif
         </div>
+        % endif
     % endcall
 % endmacro

--- a/www/on/%platform/index.spt
+++ b/www/on/%platform/index.spt
@@ -30,6 +30,13 @@ if account:
             need_reconnect = True
         else:
             friends = AccountElsewhere.get_many(platform.name, friends)
+            user_tippees = set(website.db.all("""
+                SELECT t.tippee
+                  FROM current_tips t
+                 WHERE t.tipper = %s
+                   AND t.tippee IN %s
+                   AND t.amount > 0
+            """, (user.id, set(e.participant.id for e in friends))))
 
 limited = getattr(platform, 'api_friends_limited', False)
 
@@ -37,6 +44,7 @@ limited = getattr(platform, 'api_friends_limited', False)
 % extends "templates/base.html"
 
 % from 'templates/auth.html' import auth_button with context
+% from 'templates/profile-box.html' import profile_box_embedded_elsewhere with context
 % from "templates/your-tip.html" import tip_form with context
 
 % block subnav
@@ -85,29 +93,19 @@ limited = getattr(platform, 'api_friends_limited', False)
 % else
 <p>{{ ngettext("You have {n} friend on {0}.", "You have {n} friends on {0}.",
                nfriends, platform.display_name) if nfriends >= 0 }}</p>
-<table class="table table-condensed valign-middle">
-    <tr>
-        <th>{{ _('Name') }}</th>
-        <th>{{ _('On Liberapay?') }}</th>
-        <th>{{ _('Receives') }}</th>
-        <th>{{ _('Support') }}</th>
-    </tr>
-    % for friend in friends
-    % set p = friend.participant
-    % set tippee = p if p.join_time else friend
-    <tr class="{{ 'info' if p.join_time and p.accepts_tips else '' }}">
-        <td><a href="/on/{{ platform.name }}/{{ friend.liberapay_slug }}/">{{ friend.friendly_name }}</a></td>
-        <td>{{ _("Yes") if p.join_time else _("No") }}</td>
-        <td>{{ _('hidden') if p.hide_receiving else p.receiving and locale.format_money(p.receiving) or '0' }}</td>
-        <td>{{ tip_form(tippee=tippee, inline=True) if p.accepts_tips else
-               _("{0} doesn't accept donations", friend.friendly_name) }}</td>
-    </tr>
-    % endfor
-    % if pages_urls
-        % from 'templates/pagination.html' import pages_links with context
-        <tr><td colspan="5">{{ pages_links(pages_urls) }}</td></tr>
-    % endif
-</table>
+<div class="inline-boxes">
+% for friend in friends
+    {{ profile_box_embedded_elsewhere(
+        friend, has_tip=(friend.participant.id in user_tippees),
+        show_button=True, show_numbers=False, show_platform_icon=False,
+    ) }}
+% endfor
+</div>
+% if pages_urls
+    % from 'templates/pagination.html' import pages_links with context
+    {{ pages_links(pages_urls) }}
+% endif
+
 {{ limitation_note() }}
 % endif
 


### PR DESCRIPTION
This branch transitions the social explorer from a nonresponsive table to profile boxes (similar to the ones in the explore pages).

Screenshots before and after, at a mobile-like size:

![liberapay-2019-08-05-social-explorer-xs old](https://user-images.githubusercontent.com/1581590/62480372-f0e1cb00-b7af-11e9-87a0-0e16353e6458.png)

---

![liberapay-2019-08-05-social-explorer-xs new](https://user-images.githubusercontent.com/1581590/62480384-f50de880-b7af-11e9-9ede-56a7471bf699.png)
