### PR TITLE
Fix 'mark notifications as read' message

### DIFF
--- a/i18n/core/ar.po
+++ b/i18n/core/ar.po
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/ca.po
+++ b/i18n/core/ca.po
@@ -3186,7 +3186,7 @@ msgstr "Us voleu subscriure a les novetats de {0}?"
 msgid "Please confirm"
 msgstr "Si us plau, confirmeu"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marca totes les notificacions com a llegides"
 
 msgid "Mark as read"

--- a/i18n/core/cs.po
+++ b/i18n/core/cs.po
@@ -3197,7 +3197,7 @@ msgstr "Přihlásit se k odběru novinek od {0}?"
 msgid "Please confirm"
 msgstr "Prosím potvrďte"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Označit všechna oznámení jako přečtená"
 
 msgid "Mark as read"

--- a/i18n/core/da.po
+++ b/i18n/core/da.po
@@ -3186,7 +3186,7 @@ msgstr "Abonner på opdateringer fra {0}?"
 msgid "Please confirm"
 msgstr "Godkend venligst"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marker alle notifikationer som læst"
 
 msgid "Mark as read"

--- a/i18n/core/de.po
+++ b/i18n/core/de.po
@@ -3186,7 +3186,7 @@ msgstr "Möchten Sie Neuigkeiten von {0} abonnieren?"
 msgid "Please confirm"
 msgstr "Bitte bestätigen"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Alle Benachrichtigungen als gelesen markieren"
 
 msgid "Mark as read"

--- a/i18n/core/el.po
+++ b/i18n/core/el.po
@@ -3183,7 +3183,7 @@ msgstr "Εγγραφείτε για ενημερώσεις από {0};"
 msgid "Please confirm"
 msgstr "Παρακαλώ επιβεβαιώστε"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/eo.po
+++ b/i18n/core/eo.po
@@ -3186,7 +3186,7 @@ msgstr "Ĉu aboni novaĵojn de {0}?"
 msgid "Please confirm"
 msgstr "Bonvolu konfirmi"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marki ĉiujn sciigojn legitaj"
 
 msgid "Mark as read"

--- a/i18n/core/es.po
+++ b/i18n/core/es.po
@@ -3186,7 +3186,7 @@ msgstr "¿Suscribirse a actualizaciones de {0}?"
 msgid "Please confirm"
 msgstr "Por favor, confirma"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marcar todas las notificaciones como leídas"
 
 msgid "Mark as read"

--- a/i18n/core/et.po
+++ b/i18n/core/et.po
@@ -3165,7 +3165,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/fi.po
+++ b/i18n/core/fi.po
@@ -3186,7 +3186,7 @@ msgstr "Tilaatko yhteisön {0} tiedotteet?"
 msgid "Please confirm"
 msgstr "Vahvista toimenpide"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Merkitse kaikki ilmoitukset luetuiksi"
 
 msgid "Mark as read"

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -3186,7 +3186,7 @@ msgstr "Vous inscrire aux actualités de {0} ?"
 msgid "Please confirm"
 msgstr "Veuillez confirmer"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marquer toutes les notifications comme lues"
 
 msgid "Mark as read"

--- a/i18n/core/fy.po
+++ b/i18n/core/fy.po
@@ -3164,7 +3164,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/ga.po
+++ b/i18n/core/ga.po
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/hu.po
+++ b/i18n/core/hu.po
@@ -3152,7 +3152,7 @@ msgstr "Feliratkozik a(z) {0} híreire?"
 msgid "Please confirm"
 msgstr "Kérjük erősítse meg"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Valamennyi értesítést megjelölése olvasottként"
 
 msgid "Mark as read"

--- a/i18n/core/id.po
+++ b/i18n/core/id.po
@@ -3137,7 +3137,7 @@ msgstr "Berlangganan untuk mendapatkan yang terbaru dari {0}?"
 msgid "Please confirm"
 msgstr "Mohon konfirmasi"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Tandai semua pemberitahuan sebagai sudah dibaca"
 
 msgid "Mark as read"

--- a/i18n/core/it.po
+++ b/i18n/core/it.po
@@ -3186,7 +3186,7 @@ msgstr "Vuoi ricevere aggiornamenti da {0}?"
 msgid "Please confirm"
 msgstr "Per favore, conferma"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Segna tutte le notifiche come già lette"
 
 msgid "Mark as read"

--- a/i18n/core/ja.po
+++ b/i18n/core/ja.po
@@ -3155,7 +3155,7 @@ msgstr "{0} の更新を定期購読しますか？"
 msgid "Please confirm"
 msgstr "確認してください"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "すべての通知を既読にする"
 
 msgid "Mark as read"

--- a/i18n/core/ko.po
+++ b/i18n/core/ko.po
@@ -3153,7 +3153,7 @@ msgstr "{0} 의 업데이트를 구독하시겠습니까?"
 msgid "Please confirm"
 msgstr "확인이 필요합니다"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "모든 알림을 읽은 것으로 표시"
 
 msgid "Mark as read"

--- a/i18n/core/lt.po
+++ b/i18n/core/lt.po
@@ -3196,7 +3196,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/lv.po
+++ b/i18n/core/lv.po
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/ms.po
+++ b/i18n/core/ms.po
@@ -3186,7 +3186,7 @@ msgstr "Langgan kemas kini daripada {0}?"
 msgid "Please confirm"
 msgstr "Sila sahkan"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Tanda semua pemberitahuan sebagai sudah baca"
 
 msgid "Mark as read"

--- a/i18n/core/nb.po
+++ b/i18n/core/nb.po
@@ -3187,7 +3187,7 @@ msgstr "Abonner på oppdateringer fra {0}?"
 msgid "Please confirm"
 msgstr "Bekreft"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Merk alle merknader som leste"
 
 msgid "Mark as read"

--- a/i18n/core/nl.po
+++ b/i18n/core/nl.po
@@ -3186,7 +3186,7 @@ msgstr "Abonneer op updates van {0}?"
 msgid "Please confirm"
 msgstr "Bevestig alsjeblieft"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Markeer alle meldingen als gelezen"
 
 msgid "Mark as read"

--- a/i18n/core/pl.po
+++ b/i18n/core/pl.po
@@ -3218,7 +3218,7 @@ msgstr "Subskrybować aktualności od {0}?"
 msgid "Please confirm"
 msgstr "Prosimy o potwierdzenie"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Oznacz wszystkie powiadomienia jako przeczytane"
 
 msgid "Mark as read"

--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -3186,7 +3186,7 @@ msgstr "Se inscrever para receber notícias de {0}?"
 msgid "Please confirm"
 msgstr "Confirme"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marcar todas as notificações como lidas"
 
 msgid "Mark as read"

--- a/i18n/core/ro.po
+++ b/i18n/core/ro.po
@@ -3197,7 +3197,7 @@ msgstr "Vă abonați la noutăți de la {0}?"
 msgid "Please confirm"
 msgstr "Confirmați vă rog"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Marchează toate notificările ca citite"
 
 msgid "Mark as read"

--- a/i18n/core/ru.po
+++ b/i18n/core/ru.po
@@ -3217,7 +3217,7 @@ msgstr "Подписаться на обновления от {0}?"
 msgid "Please confirm"
 msgstr "Подтвердите действие"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Пометить все уведомления как прочитанные"
 
 msgid "Mark as read"

--- a/i18n/core/sk.po
+++ b/i18n/core/sk.po
@@ -3216,7 +3216,7 @@ msgstr "Prihlásiť sa k odberu noviniek od {0}?"
 msgid "Please confirm"
 msgstr "Prosím potvrďte"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Označiť všetky oznámenia ako prečítané"
 
 msgid "Mark as read"

--- a/i18n/core/sl.po
+++ b/i18n/core/sl.po
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/sv.po
+++ b/i18n/core/sv.po
@@ -3185,7 +3185,7 @@ msgstr "Prenumerera på uppdateringar från {0}?"
 msgid "Please confirm"
 msgstr "Vänligen bekräfta"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Markera alla notifieringar som lästa"
 
 msgid "Mark as read"

--- a/i18n/core/tr.po
+++ b/i18n/core/tr.po
@@ -3167,7 +3167,7 @@ msgstr ""
 msgid "Please confirm"
 msgstr ""
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr ""
 
 msgid "Mark as read"

--- a/i18n/core/uk.po
+++ b/i18n/core/uk.po
@@ -3217,7 +3217,7 @@ msgstr "Підписатися на оновлення від {0}?"
 msgid "Please confirm"
 msgstr "Підтвердити дію"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "Позначити всі сповіщення прочитаними"
 
 msgid "Mark as read"

--- a/i18n/core/zh_Hant.po
+++ b/i18n/core/zh_Hant.po
@@ -3155,7 +3155,7 @@ msgstr "訂閱{0} 的訊息更新?"
 msgid "Please confirm"
 msgstr "請確認"
 
-msgid "Mark all notifications as read"
+msgid "Mark all notifications in this page as read"
 msgstr "所有的通知標為已讀"
 
 msgid "Mark as read"

--- a/www/%username/notifications.spt
+++ b/www/%username/notifications.spt
@@ -50,7 +50,7 @@ participant.render_notifications(state, before=before, limit=limit)
     % endif
     <button class="btn btn-primary" name="mark_all_as_read" value="true"
         {{ 'disabled' if not unread_notifications }}>{{
-        _("Mark all notifications as read")
+        _("Mark all notifications in this page as read")
     }}</button><br>
     <br>
     % for notif in notifs


### PR DESCRIPTION
Only the notifications from the current page are marked as read, not all of the unread ones, as the message previously implied.
