### PR TITLE
Log HTTP headers of sign-up requests

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -135,7 +135,7 @@ class Participant(Model, MixinTeam):
             """.format(x), vals)
 
     @classmethod
-    def make_active(cls, kind, currency, username=None, cursor=None):
+    def make_active(cls, kind, currency, username=None, cursor=None, request_data=None):
         """Return a new active participant.
         """
         now = utcnow()
@@ -154,6 +154,7 @@ class Participant(Model, MixinTeam):
                 INSERT INTO participants ({0}) VALUES ({1})
                   RETURNING participants.*::participants
             """.format(cols, placeholders), vals)
+            p.add_event(c, 'sign_up_request', request_data)
             if username:
                 p.change_username(username, cursor=c)
         return p


### PR DESCRIPTION
This commit stores HTTP request headers in the database when a new account is created. The purpose of this change is to enable me to look for differences between legitimate and nefarious account creation requests. Once that's done the data that we don't need anymore will be deleted.