### PR TITLE
Fix scheduling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
  - tar -xaf ../../liberapay-liberapay.com.tar.gz --strip-components=1
 install:
  - if [ "${TRAVIS_BRANCH}" = "master" -a "${TRAVIS_PULL_REQUEST}" = "false" ]; then rm -rf .tox; fi
- - pip install tox
+ - pip install tox "six>=1.14.0"
 before_script:
  - psql -U postgres -c 'CREATE DATABASE liberapay_tests;'
  - DATABASE_URL=liberapay_tests ./recreate-schema.sh test

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2580,6 +2580,9 @@ class Participant(Model, MixinTeam):
                          , pt.ctime DESC
                 """, dict(payer=self.id, tippees=tippees)))
                 for tip in list(renewable_tips):
+                    if tip.renewal_mode == 2 and tip.tippee_p.payment_providers & 1 == 0:
+                        # Automatic payments are only possible through Stripe.
+                        tip.renewal_mode = 1
                     if tip.renewal_mode == 2:
                         last_payment_amount = last_payments.get(tip.tippee)
                         if last_payment_amount:

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -727,3 +727,14 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(scheduled_payins) == 2
         assert scheduled_payins[0].amount == EUR('49.50')
         assert scheduled_payins[1].amount == EUR('24.00')
+
+    def test_schedule_renewals_marks_paypal_payment_as_manual(self):
+        alice = self.make_participant('alice', email='alice@liberapay.com')
+        bob = self.make_participant('bob')
+        alice.set_tip_to(bob, EUR('5.99'), renewal_mode=2)
+        alice_card = self.upsert_route(alice, 'paypal')
+        self.make_payin_and_transfer(alice_card, bob, EUR('60.00'))
+        scheduled_payins = alice.schedule_renewals()
+        assert len(scheduled_payins) == 1
+        assert scheduled_payins[0].amount is None
+        assert scheduled_payins[0].automatic is False


### PR DESCRIPTION
Scheduled PayPal payments shouldn't be tagged as "automatic" since we're not able to execute them automatically.