### PR TITLE
Update the list of countries supported by Stripe

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -353,7 +353,8 @@ PAYOUT_COUNTRIES = {
     """.split()),  # https://www.paypal.com/us/webapps/mpp/country-worldwide
 
     'stripe': set("""
-        AT AU BE CA CH DE DK ES FI FR GB HK IE IT JP LU NL NO NZ PT SE SG US
+        AT AU BE CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MY NL NO NZ
+        PL PT SE SG SI SK US
         PR
     """.split()),  # https://stripe.com/global
 }


### PR DESCRIPTION
The new countries are Estonia, Greece, Latvia, Lithuania, Malaysia, Poland, Slovakia and Slovenia.

The official announcement from Stripe mistakenly lists Portugal instead of Malaysia: [Stripe launches in eight more European countries](https://stripe.com/blog/stripe-expands-in-europe).