### PR TITLE
Bolster email sending

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -1292,7 +1292,13 @@ class Participant(Model, MixinTeam):
                 website.mailer.send(**message)
             except Exception as e:
                 website.tell_sentry(e, {})
-                raise UnableToSendEmail(email)
+                try:
+                    # Retry without the user's name in the `To:` header
+                    message['to'] = [email]
+                    website.mailer.send(**message)
+                except Exception as e:
+                    website.tell_sentry(e, {})
+                    raise UnableToSendEmail(email)
             website.log_email(message)
 
     @classmethod


### PR DESCRIPTION
There is currently a bug in Mailshake (see <https://github.com/jpsca/MailShake/pull/15>) which causes an error when attempting to send an email to someone who has a long non-ASCII name.