### PR TITLE
Clarify a few things

### DIFF
--- a/emails/base.spt
+++ b/emails/base.spt
@@ -6,9 +6,9 @@
 $body
 
 <div style="color: #999; padding: 22px 0 0;">
-    <div>
-        {{ _("Something not right? Reply to this email for help.") }}
-    </div>
+    <div>{{
+        _("Something wrong? This email was sent automatically, but you can contact us by replying to it.")
+    }}</div>
     <div style="font-size: 14px; padding-top: 12px;">
         <a href="https://liberapay.com/about/me/emails/"
            style="text-decoration: underline;">{{
@@ -27,6 +27,6 @@ $body
 
 ---
 
-{{ _("Something not right? Reply to this email for help.") }}
+{{ _("Something wrong? This email was sent automatically, but you can contact us by replying to it.") }}
 
 {{ _("Change your email settings") }}: https://liberapay.com/about/me/emails/

--- a/emails/upcoming_debit.spt
+++ b/emails/upcoming_debit.spt
@@ -58,3 +58,9 @@
     link_start='<a href="%s">'|safe % participant.url('giving/'),
     link_end='</a>'|safe
 ) }}</p>
+
+<p>{{ _(
+    "A receipt will be available once the payment has been successfully processed. You can see all your payments and receipts in {link_start}your account's ledger{link_end}.",
+    link_start='<a href="%s">'|safe % participant.url('ledger/'),
+    link_end='</a>'|safe
+) }}</p>

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -245,6 +245,11 @@ title = _("Funding your donations")
         <p><a class="btn btn-primary btn-lg" href="{{ payer.path('giving/pay') }}?retry={{ payin.id }}">{{ _("Try again") }}</a></p>
     % elif status == 'pending'
         <div class="alert alert-info">{{ _("The payment has been initiated.") }}</div>
+        <p>{{ _(
+            "A receipt will be available once the payment has been successfully processed. You can see all your payments and receipts in {link_start}your account's ledger{link_end}.",
+            link_start='<a href="%s">'|safe % payer.path('ledger/'),
+            link_end='</a>'|safe
+        ) }}</p>
     % endif
 
     % if status != 'failed'

--- a/www/about/teams.spt
+++ b/www/about/teams.spt
@@ -46,14 +46,38 @@ title = _("Teams")
 
 <p>{{ _(
     "A Liberapay team coordinates donations from multiple donors to multiple "
-    "donees. Donors choose how much they want to give, donees decide how to "
-    "share the money, Liberapay computes and executes the transfers from "
-    "donors to donees."
+    "donees. The donors choose how much they want to give, the team members "
+    "specify how they want to share the money, and Liberapay attempts to "
+    "distribute the funds accordingly."
 ) }}</p>
 
 <p>{{ _(
-    "Teams are for peer-to-peer donations, they can't be used by a legal "
-    "entity to distribute donations to its members."
+    "A team account isn't meant to be used by the members of single legal entity, "
+    "it is designed for a group of independent individuals or organizations who "
+    "work together on a common project. However, it's also okay to create a team "
+    "account for a project that only has one contributor, as this allows marking "
+    "a donation as being intended to support that project specifically rather "
+    "than the person behind it."
+) }}</p>
+
+<p>{{ _(
+    "A team account {bold}does not store money{end_bold} for later use. Every "
+    "donation is distributed immediately, either to multiple members if "
+    "possible, or to a single member when splitting the money isn't supported "
+    "by the payment processor. Because of these payment processing limitations, "
+    "the amounts received by the members can be temporarily unbalanced, "
+    "especially if the team has fewer patrons than members.",
+    bold='<strong>'|safe, end_bold='</strong>'|safe,
+) }}</p>
+
+<p>{{ _(
+    "If Liberapay team accounts don't fit your needs, you may want to use the "
+    "{link_start}Open Collective{link_end} platform instead, which allows a team "
+    "to be “hosted” by a registered nonprofit. This “fiscal host” is the legal "
+    "owner of the team's funds, oversees how they're used, and takes a 5% fee. "
+    "(We're planning to implement a similar system in Liberapay, but we don't "
+    "know when it will be done.)",
+    link_start='<a href="https://opencollective.com/">'|safe, link_end='</a>'|safe,
 ) }}</p>
 
 <h3>{{ _("Creating a team") }}</h3>


### PR DESCRIPTION
This branch:

- modifies the [/about/teams](https://liberapay.com/about/teams) page to warn people of the current limitations of team accounts
- modifies the base email template to clarify that emails are generated automatically
- adds a paragraph about receipts at the end of the `upcoming_debit` notifications
- adds the same paragraph in the final payment page