### PR TITLE
Resolving Issue #463: Income is not easily divisible

### DIFF
--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -11,7 +11,7 @@ from babel.dates import format_timedelta
 import mangopay
 import pando.utils
 import requests
-
+from liberapay.payin.common import resolve_amounts
 from liberapay import constants
 from liberapay.billing.transactions import Money, transfer
 from liberapay.exceptions import NegativeBalance
@@ -599,7 +599,7 @@ class Payday:
                     take.amount -= transfer_amount.convert(take.amount.currency)
                 if in_advance_amount:
                     tip.paid_in_advance -= in_advance_amount
-                    take.paid_in_advance -= in_advance_amount.convert(take.amount.currency)
+                    take.paid_in_advance -= in_advance_amount.convert(take.paid_in_advance.currency)
                 if on_time_amount:
                     tip.balances -= on_time_amount
                 tip.amount -= transfer_amount

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -469,12 +469,12 @@ class Payday:
         tip_currencies = set(t.full_amount.currency for t in tips)
         takes_by_preferred_currency = group_by(takes, lambda t: t.main_currency)
         takes_by_secondary_currency = {c: [] for c in tip_currencies}
-        if fuzzy_takes_sum:
-            takes_ratio = min(fuzzy_income_sum / fuzzy_takes_sum, 1)
-        else:
-            takes_ratio = 0
+        resolved_takes = resolve_amounts(min(fuzzy_income_sum, fuzzy_takes_sum), {take.member: take.amount.convert(fuzzy_income_sum.currency) for take in takes})
         for take in takes:
-            take.amount = (take.amount * takes_ratio).round_up()
+            if take.member in resolved_takes:
+              take.amount = resolved_takes[take.member]
+            else:
+              take.amount = Money(0, take.amount.currency)
             if take.paid_in_advance is None:
                 take.paid_in_advance = take.amount.zero()
             if take.accepted_currencies is None:

--- a/liberapay/billing/payday.py
+++ b/liberapay/billing/payday.py
@@ -11,11 +11,12 @@ from babel.dates import format_timedelta
 import mangopay
 import pando.utils
 import requests
-from liberapay.payin.common import resolve_amounts
+
 from liberapay import constants
 from liberapay.billing.transactions import Money, transfer
 from liberapay.exceptions import NegativeBalance
 from liberapay.i18n.currencies import MoneyBasket
+from liberapay.payin.common import resolve_amounts
 from liberapay.utils import group_by
 from liberapay.website import website
 
@@ -469,12 +470,15 @@ class Payday:
         tip_currencies = set(t.full_amount.currency for t in tips)
         takes_by_preferred_currency = group_by(takes, lambda t: t.main_currency)
         takes_by_secondary_currency = {c: [] for c in tip_currencies}
-        resolved_takes = resolve_amounts(min(fuzzy_income_sum, fuzzy_takes_sum), {take.member: take.amount.convert(fuzzy_income_sum.currency) for take in takes})
+        resolved_takes = resolve_amounts(
+            min(fuzzy_income_sum, fuzzy_takes_sum),
+            {take.member: take.amount.convert(fuzzy_income_sum.currency) for take in takes}
+        )
         for take in takes:
             if take.member in resolved_takes:
-              take.amount = resolved_takes[take.member]
+                take.amount = resolved_takes[take.member]
             else:
-              take.amount = Money(0, take.amount.currency)
+                take.amount = Money(0, take.amount.currency)
             if take.paid_in_advance is None:
                 take.paid_in_advance = take.amount.zero()
             if take.accepted_currencies is None:

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -527,7 +527,7 @@ def resolve_amounts(available_amount, base_amounts, convergence_amounts=None):
 
     # Compute the prorated amounts
     base_sum = Money.sum(base_amounts.values(), amount_left.currency)
-     base_ratio = 0
+    base_ratio = 0
 
     if base_sum != 0:
         base_ratio = amount_left / base_sum 
@@ -547,7 +547,7 @@ def resolve_amounts(available_amount, base_amounts, convergence_amounts=None):
             base_amount = base_amounts[key] * base_ratio
             return (current_amount - base_amount) / base_amount
 
-         count = 0
+        count = 0
 
         for check_priority in r.items():
             if count == 0:

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -530,7 +530,7 @@ def resolve_amounts(available_amount, base_amounts, convergence_amounts=None):
     base_ratio = 0
 
     if base_sum != 0:
-        base_ratio = amount_left / base_sum 
+        base_ratio = amount_left / base_sum
     for key, base_amount in sorted(base_amounts.items()):
         if base_amount == 0:
             continue
@@ -551,13 +551,13 @@ def resolve_amounts(available_amount, base_amounts, convergence_amounts=None):
 
         for check_priority in r.items():
             if count == 0:
-               comparator = compute_priority(check_priority)
-               count += 1
+                comparator = compute_priority(check_priority)
+                count += 1
             elif comparator == compute_priority(check_priority):
                 count += 1
 
-        # If everyone has the same priority & there is only 0.01 to distribute, then randomly select 
-        if count == len(r) and amount_left == 0.01: 
+        # If everyone has the same priority & there is only 0.01 to distribute, then randomly select
+        if count == len(r) and amount_left == 0.01:
             shuffle_keys = list(r.keys())
             random.shuffle(shuffle_keys)
 
@@ -572,7 +572,6 @@ def resolve_amounts(available_amount, base_amounts, convergence_amounts=None):
                 amount_left -= min_transfer_amount
                 if amount_left == 0:
                     break
-        
 
     # Final check and return
     assert amount_left == 0, '%r != 0' % amount_left

--- a/tests/py/test_payday.py
+++ b/tests/py/test_payday.py
@@ -493,11 +493,11 @@ class TestPaydayForTeams(FakeTransfersHarness):
         This tests the payment to teams with a nondivisible income (with respect to the number of team members):
             - creates a team of 7 people
             - has a total income of 0.85 euros/week
-            - each member of the team would like to have an income of 1 euro 
-            - each participant will 0.12 euros except 1 participant will have 0.13 euros 
-            - team should have a leftover of 0.00 euros after each week 
+            - each member of the team would like to have an income of 1 euro
+            - each participant will 0.12 euros except 1 participant will have 0.13 euross
+            - team should have a leftover of 0.00 euros after each week
         """
-        team = self.make_participant('team', kind = 'group')
+        team = self.make_participant('team', kind='group')
         charlie = self.make_participant('charlie', balance=EUR(1000))
         charlie.set_tip_to(team, EUR('0.85'))
 


### PR DESCRIPTION
**Problem:** As described in issue 463, previously, incorrect rounding could lead to one single team member getting a significantly different amount each week. 

**Solution:** We changed a call (within resolve_takes) to resolve_amounts to generally better distribute takes. We also made a specific if statement that checks for the specific case described in the original issue report and randomly selects a team member to get one single extra cent each week. 
The random selection required importing the random library and adding a large section of code in resolve_amounts. An alternative solution could be giving the same team member one extra cent every week. This is still an improvement on the original problem as the net difference between takes is only the minimum currency value(i.e. one cent). Let us know in reviews if this non randomized version is a preferred solution. 

**Overview of changes:** Added test in test_payday, added call in payday.py, changed values in resolve_takes to match currencies, randomized extra cent distribution in resolve_amounts