### PR TITLE
Fix renewal reminders for PayPal-only donations

### DIFF
--- a/liberapay/payin/cron.py
+++ b/liberapay/payin/cron.py
@@ -277,7 +277,7 @@ def _filter_transfers(payer, transfers, automatic):
             tr['amount'] = Money(**tr['amount'])
         beneficiary = tr['beneficiary'] = website.db.Participant.from_id(tr['tippee_id'])
         tip = tr['tip'] = payer.get_tip_to(beneficiary)
-        if tip.renewal_mode < 1 or (tip.renewal_mode == 2) != automatic:
+        if tip.renewal_mode < 1 or automatic and (tip.renewal_mode != 2):
             canceled_transfers.append(tr)
         elif beneficiary.status != 'active' or beneficiary.is_suspended or \
              beneficiary.payment_providers & 1 == 0:


### PR DESCRIPTION
This patch fixes a significant bug: the notification that a donation needs to be renewed manually isn't sent if the donor had chosen automatic renewals but the renewal payment can't be processed automatically because the recipient doesn't have a Stripe account connected.