### PR TITLE
Fix the totals in wallet ledgers

### DIFF
--- a/tests/py/test_history.py
+++ b/tests/py/test_history.py
@@ -91,8 +91,8 @@ class TestHistory(FakeTransfersHarness):
 
         totals, start, end, events = get_wallet_ledger(self.db, bob, now.year)
         assert totals['kind'] == 'totals'
-        assert not totals['regular_donations']['sent']
-        assert totals['regular_donations']['received'] == EUR(12)
+        assert not totals['donations']['sent']
+        assert totals['donations']['received'] == EUR(12)
         assert len(events) == 8
         assert events[0]['kind'] == 'day-end'
         assert events[0]['payday_number'] == 3
@@ -103,7 +103,7 @@ class TestHistory(FakeTransfersHarness):
         alice = Participant.from_id(alice.id)
         assert alice.balance == 4990
         totals, start, end, events = get_wallet_ledger(self.db, alice, now.year)
-        assert totals['regular_donations']['sent'] == EUR(10)
+        assert totals['donations']['sent'] == EUR(10)
         assert len(events) == 10
 
         carl = Participant.from_id(carl.id)

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -126,20 +126,20 @@ if user.is_admin:
 
 <div class="row col-lg-10">
 % if totals
-    % set regular_donations = totals['regular_donations']
+    % set donations = totals['donations']
     % set reimbursements = totals['reimbursements']
-    % set total_sent = regular_donations['sent'] + reimbursements['sent']
+    % set total_sent = donations['sent'] + reimbursements['sent']
     {{ _("Total money sent: {0}", total_sent) }}<br>
     % if total_sent
     <ul>
-    % if regular_donations['sent']
-    % for money_amount in regular_donations['sent']
+    % if donations['sent']
+    % for money_amount in donations['sent']
     % if money_amount
     <li>
     {{ ngettext(
-        "{money_amount} in recurrent donations to {n} person",
-        "{money_amount} in recurrent donations to {n} people",
-        regular_donations['ntippees'][money_amount.currency],
+        "{money_amount} in donations to {n} person",
+        "{money_amount} in donations to {n} people",
+        donations['ntippees'][money_amount.currency],
         money_amount=money_amount
     ) }}
         (<a href="{{ participant.path('wallet/export.csv') }}?year={{ year }}&amp;key=given&amp;mode=aggregate">{{
@@ -168,17 +168,17 @@ if user.is_admin:
     % endif
     </ul>
     % endif
-    % set total_received = regular_donations['received'] + reimbursements['received']
+    % set total_received = donations['received'] + reimbursements['received']
     {{ _("Total money received: {0}", total_received) }}
     % if total_received
     <ul>
-    % if regular_donations['received']
-    % for money_amount in regular_donations['received']
+    % if donations['received']
+    % for money_amount in donations['received']
     % if money_amount
     <li>{{ ngettext(
-        "{money_amount} in recurrent donations from {n} donor",
-        "{money_amount} in recurrent donations from {n} donors",
-        regular_donations['npatrons'][money_amount.currency],
+        "{money_amount} in donations from {n} donor",
+        "{money_amount} in donations from {n} donors",
+        donations['npatrons'][money_amount.currency],
         money_amount=money_amount
     ) }}</li>
     % endif

--- a/www/%username/wallet/statement.spt
+++ b/www/%username/wallet/statement.spt
@@ -76,19 +76,19 @@ output.body = render(globals(), allow_partial_i18n=False)
     <br>
 
     % if totals
-        % set regular_donations = totals['regular_donations']
+        % set donations = totals['donations']
         % set reimbursements = totals['reimbursements']
-        % set total_sent = regular_donations['sent'] + reimbursements['sent']
+        % set total_sent = donations['sent'] + reimbursements['sent']
         {{ _("Total money sent: {0}", total_sent) }}<br>
         % if total_sent
         <ul>
-        % if regular_donations['sent']
-        % for money_amount in regular_donations['sent']
+        % if donations['sent']
+        % for money_amount in donations['sent']
         % if money_amount
         <li>{{ ngettext(
-            "{money_amount} in recurrent donations to {n} person",
-            "{money_amount} in recurrent donations to {n} people",
-            regular_donations['ntippees'][money_amount.currency],
+            "{money_amount} in donations to {n} person",
+            "{money_amount} in donations to {n} people",
+            donations['ntippees'][money_amount.currency],
             money_amount=money_amount
         ) }}</li>
         % endif
@@ -108,17 +108,17 @@ output.body = render(globals(), allow_partial_i18n=False)
         % endif
         </ul>
         % endif
-        % set total_received = regular_donations['received'] + reimbursements['received']
+        % set total_received = donations['received'] + reimbursements['received']
         {{ _("Total money received: {0}", total_received) }}
         % if total_received
         <ul>
-        % if regular_donations['received']
-        % for money_amount in regular_donations['received']
+        % if donations['received']
+        % for money_amount in donations['received']
         % if money_amount
         <li>{{ ngettext(
-            "{money_amount} in recurrent donations from {n} donor",
-            "{money_amount} in recurrent donations from {n} donors",
-            regular_donations['npatrons'][money_amount.currency],
+            "{money_amount} in donations from {n} donor",
+            "{money_amount} in donations from {n} donors",
+            donations['npatrons'][money_amount.currency],
             money_amount=money_amount
         ) }}</li>
         % endif


### PR DESCRIPTION
It no longer makes any sense to only include just-in-time recurrent donations in the income totals, we need to count all the donation types (one-offs, in advance, in arrears).