### PR TITLE
Rate limit more requests

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -428,6 +428,8 @@ RATE_LIMITS = {
     'email.bypass_error': (2, 60*60*24*7),  # 2 per week
     'email.unblacklist.source': (5, 60*60*24*7),  # 5 per week
     'email.unblacklist.target': (3, 60*60*24*7),  # 3 per week
+    'http-query.ip-addr': (10, 10),  # 10 per 10 seconds
+    'http-query.user': (10, 10),  # 10 per 10 seconds
     'http-unsafe.ip-addr': (10, 10),  # 10 per 10 seconds
     'http-unsafe.user': (10, 10),  # 10 per 10 seconds
     'insert_identity': (7, 60*60*24*7),  # 7 per week

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -425,6 +425,7 @@ RATE_LIMITS = {
     'change_password': (7, 60*60*24*7),  # 7 per week
     'change_username': (7, 60*60*24*7),  # 7 per week
     'check_password': (25, 60*60*24*7),  # 25 per week
+    'elsewhere-lookup.ip-addr': (5, 20),  # 5 per 20 seconds
     'email.bypass_error': (2, 60*60*24*7),  # 2 per week
     'email.unblacklist.source': (5, 60*60*24*7),  # 5 per week
     'email.unblacklist.target': (3, 60*60*24*7),  # 3 per week

--- a/tests/py/test_elsewhere.py
+++ b/tests/py/test_elsewhere.py
@@ -112,6 +112,7 @@ class TestElsewhere(EmailHarness):
             get_user_info.side_effect = lambda *a: alice
             response = self.client.GET('/on/%s/alice/' % platform.name)
             assert response.code == 200
+            self.db.run("DELETE FROM rate_limiting")
 
     @mock.patch('liberapay.elsewhere._base.Platform.get_user_info')
     def test_user_page_shows_pledges(self, get_user_info):


### PR DESCRIPTION
This branch adds two new rate limits: one for HTTP requests that contain a querystring, and another for requests that trigger an elsewhere API request (for example a GitHub or Twitter user lookup).