### PR TITLE
CSRF tokens on demand

### DIFF
--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -184,6 +184,7 @@ algorithm.functions = [
     canonize,
     algorithm['extract_accept_header'],
     set_default_security_headers,
+    csrf.add_csrf_token_to_state,
     set_up_i18n,
     insert_constants,
     authentication.start_user_as_anon,

--- a/liberapay/security/csrf.py
+++ b/liberapay/security/csrf.py
@@ -21,13 +21,58 @@ CSRF_TOKEN = 'csrf_token'
 CSRF_TIMEOUT = timedelta(days=7)
 
 
+class CSRF_Token:
+    """A lazy anti-CSRF token generator.
+    """
+
+    __slots__ = ('state', '_token')
+
+    def __init__(self, state):
+        self.state = state
+        self._token = None
+
+    def __bool__(self):
+        return bool(self._token)
+
+    def __eq__(self, other):
+        return self._token == other
+
+    def __ne__(self, other):
+        return self._token != other
+
+    def __repr__(self):
+        return f"<CSRF_Token _token={self._token!r}>"
+
+    def __str__(self):
+        return self.token
+
+    @property
+    def token(self):
+        if not self._token:
+            try:
+                cookie_token = self.state['request'].headers.cookie[CSRF_TOKEN].value
+            except KeyError:
+                cookie_token = ''
+            if len(cookie_token) == TOKEN_LENGTH:
+                self._token = cookie_token
+            else:
+                self._token = get_random_string(TOKEN_LENGTH)
+        return self._token
+
+
+def add_csrf_token_to_state(state):
+    state['csrf_token'] = CSRF_Token(state)
+
+
 def reject_forgeries(state, request, response, website, _):
     request_path = request.path.raw
     off = (
-        # Don't generate CSRF tokens for assets, to avoid busting the cache.
-        request_path.startswith('/assets/') or
-        # Don't generate or check CSRF tokens for callbacks, it's not necessary.
-        request_path.startswith('/callbacks/')
+        # Assume that methods defined as 'safe' by RFC7231 don't need protection.
+        request.method in SAFE_METHODS or
+        # Don't check CSRF tokens for callbacks, it's not necessary.
+        request_path.startswith('/callbacks/') or
+        # CSRF protection is turned off for this request.
+        request_path == '/migrate' and not request.qs
     )
     if off:
         return
@@ -36,20 +81,6 @@ def reject_forgeries(state, request, response, website, _):
     try:
         cookie_token = request.headers.cookie[CSRF_TOKEN].value
     except KeyError:
-        cookie_token = None
-
-    if cookie_token and len(cookie_token) == TOKEN_LENGTH:
-        state['csrf_token'] = cookie_token
-    else:
-        state['csrf_token'] = get_random_string(TOKEN_LENGTH)
-
-    if request.method in SAFE_METHODS:
-        # Assume that methods defined as 'safe' by RFC7231 don't need protection.
-        return
-    elif request_path == '/migrate' and not request.qs:
-        # CSRF protection is turned off for this request.
-        return
-    elif not cookie_token:
         raise response.error(403, _(
             "A security check has failed. Please make sure your browser is "
             "configured to allow cookies for {domain}, then try again.",
@@ -72,7 +103,7 @@ def reject_forgeries(state, request, response, website, _):
         if not second_token:
             raise response.error(403, "The X-CSRF-TOKEN header is missing.")
 
-    if not constant_time_compare(second_token, state['csrf_token']):
+    if not constant_time_compare(second_token, cookie_token):
         raise response.error(403, "The anti-CSRF tokens don't match.")
 
 
@@ -82,4 +113,4 @@ def add_token_to_response(response, csrf_token=None):
     if csrf_token:
         # Don't set httponly so that we can POST using XHR.
         # https://github.com/gratipay/gratipay.com/issues/3030
-        response.set_cookie(CSRF_TOKEN, csrf_token, expires=CSRF_TIMEOUT, httponly=False)
+        response.set_cookie(CSRF_TOKEN, str(csrf_token), expires=CSRF_TIMEOUT, httponly=False)

--- a/www/migrate.spt
+++ b/www/migrate.spt
@@ -45,11 +45,11 @@ elif step == '2':
             r = requests.post(
                 gratipay_migrate_url % (body['username'],),
                 data={
-                    'csrf_token': csrf_token,
+                    'csrf_token': 'ThisIsATokenThatIsThirtyTwoBytes',
                     'secret': website.env.secret_for_gratipay,
                 },
                 cookies={
-                    'csrf_token': csrf_token,
+                    'csrf_token': 'ThisIsATokenThatIsThirtyTwoBytes',
                     'session': body['session_token'],
                 }
             )


### PR DESCRIPTION
This commit optimizes the anti-CSRF mechanism to only extract/generate/return a token on demand, i.e. when there's a form in the page being rendered.

This change is probably a good step towards fixing #1131.

Theoretically this change also makes it easier to cache some dynamic pages like the homepage (#124), however in practice it still seems to be difficult.