### PR TITLE
Fix donation reminders

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -1133,7 +1133,7 @@ class Payday(object):
         for p, donations in participants:
             for tip in donations:
                 tip['periodic_amount'] = Money(**tip['periodic_amount'])
-            p.notify('donate_reminder', donations=donations)
+            p.notify('donate_reminder', donations=donations, email_unverified_address=True)
             n += 1
         log("Sent %i donate_reminder notifications." % n)
 

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -1090,17 +1090,17 @@ class Payday(object):
                        SELECT t.periodic_amount, t.tippee_username
                    ) a))
               FROM (
-                     SELECT t.*, p2.username AS tippee_username
+                     SELECT t.*, tippee_p.username AS tippee_username
                        FROM current_tips t
-                       JOIN participants p2 ON p2.id = t.tippee
+                       JOIN participants tippee_p ON tippee_p.id = t.tippee
                       WHERE t.renewal_mode > 0
                         AND ( t.paid_in_advance IS NULL OR
                               t.paid_in_advance < t.amount
                             )
-                        AND p2.status = 'active'
-                        AND p2.is_suspended IS NOT true
-                        AND p2.payment_providers > 0
-                        AND (p2.goal IS NULL OR p2.goal >= 0)
+                        AND tippee_p.status = 'active'
+                        AND tippee_p.is_suspended IS NOT true
+                        AND tippee_p.payment_providers > 0
+                        AND ( tippee_p.goal IS NULL OR tippee_p.goal >= 0 )
                    ) t
              WHERE EXISTS (
                      SELECT 1
@@ -1132,6 +1132,8 @@ class Payday(object):
           ORDER BY t.tipper
         """)
         for p, donations in participants:
+            if p.status != 'active' or p.is_suspended:
+                continue
             for tip in donations:
                 tip['periodic_amount'] = Money(**tip['periodic_amount'])
             p.notify('donate_reminder', donations=donations, email_unverified_address=True)

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -1109,15 +1109,16 @@ class Payday(object):
                         AND COALESCE(tr.team, tr.tippee) = t.tippee
                         AND tr.context IN ('tip', 'take')
                         AND tr.status = 'succeeded'
-                        AND tr.timestamp >= (current_timestamp - interval '9 weeks')
+                        AND tr.timestamp >= (current_date - interval '26 weeks')
                    )
-               AND (
-                     SELECT count(*)
+               AND NOT EXISTS (
+                     SELECT 1
                        FROM notifications n
                       WHERE n.participant = t.tipper
                         AND n.event = 'donate_reminder'
+                        AND n.ts >= (current_date - interval '3 weeks')
                         AND n.is_new
-                   ) < 2
+                   )
                AND NOT EXISTS (
                      SELECT 1
                        FROM payin_transfers pt
@@ -1125,7 +1126,7 @@ class Payday(object):
                         AND COALESCE(pt.team, pt.recipient) = t.tippee
                         AND pt.context IN ('personal-donation', 'team-donation')
                         AND pt.status = 'pending'
-                        AND pt.ctime >= (current_timestamp - interval '9 weeks')
+                        AND pt.ctime >= (current_date - interval '3 weeks')
                    )
           GROUP BY t.tipper
           ORDER BY t.tipper

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1265,13 +1265,17 @@ class Participant(Model, MixinTeam):
     # Notifications
     # =============
 
-    def notify(self, event, force_email=False, email=True, web=True, idem_key=None, **context):
+    def notify(self, event, force_email=False, email=True, web=True, idem_key=None,
+               email_unverified_address=False, **context):
         if email and not force_email:
             bit = EVENTS.get(event.split('~', 1)[0]).bit
             email = self.email_notif_bits & bit > 0
         p_id = self.id
-        context = serialize(context)
+        # If email_unverified_address is on, allow sending to an unverified email address.
+        if email_unverified_address and not self.email:
+            context['email'] = self.get_email_address()
         # Check that this notification isn't a duplicate
+        context = serialize(context)
         n = self.db.one("""
             SELECT count(*)
               FROM notifications


### PR DESCRIPTION
This branch fixes #1433. Considering that for a donation reminder to be sent the user must have spent money, the potential for abuse seems sufficiently low for us to bend our rules and send the email to an unconfirmed address.