### PR TITLE
pt.po: fix gender of "forma de pagamento"

### DIFF
--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -1416,7 +1416,7 @@ msgstr "Nova senha"
 
 #, python-brace-format
 msgid "{username} hasn't configured any payment method yet, so your donation cannot actually be processed right now. We will notify you when payment becomes possible."
-msgstr "Nenhuma forma de pagamento configurado para {username} ainda, logo, o processamento da doação não é viável no momento. Nós notificaremos quando a doação for possível."
+msgstr "Nenhuma forma de pagamento configurada para {username} ainda, logo, o processamento da doação não é viável no momento. Nós notificaremos quando a doação for possível."
 
 #, python-brace-format
 msgid "Donations to {username} can be paid using a credit or debit card (Visa, MasterCard, American Express), or by direct debit of a Euro bank account (for donations in Euro only)."
@@ -2338,7 +2338,7 @@ msgid "The payment processor {name} returned an error: “{error_message}”."
 msgstr "O processador de pagamentos {name} retornou um erro: \"{error_message}\"."
 
 msgid "The payment instrument is invalid, please select or add another one."
-msgstr "O forma de pagamento é inválido. Selecione ou adicione outro."
+msgstr "A forma de pagamento é inválida. Selecione ou adicione outra."
 
 msgid "More information is required in order to process this payment."
 msgstr "O pagamento requer mais dados para ser processado."
@@ -2976,7 +2976,7 @@ msgstr[0] "Destacou {n} repositório em {platform}."
 msgstr[1] "Destacou {n} repositórios em {platform}."
 
 msgid "The payment instrument has been successfully added."
-msgstr "O forma de pagamento foi adicionado com sucesso."
+msgstr "A forma de pagamento foi adicionada com sucesso."
 
 msgid "Add a payment instrument"
 msgstr "Adicionar uma forma de pagamento"


### PR DESCRIPTION
I am aware that these files are editable via Weblate, but there seems to be an error with the Portuguese translation at the moment; in the repo there's only a single `pt.po`, but in Weblate there's [pt_PT](https://hosted.weblate.org/languages/pt_PT/liberapay/) and [pt_BR](https://hosted.weblate.org/languages/pt_BR/liberapay/), both of which currently show an error saying:

> The VCS repository has many changes compared to the upstream. Please merge the changes manually or set up push to automate this.