### PR TITLE
Reverse accepting or refusing a team invitation

### DIFF
--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -179,6 +179,11 @@ class Participant(Model, MixinTeam):
                 t.add_email(email, cursor=c)
         return t
 
+    def leave_team(self, team):
+        team.set_take_for(self, None, self)
+        if not team.nmembers:
+            team.close(None)
+
     @classmethod
     def from_id(cls, id, _raise=True):
         """Return an existing participant based on id.

--- a/tests/py/test_teams.py
+++ b/tests/py/test_teams.py
@@ -62,6 +62,35 @@ class Tests(Harness):
         is_member = self.bob.member_of(self.a_team)
         assert is_member is False
 
+    def test_accept_then_refuse_invite(self):
+        self.a_team.invite(self.bob, self.alice)
+        r = self.client.PxST('/A-Team/membership/accept', auth_as=self.bob)
+        assert r.code == 302
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is True
+
+        r = self.client.PxST('/A-Team/membership/refuse', auth_as=self.bob)
+        assert r.code == 200
+        assert 'confirm' in r.text
+
+        r = self.client.PxST(
+            '/A-Team/membership/refuse', {'confirmed': 'true'}, auth_as=self.bob,
+        )
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is False
+
+    def test_refuse_then_accept_invite(self):
+        self.a_team.invite(self.bob, self.alice)
+        r = self.client.PxST('/A-Team/membership/refuse', auth_as=self.bob)
+        assert r.code == 302
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is False
+
+        r = self.client.PxST('/A-Team/membership/accept', auth_as=self.bob)
+        assert r.code == 302
+        is_member = self.bob.member_of(self.a_team)
+        assert is_member is True
+
     def test_invite_is_scoped_to_specific_team(self):
         b_team = self.make_participant('B-Team', kind='group')
         self.a_team.invite(self.bob, self.alice)

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -31,7 +31,6 @@ if team.kind != 'group':
 action = request.path['action']
 msg = None
 confirm = None
-invite = None
 
 def leave_team():
     global confirm
@@ -46,7 +45,7 @@ if action in ('accept', 'refuse'):
     invite = get_invite(team, user)
     if not invite:
         raise response.error(403, _("You are not invited to join this team."))
-    if invite.type == 'invite_accept' and action == 'accept':
+    if action == 'accept' and user.member_of(team):
         raise response.error(409, _("You have already accepted this invitation."))
     if invite.type == 'invite_refuse' and action == 'refuse':
         raise response.error(409, _("You have already refused this invitation."))
@@ -94,11 +93,11 @@ elif action == 'accept':
         user.mark_notification_as_read(notif_id)
 
 elif action == 'refuse':
-    prev_accepted = invite.type == 'invite_accept'
-    if prev_accepted:
+    is_member = user.member_of(team)
+    if is_member:
         request.qs['back_to'] = '/{}/notifications'.format(user.username)
         leave_team()
-    if not prev_accepted or request.body.get('confirmed'):
+    if not is_member or request.body.get('confirmed'):
         with website.db.get_cursor() as c:
             team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
         if notif_id:

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -31,14 +31,24 @@ if team.kind != 'group':
 action = request.path['action']
 msg = None
 confirm = None
+invite = None
+
+def leave_team():
+    global confirm
+    if not request.body.get('confirmed'):
+        confirm = _("Are you sure you want to leave this team?")
+    else:
+        team.set_take_for(user, None, user)
+        if not team.nmembers:
+            team.close(None)
 
 if action in ('accept', 'refuse'):
     invite = get_invite(team, user)
     if not invite:
         raise response.error(403, _("You are not invited to join this team."))
-    if invite.type == 'invite_accept':
+    if invite.type == 'invite_accept' and action == 'accept':
         raise response.error(409, _("You have already accepted this invitation."))
-    if invite.type == 'invite_refuse':
+    if invite.type == 'invite_refuse' and action == 'refuse':
         raise response.error(409, _("You have already refused this invitation."))
     notif_id = invite.payload.get('notification_id')
 elif not user.member_of(team):
@@ -73,12 +83,7 @@ if action == 'invite':
         msg = _("{0} is already a member of this team.", invitee.username)
 
 elif action == 'leave':
-    if not request.body.get('confirmed'):
-        confirm = _("Are you sure you want to leave this team?")
-    else:
-        team.set_take_for(user, None, user)
-        if not team.nmembers:
-            team.close(None)
+    leave_team()
 
 elif action == 'accept':
     with website.db.get_cursor() as c:
@@ -89,11 +94,16 @@ elif action == 'accept':
         user.mark_notification_as_read(notif_id)
 
 elif action == 'refuse':
-    with website.db.get_cursor() as c:
-        team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
-    if notif_id:
-        user.mark_notification_as_read(notif_id)
-    response.redirect('/')
+    prev_accepted = invite.type == 'invite_accept'
+    if prev_accepted:
+        request.qs['back_to'] = '/{}/notifications'.format(user.username)
+        leave_team()
+    if not prev_accepted or request.body.get('confirmed'):
+        with website.db.get_cursor() as c:
+            team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
+        if notif_id:
+            user.mark_notification_as_read(notif_id)
+        response.redirect('/')
 
 else:
     raise response.invalid_input(action, 'action', 'path')

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -29,8 +29,8 @@ if team.kind != 'group':
     raise response.error(404)
 
 action = request.path['action']
+back_to = request.qs.get('back_to') or user.path('notifications')
 msg = None
-confirm = None
 
 if action in ('accept', 'refuse'):
     invite = get_invite(team, user)
@@ -38,7 +38,7 @@ if action in ('accept', 'refuse'):
         raise response.error(403, _("You are not invited to join this team."))
     if action == 'accept' and user.member_of(team):
         raise response.error(409, _("You have already accepted this invitation."))
-    if invite.type == 'invite_refuse' and action == 'refuse':
+    if action == 'refuse' and invite.type == 'invite_refuse':
         raise response.error(409, _("You have already refused this invitation."))
     notif_id = invite.payload.get('notification_id')
 elif not user.member_of(team):
@@ -73,43 +73,36 @@ if action == 'invite':
         msg = _("{0} is already a member of this team.", invitee.username)
 
 elif action == 'leave':
-    if not request.body.get('confirmed'):
+    if not request.body.parse_boolean('confirmed', default=False):
         confirm = _("Are you sure you want to leave this team?")
-    else:
-        user.leave_team(team)
+        raise response.render('simplates/confirm.spt', state, msg=confirm, back_to=back_to)
+    user.leave_team(team)
 
 elif action == 'accept':
     with website.db.get_cursor() as c:
         team.add_event(c, 'invite_accept', dict(invitee=user.id), user.id)
         team.add_member(user)
     msg = _("You are now a member of the team.")
+    back_to = team.path('income/')
     if notif_id:
         user.mark_notification_as_read(notif_id)
 
 elif action == 'refuse':
-    is_member = user.member_of(team)
-    if is_member:
-        if not request.body.get('confirmed'):
-            request.qs['back_to'] = '/{}/notifications'.format(user.username)
+    if user.member_of(team):
+        if not request.body.parse_boolean('confirmed', default=False):
             confirm = _("Are you sure you want to leave this team?")
-        else:
-            user.leave_team(team)
-    if not is_member or request.body.get('confirmed'):
-        with website.db.get_cursor() as c:
-            team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
-        if notif_id:
-            user.mark_notification_as_read(notif_id)
-        response.redirect('/')
+            raise response.render('simplates/confirm.spt', state, msg=confirm, back_to=back_to)
+        user.leave_team(team)
+    with website.db.get_cursor() as c:
+        team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)
+    if notif_id:
+        user.mark_notification_as_read(notif_id)
 
 else:
     raise response.invalid_input(action, 'action', 'path')
 
-back_to = request.qs.get('back_to') or (team.path('income/') if action == 'accept' else '/')
-if not confirm:
-    if msg:
-        back_to = _modify_query(back_to, 'success', b64encode_s(msg))
-    response.redirect(back_to, trusted_url=False)
-
-response.render('simplates/confirm.spt', state, msg=confirm, back_to=back_to)
+if msg:
+    back_to = _modify_query(back_to, 'success', b64encode_s(msg))
+response.redirect(back_to, trusted_url=False)
 
 [---] text/html

--- a/www/%username/membership/%action.spt
+++ b/www/%username/membership/%action.spt
@@ -32,15 +32,6 @@ action = request.path['action']
 msg = None
 confirm = None
 
-def leave_team():
-    global confirm
-    if not request.body.get('confirmed'):
-        confirm = _("Are you sure you want to leave this team?")
-    else:
-        team.set_take_for(user, None, user)
-        if not team.nmembers:
-            team.close(None)
-
 if action in ('accept', 'refuse'):
     invite = get_invite(team, user)
     if not invite:
@@ -82,7 +73,10 @@ if action == 'invite':
         msg = _("{0} is already a member of this team.", invitee.username)
 
 elif action == 'leave':
-    leave_team()
+    if not request.body.get('confirmed'):
+        confirm = _("Are you sure you want to leave this team?")
+    else:
+        user.leave_team(team)
 
 elif action == 'accept':
     with website.db.get_cursor() as c:
@@ -95,8 +89,11 @@ elif action == 'accept':
 elif action == 'refuse':
     is_member = user.member_of(team)
     if is_member:
-        request.qs['back_to'] = '/{}/notifications'.format(user.username)
-        leave_team()
+        if not request.body.get('confirmed'):
+            request.qs['back_to'] = '/{}/notifications'.format(user.username)
+            confirm = _("Are you sure you want to leave this team?")
+        else:
+            user.leave_team(team)
     if not is_member or request.body.get('confirmed'):
         with website.db.get_cursor() as c:
             team.add_event(c, 'invite_refuse', dict(invitee=user.id), user.id)


### PR DESCRIPTION
Users can reverse their decision in accepting or refusing a team invitation (addresses issue #1932).