### PR TITLE
Distribute team donations to multiple members

### DIFF
--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -921,7 +921,7 @@ class TestPaydayForTeams(FakeTransfersHarness):
         team.set_take_for(bob, EUR('1.00'), team)
 
         stripe_account_alice = self.add_payment_account(alice, 'stripe', default_currency='EUR')
-        self.add_payment_account(bob, 'stripe', default_currency='USD')
+        self.add_payment_account(bob, 'stripe', country='US', default_currency='USD')
 
         carl = self.make_participant('carl')
         carl.set_tip_to(team, EUR('10'))

--- a/www/%username/giving/pay/paypal/%payin_id.spt
+++ b/www/%username/giving/pay/paypal/%payin_id.spt
@@ -7,7 +7,7 @@ from math import floor
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.models.participant import Participant
 from liberapay.payin.common import (
-    prepare_payin, prepare_payin_transfer, resolve_amounts, resolve_destination,
+    prepare_donation, prepare_payin, prepare_payin_transfer, resolve_amounts,
     abort_payin,
 )
 from liberapay.payin.paypal import (
@@ -66,23 +66,11 @@ if request.method == 'POST':
     )
     route = ExchangeRoute.upsert_generic_route(payer, 'paypal')
     payin = prepare_payin(website.db, payer, payin_amount, route)
+    payer_country = route.country or request.country
     for tip in tips:
-        beneficiary = tip.tippee_p
-        tr_amount = transfer_amounts[tip.id]
-        destination = resolve_destination(
-            website.db, beneficiary, 'paypal', payer, request.country, tr_amount
-        )
-        if beneficiary.kind == 'group':
-            context = 'team-donation'
-            team = beneficiary.id
-            recipient = Participant.from_id(destination.participant)
-        else:
-            context = 'personal-donation'
-            team = None
-            recipient = beneficiary
-        prepare_payin_transfer(
-            website.db, payin, recipient, destination, context,
-            tr_amount, tip.periodic_amount, tip.period, team=team
+        prepare_donation(
+            website.db, payin, tip, tip.tippee_p, 'paypal', payer, payer_country,
+            transfer_amounts[tip.id]
         )
 
     msg = _("Request in progress, please wait…")

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -11,7 +11,7 @@ from liberapay.exceptions import NextAction
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.models.participant import Participant
 from liberapay.payin.common import (
-    prepare_payin, prepare_payin_transfer, resolve_amounts, resolve_destination
+    prepare_donation, prepare_payin, prepare_payin_transfer, resolve_amounts,
 )
 from liberapay.payin.stripe import (
     charge_and_transfer, destination_charge, get_partial_iban, Money_to_int,
@@ -174,23 +174,11 @@ if request.method == 'POST':
         payin_amount, {tip.id: tip.amount for tip in tips}
     )
     payin = prepare_payin(website.db, payer, payin_amount, route)
+    payer_country = route.country or request.country
     for tip in tips:
-        beneficiary = tip.tippee_p
-        tr_amount = transfer_amounts[tip.id]
-        destination = resolve_destination(
-            website.db, beneficiary, 'stripe', payer, request.country, tr_amount
-        )
-        if beneficiary.kind == 'group':
-            context = 'team-donation'
-            team = beneficiary.id
-            recipient = Participant.from_id(destination.participant)
-        else:
-            context = 'personal-donation'
-            team = None
-            recipient = beneficiary
-        prepare_payin_transfer(
-            website.db, payin, recipient, destination, context,
-            tr_amount, tip.periodic_amount, tip.period, team=team
+        prepare_donation(
+            website.db, payin, tip, tip.tippee_p, 'stripe', payer, payer_country,
+            transfer_amounts[tip.id]
         )
 
     msg = _("Request in progress, please wait…")


### PR DESCRIPTION
This branch implements splitting a team donation into multiple transfers, when this is supported by the payment processor (so, for now, only for Stripe payments to creators in Europe).