### PR TITLE
Improve the handling of problematic accounts — part 2

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -440,8 +440,6 @@ PRIVACY_FIELDS_S = ' '.join(PRIVACY_FIELDS.keys())
 PRIVILEGES = dict(admin=1, run_payday=2)
 check_bits(list(PRIVILEGES.values()))
 
-PROFILE_VISIBILITY_ATTRS = ('profile_noindex', 'hide_from_lists', 'hide_from_search')
-
 PUBLIC_NAME_MAX_SIZE = 64
 
 QUARANTINE = timedelta(weeks=0)

--- a/liberapay/utils/__init__.py
+++ b/liberapay/utils/__init__.py
@@ -79,14 +79,15 @@ def get_participant(state, restrict=True, redirect_stub=True, allow_member=False
             canon = '/' + participant.username + request.line.uri.decoded[len(slug)+1:]
             raise response.redirect(canon)
 
-    if (restrict or participant.is_spam) and participant != user:
+    is_spam = participant.marked_as == 'spam'
+    if (restrict or is_spam) and participant != user:
         if allow_member and participant.kind == 'group' and user.member_of(participant):
             pass
         elif user.is_admin:
             log_admin_request(user, participant, request)
         elif restrict:
             raise response.error(403, _("You are not authorized to access this page."))
-        elif participant.is_spam:
+        elif is_spam:
             raise response.render('simplates/spam-profile.spt', state)
 
     status = participant.status
@@ -126,7 +127,8 @@ def get_community(state, restrict=False):
     elif user.ANON:
         raise AuthRequired
 
-    if (restrict or c.participant.is_spam):
+    is_spam = c.participant.marked_as == 'spam'
+    if (restrict or is_spam):
         if user.id == c.creator:
             pass
         elif user.is_admin:
@@ -137,7 +139,7 @@ def get_community(state, restrict=False):
             else:
                 _ = state['_']
                 raise response.error(403, _("You are not authorized to access this page."))
-        elif c.participant.is_spam:
+        elif is_spam:
             raise response.render('simplates/spam-profile.spt', state)
 
     return c

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,111 @@
+BEGIN;
+
+CREATE TYPE account_mark AS ENUM (
+    'trusted', 'okay', 'unsettling',
+    'controversial', 'irrelevant', 'misleading',
+    'spam', 'fraud'
+);
+
+ALTER TABLE participants
+    ADD COLUMN marked_as account_mark,
+    ADD COLUMN is_unsettling int NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION update_profile_visibility() RETURNS trigger AS $$
+    BEGIN
+        IF (NEW.marked_as IS NULL) THEN
+            RETURN NEW;
+        END IF;
+        IF (NEW.marked_as = 'trusted') THEN
+            NEW.is_suspended = false;
+        ELSIF (NEW.marked_as IN ('fraud', 'spam')) THEN
+            NEW.is_suspended = true;
+        ELSE
+            NEW.is_suspended = null;
+        END IF;
+        IF (NEW.marked_as = 'unsettling') THEN
+            NEW.is_unsettling = NEW.is_unsettling | 2;
+        ELSE
+            NEW.is_unsettling = NEW.is_unsettling & 2147483645;
+        END IF;
+        IF (NEW.marked_as IN ('okay', 'trusted')) THEN
+            NEW.profile_noindex = NEW.profile_noindex & 2147483645;
+            NEW.hide_from_lists = NEW.hide_from_lists & 2147483645;
+            NEW.hide_from_search = NEW.hide_from_search & 2147483645;
+        ELSIF (NEW.marked_as = 'unsettling') THEN
+            NEW.profile_noindex = NEW.profile_noindex | 2;
+            NEW.hide_from_lists = NEW.hide_from_lists & 2147483645;
+            NEW.hide_from_search = NEW.hide_from_search & 2147483645;
+        ELSE
+            NEW.profile_noindex = NEW.profile_noindex | 2;
+            NEW.hide_from_lists = NEW.hide_from_lists | 2;
+            NEW.hide_from_search = NEW.hide_from_search | 2;
+        END IF;
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+END;
+
+SELECT 'after deployment';
+
+BEGIN;
+
+UPDATE participants
+   SET marked_as = 'spam'
+ WHERE is_spam
+   AND marked_as IS NULL;
+UPDATE participants
+   SET marked_as = 'controversial'
+ WHERE is_controversial
+   AND marked_as IS NULL;
+UPDATE participants
+   SET marked_as = 'trusted'
+ WHERE is_suspended IS FALSE
+   AND marked_as IS NULL;
+
+ALTER TABLE participants
+    DROP COLUMN is_controversial,
+    DROP COLUMN is_spam;
+
+-- Repair some of the damage caused by #1993
+WITH _events AS (
+    SELECT DISTINCT ON (e.participant)
+           e.participant
+         , ( CASE WHEN e.payload->>'profile_noindex' = 'true'
+                  THEN p.profile_noindex | 2
+                  ELSE p.profile_noindex & 2147483645
+             END
+           ) AS profile_noindex
+         , ( CASE WHEN e.payload->>'hide_from_lists' = 'true'
+                  THEN p.hide_from_lists | 2
+                  ELSE p.hide_from_lists & 2147483645
+             END
+           ) AS hide_from_lists
+         , ( CASE WHEN e.payload->>'hide_from_search' = 'true'
+                  THEN p.hide_from_search | 2
+                  ELSE p.hide_from_search & 2147483645
+             END
+           ) AS hide_from_search
+      FROM events e
+      JOIN participants p ON p.id = e.participant
+     WHERE e.type = 'visibility_override'
+  ORDER BY e.participant, e.ts DESC
+)
+UPDATE participants p
+   SET profile_noindex = e.profile_noindex
+     , hide_from_lists = e.hide_from_lists
+     , hide_from_search = e.hide_from_search
+  FROM _events e
+ WHERE e.participant = p.id
+   AND p.marked_as IS NULL
+   AND ( p.profile_noindex <> e.profile_noindex OR
+         p.hide_from_lists <> e.hide_from_lists OR
+         p.hide_from_search <> e.hide_from_search
+       );
+
+UPDATE participants
+   SET marked_as = 'okay'
+ WHERE profile_noindex < 2
+   AND marked_as IS NULL;
+
+END;

--- a/style/base/columns.scss
+++ b/style/base/columns.scss
@@ -1,12 +1,12 @@
 @media (min-width: $screen-sm-min) {
     .columns-sm-2 {
         column-count: 2;
-        column-gap: 10px;
+        column-gap: 2ex;
     }
 }
 @media (min-width: $screen-md-min) {
     .columns-md-3 {
         column-count: 3;
-        column-gap: 10px;
+        column-gap: 2ex;
     }
 }

--- a/style/base/forms.scss
+++ b/style/base/forms.scss
@@ -74,10 +74,15 @@ label:not([for]) {
 
 .block-labels label {
     display: block;
-    margin-bottom: 15px;
 }
-.block-labels.max-width-500 {
-    max-width: 500px;
+.block-labels-mb-4 label {
+    display: block;
+    margin-bottom: 1.5rem;
+}
+
+.inline-labels > label {
+    display: inline-block;
+    margin: 0 3ex 5px 0;
 }
 
 .btn-block + p {

--- a/style/base/utils.scss
+++ b/style/base/utils.scss
@@ -63,6 +63,10 @@
     flex-wrap: wrap;
 }
 
+.max-width-500 {
+    max-width: 500px;
+}
+
 @for $i from 0 through 100 {
     .width-#{$i} {
         width: $i * 1%;

--- a/templates/layouts/profile.html
+++ b/templates/layouts/profile.html
@@ -12,7 +12,7 @@
 <div class="container">
 <div class="row">
 <div class="col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
-    % if participant.is_spam
+    % if participant.marked_as == 'spam'
         <p class="alert alert-warning text-center">{{ _("This profile is marked as spam.") }}</p>
     % endif
     {% block profile_alternates %}{% endblock %}

--- a/templates/macros/admin.html
+++ b/templates/macros/admin.html
@@ -1,0 +1,59 @@
+% macro admin_form(p, reload=False, style='columns-sm-2 block-labels')
+    <form action="javascript:/admin/users" method="POST" class="js-submit"{% if reload %}
+          data-on-success="reload"{% endif %}>
+        <input type="hidden" name="p_id" value="{{ p.id }}">
+        <p>This account is…</p>
+        <div class="form-group {{ style }}">
+            <label class="text-success">
+                <input type="radio" name="mark_as" value="trusted" {{
+                       'checked' if p.marked_as == 'trusted' else '' }} />
+                trusted
+            </label>
+            <label class="text-info">
+                <input type="radio" name="mark_as" value="okay" {{
+                       'checked' if p.marked_as == 'okay' else '' }} />
+                okay
+            </label>
+            <label class="text-info">
+                <input type="radio" name="mark_as" value="unsettling" {{
+                       'checked' if p.marked_as == 'unsettling' else '' }} />
+                unsettling
+                % if p.is_unsettling.__and__(1)
+                &nbsp;
+                <span class="fa fa-check-circle" title="This account has been marked as unsettling by its owner."></span>
+                % endif
+            </label>
+            <label class="text-warning">
+                <input type="radio" name="mark_as" value="controversial" {{
+                       'checked' if p.marked_as == 'controversial' else '' }} />
+                controversial
+            </label>
+            <label class="text-warning">
+                <input type="radio" name="mark_as" value="irrelevant" {{
+                       'checked' if p.marked_as == 'irrelevant' else '' }} />
+                irrelevant
+            </label>
+            <label class="text-warning">
+                <input type="radio" name="mark_as" value="misleading" {{
+                       'checked' if p.marked_as == 'misleading' else '' }} />
+                misleading
+            </label>
+            <label class="text-danger">
+                <input type="radio" name="mark_as" value="spam" {{
+                       'checked' if p.marked_as == 'spam' else '' }} />
+                spam
+            </label>
+            <label class="text-danger">
+                <input type="radio" name="mark_as" value="fraud" {{
+                       'checked' if p.marked_as == 'fraud' else '' }} />
+                fraud
+            </label>
+        </div>
+        <label class="btn btn-default">
+            <input type="radio" class="out-of-sight" name="mark_as" value="" />
+            Unselect
+        </label>
+        &nbsp;&nbsp;
+        <button class="btn btn-warning">{{ _("Save") }}</button>
+    </form>
+% endmacro

--- a/templates/macros/identity.html
+++ b/templates/macros/identity.html
@@ -8,7 +8,7 @@
 
     % set required = 'required' if required else ''
 
-    <div class="block-labels max-width-500">
+    <div class="block-labels-mb-4 max-width-500">
 
     <h3>{{ _("Personal Information") }}</h3>
 

--- a/tests/py/test_communities.py
+++ b/tests/py/test_communities.py
@@ -24,7 +24,7 @@ class Tests(Harness):
         self.com.participant.upsert_statement('en', "spammy subtitle", 'subtitle')
         self.com.participant.upsert_statement('en', "spammy sidebar", 'sidebar')
         r = self.client.PxST(
-            '/admin/users', data={'p_id': str(self.com.participant.id), 'is_spam': 'yes'},
+            '/admin/users', data={'p_id': str(self.com.participant.id), 'mark_as': 'spam'},
             auth_as=admin,
         )
         assert r.code == 200

--- a/tests/py/test_cron.py
+++ b/tests/py/test_cron.py
@@ -131,13 +131,13 @@ class TestCronJobs(EmailHarness):
         assert not emails
         # Flag the accounts
         r = self.client.PxST(
-            '/admin/users', data={'p_id': str(fraudster.id), 'is_suspended': 'yes'},
+            '/admin/users', data={'p_id': str(fraudster.id), 'mark_as': 'fraud'},
             auth_as=admin,
         )
         assert r.code == 200
         assert json.loads(r.text) == {"msg": "Done, 1 attribute has been updated."}
         r = self.client.PxST(
-            '/admin/users', data={'p_id': str(spammer.id), 'is_spam': 'yes'},
+            '/admin/users', data={'p_id': str(spammer.id), 'mark_as': 'spam'},
             auth_as=admin,
         )
         assert r.code == 200

--- a/www/%username/admin.spt
+++ b/www/%username/admin.spt
@@ -20,66 +20,15 @@ events = website.db.all("""
 """, (participant.id,))
 
 [---] text/html
+% from 'templates/macros/admin.html' import admin_form with context
+
 % extends "templates/layouts/settings.html"
+
 % block content
 
 <h3>Admin flags</h3>
 
-<form action="javascript:/admin/users" method="POST" class="js-submit" data-on-success="reload">
-    <input type="hidden" name="p_id" value="{{ participant.id }}">
-    <div class="form-group">
-        Is this profile controversial?<br>
-        <label>
-            <input type="radio" name="is_controversial" value="yes" {{
-                   'checked' if participant.is_controversial == True else '' }} />
-            Yes, isolate it
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_controversial" value="no" {{
-                   'checked' if participant.is_controversial == False else '' }} />
-            No
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_controversial" value="null" />
-            Unsure
-        </label>
-    </div>
-    <div class="form-group">
-        Is this profile spam?<br>
-        <label>
-            <input type="radio" name="is_spam" value="yes" {{
-                   'checked' if participant.is_spam == True else '' }} />
-            Yes, hide it completely
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_spam" value="no" {{
-                   'checked' if participant.is_spam == False else '' }} />
-            No
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_spam" value="null" />
-            Unsure
-        </label>
-    </div>
-    <div class="form-group">
-        Is this account fraudulent?<br>
-        <label>
-            <input type="radio" name="is_suspended" value="yes" {{
-                   'checked' if participant.is_suspended == True else '' }} />
-            Yes, disable payments
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_suspended" value="no" {{
-                   'checked' if participant.is_suspended == False else '' }} />
-            No
-        </label> &nbsp;&nbsp;
-        <label>
-            <input type="radio" name="is_suspended" value="null" />
-            Unsure
-        </label>
-    </div>
-    <button class="btn btn-warning">{{ _("Save") }}</button>
-</form>
+{{ admin_form(participant, reload=True, style='inline-labels') }}
 
 <h3>Events</h3>
 

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -3,6 +3,17 @@
 
 from liberapay.utils import excerpt_intro, get_participant, markdown
 
+MARK_CLASSES = {
+    'trusted': 'text-success',
+    'okay': 'text-info',
+    'unsettling': 'text-info',
+    'controversial': 'text-warning',
+    'irrelevant': 'text-warning',
+    'misleading': 'text-warning',
+    'spam': 'text-danger',
+    'fraud': 'text-danger',
+}
+
 [-----------------------------------------------------------------------------]
 
 participant = get_participant(state, restrict=False)
@@ -85,9 +96,12 @@ show_income = not participant.hide_receiving and participant.accepts_tips
     <p><a href="{{ participant.path('edit') }}" class="btn btn-primary btn-lg">{{ _("Edit") }}</a></p>
 % endif
 % if user.is_admin
-    % set status = 'success' if not overrides else 'warning' if len(overrides) == 1 else 'danger'
     <p><a class="btn btn-default btn-lg" href="{{ participant.path('admin') }}">Admin</a></p>
-    <p>Current isolation level: {{ len(participant.get_active_overrides()) }}</p>
+    % if participant.marked_as
+    <p>Marked as: <span class="{{ MARK_CLASSES[participant.marked_as] }}">{{ participant.marked_as }}</span></p>
+    % else
+    <p class="text-muted">Not marked</p>
+    % endif
 % endif
 </div>
 % endif

--- a/www/admin/email-domains.spt
+++ b/www/admin/email-domains.spt
@@ -157,7 +157,7 @@ title = "Email Domains"
         <p>The domain <span class="monospace">{{ domain }}</span> is not blacklisted.</p>
     % endif
 
-    <form action="" method="POST" class="block-labels">
+    <form action="" method="POST" class="block-labels-mb-4">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     % if blacklisted
         <input type="hidden" name="action" value="remove_from_blacklist" />

--- a/www/admin/users.spt
+++ b/www/admin/users.spt
@@ -8,6 +8,8 @@ PT_STATUS_MAP = {
     'failed': 'danger',
     'pre': 'muted',
 }
+ACCOUNT_MARKS = set(website.db.one("SELECT array_to_json(enum_range(NULL::account_mark))"))
+ACCOUNT_MARKS.add('')
 
 [---]
 
@@ -22,20 +24,20 @@ if request.method == 'POST':
     p = Participant.from_id(request.body.get_int('p_id'))
     updated = 0
     with website.db.get_cursor() as cursor:
-        for attr in ('is_controversial', 'is_spam', 'is_suspended'):
-            if attr not in request.body:
-                continue
-            new_value = request.body.parse_ternary(attr)
+        if 'mark_as' in request.body:
+            new_value = request.body.get_choice('mark_as', ACCOUNT_MARKS)
+            if new_value == '':
+                new_value = None
             r = cursor.one("""
                 UPDATE participants
-                   SET {0} = %(new_value)s
+                   SET marked_as = %(new_value)s
                  WHERE id = %(p_id)s
-                   AND {0} IS NOT %(new_value)s
+                   AND coalesce(marked_as::text, '') <> %(new_value)s
              RETURNING id
-            """.format(attr), dict(p_id=p.id, new_value=new_value))
+            """, dict(p_id=p.id, new_value=new_value))
             if r:
                 updated += 1
-                event_data[attr] = new_value
+                event_data['marked_as'] = new_value
 
         if event_data:
             if request.body.get('reason'):
@@ -98,7 +100,7 @@ if mode == 'all':
                             FROM events e
                        LEFT JOIN participants p2 ON p2.id = e.recorder
                            WHERE e.participant = p.id
-                             AND e.type IN ('is_suspended', 'visibility_override')
+                             AND e.type IN ('is_suspended', 'visibility_override', 'flags_changed')
                         ORDER BY ts DESC
                            LIMIT 1
                         ) e
@@ -158,7 +160,7 @@ elif mode == 'new_recipients':
                             FROM events e
                        LEFT JOIN participants p2 ON p2.id = e.recorder
                            WHERE e.participant = p.id
-                             AND e.type IN ('is_suspended', 'visibility_override')
+                             AND e.type IN ('is_suspended', 'visibility_override', 'flags_changed')
                         ORDER BY ts DESC
                            LIMIT 1
                         ) e
@@ -181,7 +183,7 @@ elif mode == 'new_recipients':
           JOIN participants p ON p.id = pt.recipient
           JOIN participants payer ON payer.id = pt.payer
      LEFT JOIN participants team ON team.id = pt.team
-         WHERE p.is_suspended IS NULL
+         WHERE p.marked_as IS NULL
            AND pt.row_number <= 20
       GROUP BY p.id
         HAVING coalesce(min(pt.id) < %s, true)
@@ -195,6 +197,7 @@ else:
 title = "Users Admin"
 
 [---] text/html
+% from 'templates/macros/admin.html' import admin_form with context
 % from 'templates/macros/avatar-url.html' import avatar_img with context
 % from 'templates/macros/icons.html' import fontawesome, glyphicon
 % from 'templates/macros/nav.html' import querystring_nav with context
@@ -351,61 +354,7 @@ title = "Users Admin"
     % endif
     </div>
     <div class="col-md-4">
-        <form action="javascript:" method="POST" class="js-submit">
-            <input type="hidden" name="p_id" value="{{ p.id }}">
-            <div class="form-group">
-                Is this profile controversial?<br>
-                <label>
-                    <input type="radio" name="is_controversial" value="yes" {{
-                           'checked' if p.is_controversial == True else '' }} />
-                    Yes, isolate it
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_controversial" value="no" {{
-                           'checked' if p.is_controversial == False else '' }} />
-                    No
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_controversial" value="null" />
-                    Unsure
-                </label>
-            </div>
-            <div class="form-group">
-                Is this profile spam?<br>
-                <label>
-                    <input type="radio" name="is_spam" value="yes" {{
-                           'checked' if p.is_spam == True else '' }} />
-                    Yes, hide it completely
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_spam" value="no" {{
-                           'checked' if p.is_spam == False else '' }} />
-                    No
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_spam" value="null" />
-                    Unsure
-                </label>
-            </div>
-            <div class="form-group">
-                Is this account fraudulent?<br>
-                <label>
-                    <input type="radio" name="is_suspended" value="yes" {{
-                           'checked' if p.is_suspended == True else '' }} />
-                    Yes, disable payments
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_suspended" value="no" {{
-                           'checked' if p.is_suspended == False else '' }} />
-                    No
-                </label> &nbsp;&nbsp;
-                <label>
-                    <input type="radio" name="is_suspended" value="null" />
-                    Unsure
-                </label>
-            </div>
-            <button class="btn btn-warning">{{ _("Save") }}</button>
-        </form>
+        {{ admin_form(p) }}
         <br>
         % if row.last_change
         <span class="text-muted">{{ _(

--- a/www/for/%name/index.html.spt
+++ b/www/for/%name/index.html.spt
@@ -41,7 +41,7 @@ title = pretty_name = community.pretty_name
 {% block before_content %}{% endblock %}
 
 % block content
-% if participant.is_spam
+% if participant.marked_as == 'spam'
     <p class="alert alert-warning text-center">{{ _("This profile is marked as spam.") }}</p>
 % endif
 

--- a/www/for/new.spt
+++ b/www/for/new.spt
@@ -30,7 +30,7 @@ title = _("Start a new community")
 % extends "templates/layouts/panel.html"
 
 % block panel_body
-<form action="" class="block-labels" method="POST">
+<form action="" class="block-labels-mb-4" method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
 
     <label>

--- a/www/payment-providers/paypal/add.spt
+++ b/www/payment-providers/paypal/add.spt
@@ -55,7 +55,7 @@ title = _("Connecting a {platform} account", platform='PayPal')
 <form action="" method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <p>{{ _("Please input the email address and country of the PayPal account you want to connect:") }}</p>
-    <div class="form-group block-labels">
+    <div class="form-group block-labels-mb-4">
     <label>
         <span>{{ _("Email") }}</span>
         <input class="form-control" name="email" value="{{ participant.email or '' }}" required />


### PR DESCRIPTION
I quickly realized that #1993 was unsatisfactory once it was deployed in production, so I'm trying a different approach. This is what it looks like:

![Screenshot of a part of the admin interface showing the new account labels (“trusted”, “okay”, “unsettling”, “controversial”, “irrelevant”, “misleading”, “spam”, and “fraud”)](https://user-images.githubusercontent.com/1581590/118101982-7e683b00-b3d8-11eb-9064-e2abc987969b.png)