### PR TITLE
Fix payday

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -423,7 +423,7 @@ class Payday:
         manual_takes = [t for t in takes if t.amount > 0]
         if manual_takes:
             manual_takes_sum = MoneyBasket(t.amount for t in manual_takes)
-            n_auto_takes = sum(1 for t in takes if t.amount > 0) or 1
+            n_auto_takes = sum(1 for t in takes if t.amount < 0) or 1
             auto_take = (
                 (fuzzy_income_sum - manual_takes_sum.fuzzy_sum(ref_currency)) /
                 n_auto_takes

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -28,12 +28,13 @@ def round_up(d):
 
 
 class TakeTransfer:
-    __slots__ = ('tipper', 'member', 'amount')
+    __slots__ = ('tipper', 'member', 'amount', 'is_leftover')
 
-    def __init__(self, tipper, member, amount):
+    def __init__(self, tipper, member, amount, is_leftover=False):
         self.tipper = tipper
         self.member = member
         self.amount = amount
+        self.is_leftover = is_leftover
 
     def __repr__(self):
         return f"TakeTransfer({self.tipper!r}, {self.member!r}, {self.amount!r})"
@@ -221,9 +222,7 @@ class Payday:
                       WHERE mtime < %(ts_start)s
                    ORDER BY team, member, mtime DESC
                    ) t
-             WHERE t.amount IS NOT NULL
-               AND t.amount <> 0
-               AND t.team IN (SELECT id FROM payday_participants)
+             WHERE t.team IN (SELECT id FROM payday_participants)
                AND t.member IN (SELECT id FROM payday_participants);
 
         CREATE UNIQUE INDEX ON payday_takes (team, member);
@@ -262,7 +261,7 @@ class Payday:
                 in_advance := zero(a_amount);
                 transfer_amount := a_amount;
 
-                IF (a_context IN ('tip', 'take')) THEN
+                IF (a_context IN ('tip', 'take', 'leftover-take')) THEN
                     tip := (
                         SELECT t
                           FROM payday_tips t
@@ -403,8 +402,9 @@ class Payday:
         """, args)
         transfers, leftover = Payday.resolve_takes(tips, takes, currency)
         for t in transfers:
-            cursor.run("SELECT transfer(%s, %s, %s, 'take', %s, NULL)",
-                       (t.tipper, t.member, t.amount, team_id))
+            context = 'leftover-take' if t.is_leftover else 'take'
+            cursor.run("SELECT transfer(%s, %s, %s, %s, %s, NULL)",
+                       (t.tipper, t.member, t.amount, context, team_id))
 
     @staticmethod
     def resolve_takes(tips, takes, ref_currency):
@@ -413,11 +413,12 @@ class Payday:
         total_income = MoneyBasket(t.full_amount for t in tips)
         if total_income == 0:
             return (), total_income
+        leftover_takes = [t for t in takes if t.paid_in_advance and not t.amount]
         if mangopay.sandbox:
-            takes = [t for t in takes if t.amount != 0]
+            takes = [t for t in takes if t.amount]
         else:
-            takes = [t for t in takes if t.amount != 0 and t.paid_in_advance]
-        if not takes:
+            takes = [t for t in takes if t.amount and t.paid_in_advance]
+        if not (takes or leftover_takes):
             return (), total_income
         fuzzy_income_sum = total_income.fuzzy_sum(ref_currency)
         manual_takes = [t for t in takes if t.amount > 0]
@@ -441,7 +442,10 @@ class Payday:
         tips_by_currency = group_by(tips, lambda t: t.full_amount.currency)
         takes_by_preferred_currency = group_by(takes, lambda t: t.main_currency)
         takes_by_secondary_currency = {c: [] for c in tips_by_currency}
-        takes_ratio = min(fuzzy_income_sum / fuzzy_takes_sum, 1)
+        if fuzzy_takes_sum:
+            takes_ratio = min(fuzzy_income_sum / fuzzy_takes_sum, 1)
+        else:
+            takes_ratio = 0
         for take in takes:
             take.amount = (take.amount * takes_ratio).round_up()
             if take.paid_in_advance is None:
@@ -518,6 +522,7 @@ class Payday:
         # Loop: compute the adjusted donation amounts, and do the transfers
         transfers = {}
         for tip in tips:
+            tip.available_amount = tip.full_amount
             if tip.paid_in_advance is None:
                 tip.paid_in_advance = tip.full_amount.zero()
             if adjust_tips:
@@ -570,10 +575,52 @@ class Payday:
                 if on_time_amount:
                     tip.balances -= on_time_amount
                 tip.amount -= transfer_amount
+                tip.available_amount -= transfer_amount
                 if tip.amount == 0:
                     break
-        transfers = transfers.values()
+        # Try to use the leftover to reduce the advances received in the past by
+        # members who have now left the team or have zeroed takes.
+        transfers = list(transfers.values())
         leftover = total_income - MoneyBasket(t.amount for t in transfers)
+        if leftover and leftover_takes:
+            leftover_takes.sort(key=lambda t: t.member)
+            leftover_takes_fuzzy_sum = MoneyBasket(
+                take.paid_in_advance for take in leftover_takes
+            ).fuzzy_sum(ref_currency)
+            advance_ratio = leftover.fuzzy_sum(ref_currency) / leftover_takes_fuzzy_sum
+            leftover_transfers = {}
+            for take in leftover_takes:
+                take.amount = (take.paid_in_advance * advance_ratio).round()
+                for tip in tips:
+                    if tip.available_amount == 0 or tip.tipper == take.member:
+                        continue
+                    tip_currency = tip.full_amount.currency
+                    fuzzy_take_amount = take.amount.convert(tip_currency)
+                    transfer_amount = min(
+                        tip.available_amount,
+                        fuzzy_take_amount,
+                        max(tip.paid_in_advance, 0),
+                        max(take.paid_in_advance.convert(tip_currency), 0),
+                    )
+                    if transfer_amount == 0:
+                        continue
+                    transfer_key = (tip.tipper, take.member)
+                    if transfer_key in transfers:
+                        leftover_transfers[transfer_key].amount += transfer_amount
+                    else:
+                        leftover_transfers[transfer_key] = TakeTransfer(
+                            tip.tipper, take.member, transfer_amount, is_leftover=True,
+                        )
+                    if transfer_amount == fuzzy_take_amount:
+                        take.amount = take.amount.zero()
+                    else:
+                        take.amount -= transfer_amount.convert(take.amount.currency)
+                    tip.paid_in_advance -= transfer_amount
+                    take.paid_in_advance -= transfer_amount.convert(take.paid_in_advance.currency)
+                    tip.available_amount -= transfer_amount
+                    if take.amount == 0:
+                        break
+            transfers.extend(leftover_transfers.values())
         return transfers, leftover
 
     @staticmethod

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,1 +1,2 @@
 ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'leftover-take';
+ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'partial-tip';

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,1 @@
+ALTER TYPE transfer_context ADD VALUE IF NOT EXISTS 'leftover-take';

--- a/www/%username/wallet/index.html.spt
+++ b/www/%username/wallet/index.html.spt
@@ -306,7 +306,7 @@ if user.is_admin:
                      link_close='</a>'|safe,
                      payer=('<a href="/{0}/">{0}</a>'|safe).format(event['username']),
                 ) }}
-            % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears')
+            % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears', 'partial-tip')
                 {{ _("anonymous donation") }}
                 % if event['unit_amount']
                     % set weeks = int(event['amount'] / event['unit_amount'])
@@ -360,7 +360,7 @@ if user.is_admin:
                      link_close='</a>'|safe,
                      payee=to,
                 ) }}
-            % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears')
+            % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears', 'partial-tip')
                 {{ _("donation to {0}", to) }}
                 % if event['unit_amount']
                     % set weeks = int(abs(event['amount'] / event['unit_amount']))

--- a/www/%username/wallet/statement.spt
+++ b/www/%username/wallet/statement.spt
@@ -213,7 +213,7 @@ output.body = render(globals(), allow_partial_i18n=False)
                          link_close='',
                          payer=event['username'],
                     ) }}
-                % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears')
+                % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears', 'partial-tip')
                     {{ _("anonymous donation") }}
                     % if event['unit_amount']
                         % set weeks = int(event['amount'] / event['unit_amount'])
@@ -265,7 +265,7 @@ output.body = render(globals(), allow_partial_i18n=False)
                          link_close='',
                          payee=to,
                     ) }}
-                % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears')
+                % elif context in ('tip', 'tip-in-advance', 'tip-in-arrears', 'partial-tip')
                     {{ _("donation to {0}", to) }}
                     % if event['unit_amount']
                         % set weeks = int(abs(event['amount'] / event['unit_amount']))


### PR DESCRIPTION
This branch:

- fixes a bug in the computation of the actual amounts of `auto` takes
- modifies the take resolution function to fully “consume” the money paid in advance to members who are no longer active team members
- modifies payday to process partially funded tips (i.e. when the amount of money left is lower than the donation's weekly amount)
