### PR TITLE
Pause donations option for Goal

### DIFF
--- a/emails/donations_paused.spt
+++ b/emails/donations_paused.spt
@@ -1,0 +1,16 @@
+% if donations_paused
+{{ _("Liberapay donation paused") }}
+% else
+{{ _("Liberapay donation resumed") }}
+% endif
+
+[---] text/html
+% if donations_paused
+<p>{{ _("Due to changes recently made by {0}, your donations for {0} have been temporarily paused.", recipient) }}</p>
+% else
+<p>{{ _("Due to changes recently made by {0}, your donations for {0} are set to resume.", recipient) }}</p>
+% endif
+
+<p>{{ _("View your updated donations page at the following link:") }}</p>
+
+<p><a href="{{ donations_url }}" style="{{ button_style('primary') }}">{{ _("View Donations Page") }}</a></p>

--- a/emails/donations_paused.spt
+++ b/emails/donations_paused.spt
@@ -1,16 +1,4 @@
-% if donations_paused
 {{ _("Liberapay donation paused") }}
-% else
-{{ _("Liberapay donation resumed") }}
-% endif
 
 [---] text/html
-% if donations_paused
-<p>{{ _("Due to changes recently made by {0}, your donations for {0} have been temporarily paused.", recipient) }}</p>
-% else
-<p>{{ _("Due to changes recently made by {0}, your donations for {0} are set to resume.", recipient) }}</p>
-% endif
-
-<p>{{ _("View your updated donations page at the following link:") }}</p>
-
-<p><a href="{{ donations_url }}" style="{{ button_style('primary') }}">{{ _("View Donations Page") }}</a></p>
+<p>{{ _("{0} has temporarily paused your donations to them.", recipient) }}</p>

--- a/emails/donations_resumed.spt
+++ b/emails/donations_resumed.spt
@@ -1,0 +1,4 @@
+{{ _("Liberapay donation resumed") }}
+
+[---] text/html
+<p>{{ _("{0} has resumed your donations to them.", recipient) }}</p>

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2334,8 +2334,9 @@ class Participant(Model, MixinTeam):
                 self.set_attributes(**r._asdict())
             if donations_paused or donations_resumed:
                 for tipper in tippers:
+                    event = 'donations_paused' if donations_paused else 'donations_resumed'
                     tipper.send_email(
-                        'donations_paused',
+                        event,
                         tipper.get_email(tipper.get_email_address()),
                         recipient=self.username,
                         donations_paused=donations_paused,

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -2309,16 +2309,19 @@ class Participant(Model, MixinTeam):
     def update_goal(self, goal, cursor=None):
         with self.db.get_cursor(cursor) as c:
             json = None if goal is None else str(goal)
+            donations_paused = goal == -2 and self.goal != -1
+            donations_resumed = goal != -1 and self.goal == -2
             self.add_event(c, 'set_goal', json)
             c.run("UPDATE participants SET goal=%s WHERE id=%s", (goal, self.id))
             self.set_attributes(goal=goal)
-            if not self.accepts_tips:
+            if not self.accepts_tips or donations_resumed:
                 tippers = c.all("""
                     SELECT p
                       FROM current_tips t
                       JOIN participants p ON p.id = t.tipper
                      WHERE t.tippee = %s
                 """, (self.id,))
+            if not self.accepts_tips:
                 for tipper in tippers:
                     tipper.update_giving(cursor=c)
                 r = c.one("""
@@ -2329,6 +2332,15 @@ class Participant(Model, MixinTeam):
                  RETURNING receiving, npatrons
                 """, (self.id,))
                 self.set_attributes(**r._asdict())
+            if donations_paused or donations_resumed:
+                for tipper in tippers:
+                    tipper.send_email(
+                        'donations_paused',
+                        tipper.get_email(tipper.get_email_address()),
+                        recipient=self.username,
+                        donations_paused=donations_paused,
+                        donations_url=tipper.url('giving/')
+                    )
 
     def update_status(self, status, cursor=None):
         with self.db.get_cursor(cursor) as c:

--- a/tests/py/test_goal.py
+++ b/tests/py/test_goal.py
@@ -1,5 +1,5 @@
 from liberapay.testing import EUR, Harness
-
+from liberapay.testing.emails import EmailHarness
 
 class Tests(Harness):
 
@@ -62,3 +62,35 @@ class Tests(Harness):
         )
         assert r.code == 302
         assert team.refetch().goal == EUR('99.99')
+
+class TestPauseDonations(EmailHarness):
+    def setUp(self):
+        EmailHarness.setUp(self)
+        self.alice = self.make_participant('alice', email='alice@example.com')
+
+    def change_goal(self, goal, goal_custom="", auth_as="alice", expect_success=False):
+        r = self.client.PxST(
+            "/alice/edit/goal",
+            {'goal': goal, 'goal_custom': goal_custom},
+            auth_as=self.alice if auth_as == 'alice' else auth_as
+        )
+        if expect_success and r.code >= 400:
+            raise r
+        return r
+
+    def test_pause(self):
+        bob = self.make_participant('bob', email='bob@example.com')
+        bob.set_tip_to(self.alice, EUR('0.99'), renewal_mode=2)
+        self.change_goal("-2", expect_success=True)
+
+        assert self.mailer.call_count == 1
+        last_email = self.get_last_email()
+        assert last_email['to'][0] == 'bob <bob@example.com>'
+        assert "paused" in last_email['text']
+
+        self.change_goal("null", "", expect_success=True)
+
+        assert self.mailer.call_count == 2
+        last_email = self.get_last_email()
+        assert last_email['to'][0] == 'bob <bob@example.com>'
+        assert "resume" in last_email['text']

--- a/www/%username/edit/goal.spt
+++ b/www/%username/edit/goal.spt
@@ -10,22 +10,25 @@ if request.method == "POST":
     elif goal == "custom":
         goal = request.body["goal_custom"]
         goal = locale.parse_money_amount(goal, participant.main_currency)
-        if not (goal > 0 or participant.is_person and goal.amount in (0, -1)):
+        if not (goal > 0 or participant.is_person and goal.amount in (0, -1, -2)):
             raise response.invalid_input(goal, 'goal_custom', 'body')
     else:
         goal = Money(request.body.get_int("goal"), participant.main_currency).round_down()
-        if not (goal > 0 or participant.is_person and goal.amount in (0, -1)):
+        if not (goal > 0 or participant.is_person and goal.amount in (0, -1, -2)):
             raise response.invalid_input(goal, 'goal', 'body')
-    participant.update_goal(goal)
+    if goal != participant.goal:
+        participant.update_goal(goal)
     form_post_success(state)
 
 if participant.kind == 'individual':
     GRATEFUL = _("I'm grateful for gifts, but don't have a specific funding goal.")
+    GRATEFUL_PAUSED_GIFTS = _("I'm grateful for gifts, but they are currently paused.")
     PATRON = _("I'm here as a patron.")
     PATRON_NO_GIFTS = _("I'm here as a patron, and politely decline to receive gifts.")
     GOAL_RAW = _("My goal is to receive {0}")
 else:
     GRATEFUL = _("We're grateful for gifts, but don't have a specific funding goal.")
+    GRATEFUL_PAUSED_GIFTS = _("We're grateful for gifts, but they are currently paused.")
     PATRON = _("We're here as a patron.")
     PATRON_NO_GIFTS = _("We're here as a patron, and politely decline to receive gifts.")
     GOAL_RAW = _("Our goal is to receive {0}")
@@ -68,6 +71,12 @@ subhead = _("Goal")
 
         % if participant.kind != 'group'
         <label>
+            <input type="radio" name="goal" id="goal-negative" value="-2"
+                   {{ 'checked' if participant.goal == -2 else '' }} />
+            {{ GRATEFUL_PAUSED_GIFTS }}
+        </label><br>
+
+        <label>
             <input type="radio" name="goal" id="goal-0" value="0"
                    {{ 'checked' if participant.goal == 0 else '' }} />
             {{ PATRON }}
@@ -75,7 +84,7 @@ subhead = _("Goal")
 
         <label>
             <input type="radio" name="goal" id="goal-negative" value="-1"
-                   {{ 'checked' if participant.goal and participant.goal < 0 else '' }} />
+                   {{ 'checked' if participant.goal == -1 else '' }} />
             {{ PATRON_NO_GIFTS }}
         </label>
         % endif

--- a/www/%username/edit/goal.spt
+++ b/www/%username/edit/goal.spt
@@ -71,7 +71,7 @@ subhead = _("Goal")
 
         % if participant.kind != 'group'
         <label>
-            <input type="radio" name="goal" id="goal-negative" value="-2"
+            <input type="radio" name="goal" id="goal--2" value="-2"
                    {{ 'checked' if participant.goal == -2 else '' }} />
             {{ GRATEFUL_PAUSED_GIFTS }}
         </label><br>
@@ -83,7 +83,7 @@ subhead = _("Goal")
         </label><br>
 
         <label>
-            <input type="radio" name="goal" id="goal-negative" value="-1"
+            <input type="radio" name="goal" id="goal--1" value="-1"
                    {{ 'checked' if participant.goal == -1 else '' }} />
             {{ PATRON_NO_GIFTS }}
         </label>

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -290,6 +290,10 @@ next_payday = compute_next_payday_date()
                     <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
                         "Inactive because the account of the recipient is closed."
                     ) }}</p>
+                % elif tippee.goal == -2
+                    <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
+                        "Inactive because the recipient's donations are temporarily paused."
+                    ) }}</p>
                 % elif not tippee.accepts_tips
                     <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
                         "Inactive because the recipient no longer accepts donations."

--- a/www/%username/giving/index.html.spt
+++ b/www/%username/giving/index.html.spt
@@ -291,8 +291,8 @@ next_payday = compute_next_payday_date()
                         "Inactive because the account of the recipient is closed."
                     ) }}</p>
                 % elif tippee.goal == -2
-                    <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(
-                        "Inactive because the recipient's donations are temporarily paused."
+                    <p class="text-info">{{ glyphicon('pause') }} {{ _(
+                        "This donation has been paused by the recipient."
                     ) }}</p>
                 % elif not tippee.accepts_tips
                     <p class="text-warning">{{ glyphicon('warning-sign') }} {{ _(


### PR DESCRIPTION
In username > edit > goal, there is an option to pause donations on individual accounts. When the pause option is selected, all patrons are notified of the pause (except if the previous goal was "I'm here as a patron, and politely decline to receive gifts. "). When the goal is updated to no longer be paused, all patrons are notified again (except if the new goal is "I'm here as a patron, and politely decline to receive gifts. ").

Closes #1745.