### PR TITLE
Use a new `Object` type to represent donations in Python code

### DIFF
--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -38,7 +38,7 @@ from liberapay.models.participant import Participant, clean_up_closed_accounts
 from liberapay.models.repository import refetch_repos
 from liberapay.security import authentication, csrf, set_default_security_headers
 from liberapay.utils import (
-    b64decode_s, b64encode_s, erase_cookie, http_caching, set_cookie,
+    Object, b64decode_s, b64encode_s, erase_cookie, http_caching, set_cookie,
 )
 from liberapay.utils.emails import clean_up_emails, handle_email_bounces
 from liberapay.utils.state_chain import (
@@ -60,6 +60,7 @@ application = website  # for stupid WSGI implementations
 
 json.register_encoder(Money, lambda m: {'amount': str(m.amount), 'currency': m.currency})
 json.register_encoder(MoneyBasket, lambda b: list(b))
+json.register_encoder(Object, lambda o: o.__dict__)
 
 website.renderer_default = 'unspecified'  # require explicit renderer, to avoid escaping bugs
 

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -155,7 +155,7 @@ def adjust_payin_transfers(db, payin, net_amount):
                 try:
                     team_donations = resolve_team_donation(
                         cursor, team, provider, payer, payer_country,
-                        prorated_amount, tip['amount']
+                        prorated_amount, tip.amount
                     )
                 except (MissingPaymentAccount, NoSelfTipping):
                     team_amounts = resolve_amounts(prorated_amount, {
@@ -177,7 +177,7 @@ def adjust_payin_transfers(db, payin, net_amount):
                     for d in team_donations.values():
                         prepare_payin_transfer(
                             db, payin, d.recipient, d.destination, 'team-donation',
-                            d.amount, tip['periodic_amount'], tip['period'],
+                            d.amount, tip.periodic_amount, tip.period,
                             team=team.id
                         )
             else:

--- a/liberapay/security/authentication.py
+++ b/liberapay/security/authentication.py
@@ -28,13 +28,13 @@ class _ANON(object):
     session = None
     id = None
     __bool__ = __nonzero__ = lambda *a: False
-    get_tip_to = staticmethod(Participant._zero_tip_dict)
+    get_tip_to = staticmethod(Participant._zero_tip)
     __repr__ = lambda self: '<ANON>'
 
     def get_currencies_for(self, tippee, tip):
         if isinstance(tippee, AccountElsewhere):
             tippee = tippee.participant
-        return tip['amount'].currency, tippee.accepted_currencies_set
+        return tip.amount.currency, tippee.accepted_currencies_set
 
 
 ANON = _ANON()

--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -9,6 +9,7 @@ from operator import getitem
 import os
 import re
 import socket
+from types import SimpleNamespace
 from urllib.parse import quote as urlquote
 
 from pando import Response, json
@@ -28,6 +29,29 @@ from liberapay.utils import cbor
 
 
 BEGINNING_OF_EPOCH = to_rfc822(datetime(1970, 1, 1)).encode('ascii')
+
+
+class Object(SimpleNamespace):
+    """
+    A namespace that supports both attribute-style and dict-style lookups and
+    assignments. This is similar to a JavaScript object, hence the name.
+    """
+
+    def __init__(self, *d, **kw):
+        self.__dict__.update(*d, **kw)
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def _asdict(self):
+        # For compatibility with namedtuple classes
+        return self.__dict__.copy()
 
 
 def get_participant(state, restrict=True, redirect_stub=True, allow_member=False,

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -96,7 +96,7 @@
                 <div class="flex-col expand-xs text-center-xs">
                     % set tip = user.get_tip_to(participant)
                     % set donate_path = participant.path('donate')
-                    % if tip['renewal_mode'] > 0
+                    % if tip.renewal_mode > 0
                         <a class="btn btn-donating btn-lg" href="{{ donate_path }}">{{
                             _("Donating ({amount})", amount=tip.amount)
                         }}</a>

--- a/tests/py/test_close.py
+++ b/tests/py/test_close.py
@@ -27,7 +27,7 @@ class TestClosing(FakeTransfersHarness):
 
         alice.close('downstream')
 
-        assert carl.get_tip_to(alice)['amount'] == EUR(2)
+        assert carl.get_tip_to(alice).amount == EUR(2)
         assert alice.balance == 0
         assert len(team.get_current_takes()) == 1
 

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -19,6 +19,7 @@ from liberapay.exceptions import (
 from liberapay.i18n.currencies import Money
 from liberapay.models.participant import NeedConfirmation, Participant
 from liberapay.testing import EUR, USD, Harness
+from liberapay.utils import Object
 
 
 class TestNeedConfirmation(Harness):
@@ -183,7 +184,7 @@ class TestStub(Harness):
     def test_getting_tips_not_made(self):
         expected = EUR('0.00')
         user2 = self.make_participant('user2')
-        actual = self.stub.get_tip_to(user2)['amount']
+        actual = self.stub.get_tip_to(user2).amount
         assert actual == expected
 
 
@@ -257,15 +258,15 @@ class Tests(Harness):
         alice = self.make_participant('alice')
         bob = self.make_stub()
         alice.set_tip_to(bob, EUR('1.00'))
-        actual = alice.get_tip_to(bob)['amount']
+        actual = alice.get_tip_to(bob).amount
         assert actual == EUR('1.00')
 
     def test_stt_works_for_pledges(self):
         alice = self.make_participant('alice')
         bob = self.make_stub()
         t = alice.set_tip_to(bob, EUR('10.00'))
-        assert isinstance(t, dict)
-        assert isinstance(t['amount'], Money)
+        assert type(t) is Object
+        assert isinstance(t.amount, Money)
         assert t['amount'] == EUR(10)
         assert t['is_funded'] is False
         assert t['is_pledge'] is True


### PR DESCRIPTION
Both `tip['amount']` and `tip.amount` will now be valid in all parts of Liberapay's code, thus reducing friction when writing code.