### PR TITLE
Tweak renewal dates

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2700,6 +2700,9 @@ class Participant(Model, MixinTeam):
                 for payin_tips in groups:
                     execution_date = min(t.due_date for t in payin_tips)
                     if renewal_mode == 2:
+                        # We schedule automatic renewals one day early so that the
+                        # donor has a little bit of time to react if it fails.
+                        execution_date -= timedelta(days=1)
                         execution_date = max(execution_date, min_automatic_debit_date)
                     new_sp = Object(
                         amount=Money.sum(

--- a/liberapay/payin/cron.py
+++ b/liberapay/payin/cron.py
@@ -252,7 +252,7 @@ def execute_scheduled_payins():
                       , r.ctime DESC
                   LIMIT 1
                ) r ON true
-         WHERE ( r.network = 'stripe-sdd' AND sp.execution_date <= (current_date + interval '5 days') OR
+         WHERE ( r.network = 'stripe-sdd' AND sp.execution_date <= (current_date + interval '6 days') OR
                  r.network = 'stripe-card' AND sp.execution_date <= current_date )
            AND sp.last_notif_ts < (current_date - interval '2 days')
            AND sp.automatic

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,6 @@
+UPDATE scheduled_payins
+   SET execution_date = execution_date - interval '1 day'
+ WHERE payin IS null
+   AND execution_date > current_date
+   AND last_notif_ts IS null
+   AND automatic IS true;

--- a/tests/py/test_schedule.py
+++ b/tests/py/test_schedule.py
@@ -61,7 +61,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(new_schedule) == 1
         assert new_schedule[0].amount == EUR('49.50')
         assert new_schedule[0].transfers == expected_transfers
-        assert new_schedule[0].execution_date == (next_payday + timedelta(weeks=50))
+        assert new_schedule[0].execution_date == (next_payday + timedelta(weeks=50, days=-1))
         assert new_schedule[0].automatic is True
 
     def test_schedule_renewals_notifies_payer_of_changes(self):
@@ -82,7 +82,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(new_schedule) == 1
         assert new_schedule[0].amount == EUR('2.00')
         assert new_schedule[0].transfers == expected_transfers
-        expected_renewal_date = next_payday + timedelta(weeks=2)
+        expected_renewal_date = next_payday + timedelta(weeks=2, days=-1)
         assert new_schedule[0].execution_date == expected_renewal_date
         assert new_schedule[0].automatic is True
         # Trigger the initial "upcoming charge" notification
@@ -118,7 +118,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(new_schedule) == 1
         assert new_schedule[0].amount == EUR('2.00')
         assert new_schedule[0].transfers == expected_transfers
-        expected_renewal_date = next_payday + timedelta(weeks=20)
+        expected_renewal_date = next_payday + timedelta(weeks=20, days=-1)
         assert new_schedule[0].execution_date == expected_renewal_date
         assert new_schedule[0].automatic is True
         emails = self.get_emails()
@@ -157,7 +157,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(new_schedule) == 1
         assert new_schedule[0].amount == EUR('5.00')
         assert new_schedule[0].transfers == expected_transfers
-        expected_renewal_date = next_payday + timedelta(weeks=2)
+        expected_renewal_date = next_payday + timedelta(weeks=2, days=-1)
         assert new_schedule[0].execution_date == expected_renewal_date
         assert new_schedule[0].automatic is True
         # Trigger the initial "upcoming charge" notification
@@ -194,7 +194,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert new_schedule[0].amount == EUR('2.00')
         assert new_schedule[0].transfers == [expected_transfers[0]]
         previous_renewal_date = expected_renewal_date
-        expected_renewal_date = next_payday + timedelta(weeks=4)
+        expected_renewal_date = next_payday + timedelta(weeks=4, days=-1)
         assert new_schedule[0].execution_date == expected_renewal_date
         assert new_schedule[0].automatic is True
         emails = self.get_emails()
@@ -254,7 +254,7 @@ class TestDonationRenewalScheduling(EmailHarness):
         assert len(schedule) == 1
         assert schedule[0].amount == EUR('37.00')
         assert schedule[0].transfers == expected_transfers
-        expected_renewal_date = next_payday + timedelta(weeks=37)
+        expected_renewal_date = next_payday + timedelta(weeks=37, days=-1)
         assert schedule[0].execution_date == expected_renewal_date
         assert schedule[0].automatic is True
 


### PR DESCRIPTION
This branch modifies when automatic payments are initiated. Specifically, the payments will be scheduled to happen one day early, and SEPA Direct Debits will be initiated one day earlier (6 days before the planned execution date instead of 5 days).