### PR TITLE
privacy setting isn't linking to the correct page

### DIFF
--- a/www/%username/widgets/index.html.spt
+++ b/www/%username/widgets/index.html.spt
@@ -43,7 +43,7 @@ response.headers[b'Content-Security-Policy'] = csp
     <p class="alert alert-warning">{{ _(
         "This widget is not available because it is not compatible with the "
         "{link_open}privacy settings{link_close} you have chosen.",
-        link_open=('<a href="{0}settings#privacy">'|safe).format(profile_url),
+        link_open=('<a href="{0}edit/privacy">'|safe).format(profile_url),
         link_close='</a>'|safe
     ) }}</p>
     % else
@@ -60,7 +60,7 @@ response.headers[b'Content-Security-Policy'] = csp
     <p class="alert alert-warning">{{ _(
         "This widget is not available because it is not compatible with the "
         "{link_open}privacy settings{link_close} you have chosen.",
-        link_open=('<a href="{0}settings#privacy">'|safe).format(profile_url),
+        link_open=('<a href="{0}edit/privacy">'|safe).format(profile_url),
         link_close='</a>'|safe
     ) }}</p>
     % else


### PR DESCRIPTION
While on [the widget page](https://en.liberapay.com/me/widgets/), the "privacy setting" link does send to https://liberapay.com/me/settings#privacy while it should link to https://liberapay.com/me/edit/privacy .

This might fix this.

![me-widgets-link](https://user-images.githubusercontent.com/8705846/104849093-451b3500-58e8-11eb-906a-37637471e51e.png)

