### PR TITLE
:lock: Corrects shields URLs to utilize encryption

### DIFF
--- a/www/%username/widgets/index.html.spt
+++ b/www/%username/widgets/index.html.spt
@@ -75,20 +75,20 @@ response.headers[b'Content-Security-Policy'] = csp
 
     <p>{{ _("Use these code snippets to add a badge to your website or README:") }}</p>
 
-    <pre>&lt;img src="http://img.shields.io/liberapay/receives/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
+    <pre>&lt;img src="https://img.shields.io/liberapay/receives/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
 
-    <p><img src="http://img.shields.io/liberapay/receives/{{ participant.username }}.svg?logo=liberapay"></p>
+    <p><img src="https://img.shields.io/liberapay/receives/{{ participant.username }}.svg?logo=liberapay"></p>
 
-    <pre>&lt;img src="http://img.shields.io/liberapay/gives/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
+    <pre>&lt;img src="https://img.shields.io/liberapay/gives/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
 
-    <p><img src="http://img.shields.io/liberapay/gives/{{ participant.username }}.svg?logo=liberapay"></p>
+    <p><img src="https://img.shields.io/liberapay/gives/{{ participant.username }}.svg?logo=liberapay"></p>
 
-    <pre>&lt;img src="http://img.shields.io/liberapay/patrons/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
+    <pre>&lt;img src="https://img.shields.io/liberapay/patrons/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
 
-    <p><img src="http://img.shields.io/liberapay/patrons/{{ participant.username }}.svg?logo=liberapay"></p>
+    <p><img src="https://img.shields.io/liberapay/patrons/{{ participant.username }}.svg?logo=liberapay"></p>
 
-    <pre>&lt;img src="http://img.shields.io/liberapay/goal/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
+    <pre>&lt;img src="https://img.shields.io/liberapay/goal/{{ participant.username }}.svg?logo=liberapay"&gt;</pre>
 
-    <p><img src="http://img.shields.io/liberapay/goal/{{ participant.username }}.svg?logo=liberapay"></p>
+    <p><img src="https://img.shields.io/liberapay/goal/{{ participant.username }}.svg?logo=liberapay"></p>
 
 % endblock


### PR DESCRIPTION
This should fix issues of browsers reporting messages similar to...

    Connection
    Connection Is Not Secure
    ⚠️ Parts of this web page are not secure (such as images)

... which pop on _`/<account>/widgets/`_ path.


Hopefully y'all aren't put-off by this PR, because reviewing the HackerOne categories didn't show any that seemed applicable, so I figured a Pull Request would be a swifter fix.