### PR TITLE
Add statement to public.json

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -3529,14 +3529,12 @@ class Participant(Model, MixinTeam):
               FROM statements
              WHERE participant = %s
                AND type = 'summary'
-          GROUP BY lang, type
         """, (self.id,), back_as=dict)
         output['statements'] = self.db.all("""
             SELECT lang, content
               FROM statements
              WHERE participant = %s
                AND type = 'profile'
-          GROUP BY lang, type
         """, (self.id,), back_as=dict)
 
         return output

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -3521,6 +3521,9 @@ class Participant(Model, MixinTeam):
             giving = None
         output['giving'] = giving
 
+        # Key: statements
+        output['statements'] = self.get_statement(self.get_statement_langs())
+
         return output
 
     def path(self, path, query=''):

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -3479,6 +3479,7 @@ class Participant(Model, MixinTeam):
         output = {
             'id': self.id,
             'username': self.username,
+            'display_name': self.public_name,
             'avatar': self.avatar_url,
             'kind': self.kind,
         }
@@ -3521,8 +3522,22 @@ class Participant(Model, MixinTeam):
             giving = None
         output['giving'] = giving
 
-        # Key: statements
-        output['statements'] = self.get_statement(self.get_statement_langs())
+        # Keys: summaries and statements
+        # Values: lists of dicts containing the user's texts in various languages
+        output['summaries'] = self.db.all("""
+            SELECT lang, content
+              FROM statements
+             WHERE participant = %s
+               AND type = 'summary'
+          GROUP BY lang, type
+        """, (self.id,), back_as=dict)
+        output['statements'] = self.db.all("""
+            SELECT lang, content
+              FROM statements
+             WHERE participant = %s
+               AND type = 'profile'
+          GROUP BY lang, type
+        """, (self.id,), back_as=dict)
 
         return output
 


### PR DESCRIPTION
**Aim**

Add the project's statement to the public.json document.

**Context**

I'm building Keyoxide, a client for decentralized OpenPGP identity proofs. In this model, URLs to user accounts are stored inside OpenPGP keys. A client follows that link and after figuring out which service the URL belongs to, fetches a JSON document containing user details using the public API provided by said service. In this JSON document, some user-customizable field must contain the fingerprint of the OpenPGP key. This establishes a bidirectional link between key and user account and allows the client to verify the identity proof.

Liberapay has such a public API (/%username/public.json). Unfortunately, no field can currently be fully customized by the user, making identity proofs impossible.

This PR adds the project's statement to the public.json document, allowing the user to add their key's fingerprint to the end of the statement and make the proof verifiable. Once this is done, I will add a Donate button to all Keyoxide profile pages that have a verified Liberapay account.

**Important note**

I wasn't able to run the tests or, for that matter, verify this PR even works. I'm having a few issues with my dev machine, need to nuke-and-pave soon. I looked at the code and the SQL schema for an hour, and this made most sense to me.

If someone would be so generous to verify the validity of this code, that would be much appreciated! If not, this PR will have to wait until I am able to.