### PR TITLE
Require cookies for email log-ins, confirmations and disavowals

### DIFF
--- a/www/%username/emails/confirm.spt
+++ b/www/%username/emails/confirm.spt
@@ -3,6 +3,7 @@
 This simplate must not reveal the email address in its response.
 """
 
+from liberapay.security.csrf import require_cookie
 from liberapay.utils import get_participant
 from liberapay.utils.emails import EmailVerificationResult
 
@@ -14,6 +15,8 @@ if request.method == 'HEAD':
 
 # Redirecting this request can lead to confusing situations, so we ask `get_participant` to avoid redirecting it.
 participant = get_participant(state, restrict=False, redirect_canon=False, redirect_stub=False)
+
+require_cookie(state)
 
 if 'email.verification-result' in state:
     result = state['email.verification-result']

--- a/www/%username/emails/disavow.spt
+++ b/www/%username/emails/disavow.spt
@@ -6,6 +6,7 @@ been deleted or renamed.
 
 from liberapay.models.participant import Participant
 from liberapay.security.crypto import constant_time_compare
+from liberapay.security.csrf import require_cookie
 from liberapay.utils.emails import EmailVerificationResult
 
 [---]
@@ -13,6 +14,8 @@ from liberapay.utils.emails import EmailVerificationResult
 # Don't allow HEAD requests.
 if request.method == 'HEAD':
     raise response.error(405, request.method)
+
+require_cookie(state)
 
 slug = request.path['username']
 if slug.startswith('~'):


### PR DESCRIPTION
This commit attempts to solve the problem of links sent to a user's email address being activated by a link checker (software that looks for HTTP links and sends GET requests to those URLs to perform various checks).

As a bonus, it also fixes a related issue: a proper error message will be displayed when a user opens a log-in link in a browser that has cookies disabled.