### PR TITLE
Remove ipaddress dependency

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -210,10 +210,6 @@ boto3==1.9.221 \
         --hash=sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d \
         --hash=sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba
 
-ipaddress==1.0.18 \
-    --hash=sha256:d34cf15d95ce9a734560f7400a8bd2ac2606f378e2a1d0eadbf1c98707e7c74a \
-    --hash=sha256:5d8534c8e185f2d8a1fda1ef73f2c8f4b23264e8e30063feeb9511d492a413e1
-
 cached-property==1.3.1 \
     --hash=sha256:6562f0be134957547421dda11640e8cadfa7c23238fc4e0821ab69efdb1095f3 \
     --hash=sha256:fe045921fe75c873064028e9fbbe06121114ccf613227f4ba284fa7d4c9ff27f


### PR DESCRIPTION
Since `ipaddress` [is included in Python 3.3+](https://docs.python.org/3.3/library/ipaddress.html) (and stable from Python 3.4), the version from `pypi` is unnecessary.