### PR TITLE
Improve the Giving page

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,7 @@
+BEGIN;
+    ALTER TABLE tips ADD COLUMN hidden boolean;
+    CREATE OR REPLACE VIEW current_tips AS
+        SELECT DISTINCT ON (tipper, tippee) *
+          FROM tips
+      ORDER BY tipper, tippee, mtime DESC;
+END;

--- a/tests/py/test_participant.py
+++ b/tests/py/test_participant.py
@@ -82,11 +82,17 @@ class TestTakeOver(Harness):
         self.make_payin_and_transfer(alice_card, bob, EUR('10'))
         alice.set_tip_to(carl.participant, EUR('5.00'))
         bob.take_over(carl, have_confirmation=True)
-        tips = self.db.all("select * from tips where renewal_mode > 0 order by id asc")
-        assert len(tips) == 3
-        assert tips[-1].amount == 5
-        assert tips[-1].paid_in_advance == EUR('10')
-        assert tips[-1].is_funded is True
+        tips = self.db.all("select * from tips order by id asc")
+        assert len(tips) == 4
+        assert tips[2].tippee == bob.id
+        assert tips[2].amount == EUR('5.00')
+        assert tips[2].paid_in_advance == EUR('10')
+        assert tips[2].is_funded is True
+        assert tips[3].tippee == carl.participant.id
+        assert tips[3].amount == EUR('5.00')
+        assert tips[3].renewal_mode == 0
+        assert tips[3].paid_in_advance is None
+        assert tips[3].hidden is True
         self.db.self_check()
 
     def test_idempotent(self):

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -6,7 +6,7 @@ from pando.utils import utcnow
 
 from liberapay.billing.payday import compute_next_payday_date
 from liberapay.models.participant import Participant
-from liberapay.utils import get_participant, group_by
+from liberapay.utils import form_post_success, get_participant, group_by
 
 
 RENEWAL_MODE_START_DATE = date(2020, 2, 7)
@@ -44,9 +44,12 @@ if request.method == 'POST':
             participant.add_event(website.db, 'auto_renewal_hint', 'rejected')
         else:
             raise response.invalid_input(auto_renewal, 'auto_renewal', 'body')
+    elif 'hide' in request.body:
+        tippee_id = request.body.get_int('hide')
+        participant.hide_tip_to(tippee_id)
     else:
         raise response.error(400)
-    response.redirect(request.line.uri)
+    form_post_success(state)
 
 has_pending_transfer = set(website.db.all("""
     SELECT DISTINCT coalesce(pt.team, pt.recipient) AS tippee
@@ -63,7 +66,6 @@ title = participant.username
 subhead = _("Giving")
 cancelled_tips = [x for x in tips if x.renewal_mode <= 0 and x.mtime >= recently]
 cancelled_pledges = [x for x in pledges if x.renewal_mode <= 0 and x.mtime >= recently]
-ncancelled = len(cancelled_tips) + len(cancelled_pledges)
 
 # don't filter until after cancelled are looked at
 tips = [t for t in tips if t.renewal_mode > 0]
@@ -422,9 +424,10 @@ next_payday = compute_next_payday_date()
     % endfor
 % endif
 
-% if ncancelled
-    <h3>{{ _("Recently Cancelled") }} ({{ ncancelled }})
-        <small>{{ _("within the last 30 days") }}</small></h3>
+% if cancelled_tips
+    <h3>{{ _("Stopped donations") }} ({{ len(cancelled_tips) }})</h3>
+    <form action="" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     % for tip in cancelled_tips
         % set tippee = tip.tippee_p
         <div class="card card-default card-xs-vanish donation">
@@ -454,6 +457,10 @@ next_payday = compute_next_payday_date()
                             <a class="btn btn-default btn-xs" href="{{ tippee.path('donate') }}">{{
                                 _("Restart")
                             }}</a>
+                            <button class="btn btn-default btn-xs" name="hide" value="{{ tip.tippee }}"
+                                    title="{{ _('Hide') }}">
+                                <span class="text-danger">{{ glyphicon('remove', _('Hide')) }}</span>
+                            </button>
                         </span>
                     </div>
                 </div>
@@ -465,6 +472,13 @@ next_payday = compute_next_payday_date()
             ) }}</p>
         </div>
     % endfor
+    </form>
+% endif
+
+% if cancelled_pledges
+    <h3>{{ _("Cancelled pledges") }} ({{ len(cancelled_pledges) }})</h3>
+    <form action="" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     % for tip in cancelled_pledges
         % set e = tip.e_account
         <div class="card card-default card-xs-vanish donation">
@@ -497,6 +511,10 @@ next_payday = compute_next_payday_date()
                             <a class="btn btn-default btn-xs" href="{{ e.liberapay_path }}">{{
                                 _("Restart")
                             }}</a>
+                            <button class="btn btn-default btn-xs" name="hide" value="{{ tip.tippee }}"
+                                    title="{{ _('Hide') }}">
+                                <span class="text-danger">{{ glyphicon('remove', _('Hide')) }}</span>
+                            </button>
                         </span>
                     </div>
                 </div>
@@ -508,6 +526,7 @@ next_payday = compute_next_payday_date()
             ) }}</p>
         </div>
     % endfor
+    </form>
 % endif
 
 % endblock

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -470,6 +470,13 @@ next_payday = compute_next_payday_date()
                 timespan_ago_1=to_age(tip.ctime),
                 timespan_ago_2=to_age(tip.mtime)
             ) }}</p>
+            % if tip.paid_in_advance and tip.paid_in_advance >= tip.amount
+                <p class="text-info">{{ glyphicon('info-sign') }} {{ _(
+                    "This stopped donation still has {money_amount} paid in advance. "
+                    "That advance will be consumed every week until it reaches zero.",
+                    money_amount=tip.paid_in_advance
+                ) }}</p>
+            % endif
         </div>
     % endfor
     </form>

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -267,6 +267,20 @@ next_payday = compute_next_payday_date()
                         timespan_ago_2=to_age(tip.mtime)
                     ) }}</p>
                 % endif
+                <p>
+                    % if tip.renewal_mode == 2
+                        % if tip.tippee_p.payment_providers == 2
+                            <span class="text-warning">{{ glyphicon('repeat') }} {{ _(
+                                "Automatic renewals are enabled for this donation, but are "
+                                "currently impossible due to payment processor limitations."
+                            ) }}</span>
+                        % else
+                            {{ glyphicon('repeat') }} {{ _("Automatic renewal") }}
+                        % endif
+                    % else
+                        {{ glyphicon('user') }} {{ _("Manual renewal") }}
+                    % endif
+                </p>
                 % if tippee.is_suspended
                     <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
                         "Inactive because the account of the recipient is blacklisted."
@@ -280,17 +294,10 @@ next_payday = compute_next_payday_date()
                         "Inactive because the recipient no longer accepts donations."
                     ) }}</p>
                 % elif tip.paid_in_advance and tip.paid_in_advance >= tip.amount
+                    % set weeks_remaning = int(tip.paid_in_advance / tip.amount)
                     <p>
                         <span class="text-success">{{ glyphicon('ok-sign') }} {{ _("Active") }}</span>
                         &nbsp;&nbsp;
-                        % if tip.renewal_mode == 2
-                            {{ glyphicon('repeat') }} {{ _("Automatic renewal") }}
-                        % else
-                            {{ glyphicon('user') }} {{ _("Manual renewal") }}
-                        % endif
-                    </p>
-                    % set weeks_remaning = int(tip.paid_in_advance / tip.amount)
-                    <p>
                         % set delta = timedelta(weeks=weeks_remaning - 1)
                         {{ _(
                             "Next payment due {in_N_weeks_months_or_years}.",

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -392,7 +392,7 @@ next_payday = compute_next_payday_date()
                                 }}</a>
                                 <button class="btn btn-default btn-xs" name="tippee" value="{{ tip.tippee }}"
                                         title="{{ _('Cancel the pledge') }}">
-                                    <span class="text-warning">{{ glyphicon('remove') }}</span>
+                                    <span class="text-warning">{{ glyphicon('remove', _('Cancel the pledge')) }}</span>
                                 </button>
                             </span>
                         </div>


### PR DESCRIPTION
This branch modifies the Giving to:

- show all stopped donations, not just the ones stopped in the last 30 days;
- allow hiding a specific donation that has been stopped;
- show more information about inactive and stopped donations;
- show a warning when a donation can't be renewed automatically.