### PR TITLE
Fix the `get_tips_awaiting_renewal` method

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2556,7 +2556,6 @@ class Participant(Model, MixinTeam):
                        AND t.amount <> 0
                        AND p.payment_providers > 0
                        AND p.is_suspended IS NOT TRUE
-                       AND ( p.goal IS NULL OR p.goal >= 0 )
                   ORDER BY t.member <> %s DESC
                 """, (tippee_p.id, self.id))
                 if not members:


### PR DESCRIPTION
The exclusion of teams with a single member who doesn't accept donations personally was causing confusion, and it wasn't coherent with how this case is handled elsewhere in the code.