### PR TITLE
Add Mexico to the list of countries supported by Stripe

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -351,8 +351,8 @@ PAYOUT_COUNTRIES = {
     """.split()),  # https://www.paypal.com/us/webapps/mpp/country-worldwide
 
     'stripe': set("""
-        AT AU BE CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MY NL NO NZ
-        PL PT SE SG SI SK US
+        AT AU BE CA CH DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MX MY NL NO
+        NZ PL PT SE SG SI SK US
         PR
     """.split()),  # https://stripe.com/global
 }


### PR DESCRIPTION
[Stripe launches in Mexico](https://stripe.com/blog/stripe-launches-in-mexico)