### PR TITLE
Add Hungary to countries supported by Stripe

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -387,8 +387,8 @@ PAYOUT_COUNTRIES = {
     """.split()),  # https://www.paypal.com/us/webapps/mpp/country-worldwide
 
     'stripe': set("""
-        AT AU BE BG CA CH CY CZ DE DK EE ES FI FR GB GR HK IE IT JP LT LU LV MT
-        MX MY NL NO NZ PL PT RO SE SG SI SK US
+        AT AU BE BG CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IT JP LT LU LV
+        MT MX MY NL NO NZ PL PT RO SE SG SI SK US
         PR
     """.split()),  # https://stripe.com/global
 }


### PR DESCRIPTION
Apparently it was added a month ago: <https://twitter.com/stripe/status/1328960251287261186>. Croatia is now the last EU country not supported by Stripe.