### PR TITLE
Handle transient email delivery errors better

### DIFF
--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -8,7 +8,16 @@ import os
 
 from environment import Environment, is_yesish
 from jinja2 import StrictUndefined
-from pando.website import Website
+from pando.website import Website as _Website
+
+
+class Website(_Website):
+
+    def warning(self, msg, state={}):
+        try:
+            raise Warning(msg)
+        except Warning as e:
+            self.tell_sentry(state, e)
 
 
 env = Environment(

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+UPDATE email_blacklist
+   SET ignore_after = ts + interval '5 days'
+ WHERE ignore_after IS NULL
+   AND ses_data->'bounce'->>'bounceType' = 'Transient';


### PR DESCRIPTION
Errors reported as being "transient" will only result in the address being blacklisted for 5 days. Unless multiple such errors happen within 3 months, then the blacklisting is extended to 6 months.