### PR TITLE
Fix team donations

### DIFF
--- a/liberapay/i18n/currencies.py
+++ b/liberapay/i18n/currencies.py
@@ -78,8 +78,14 @@ def _Money_parse(cls, amount_str, default_currency='EUR'):
     else:
         raise ValueError("%r is not a valid money amount" % amount_str)
 
-def _Money_round(self, rounding=ROUND_HALF_UP):
-    return Money(self.amount, self.currency, rounding=rounding)
+def _Money_round(self, rounding=ROUND_HALF_UP, allow_zero=True):
+    r = Money(self.amount, self.currency, rounding=rounding)
+    if not allow_zero:
+        if self.amount == 0:
+            raise ValueError("can't round zero away from zero")
+        if r.amount == 0:
+            return self.minimum() if self.amount > 0 else -self.minimum()
+    return r
 
 class _Minimums(defaultdict):
     def __missing__(self, currency):

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -757,7 +757,7 @@ class Participant(Model, MixinTeam):
                         for take in tip.takes:
                             resolved_amount = resolved_takes.get(take.member, zero)
                             if resolved_amount > 0:
-                                unit_amount = (resolved_amount / n_weeks).round_up()
+                                unit_amount = (resolved_amount / n_weeks).round(allow_zero=False)
                                 transfers.append(
                                     [take.member, None, resolved_amount, team_id, wallet, unit_amount]
                                 )
@@ -767,7 +767,7 @@ class Participant(Model, MixinTeam):
                         for take in tip.takes:
                             resolved_amount = take.resolved_amount
                             if resolved_amount > 0:
-                                unit_amount = (resolved_amount / n_weeks).round_up()
+                                unit_amount = (resolved_amount / n_weeks).round(allow_zero=False)
                                 transfers.append(
                                     [take.member, resolved_amount, None, team_id, wallet, unit_amount]
                                 )

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -441,7 +441,7 @@ def resolve_team_donation(
             if selected_takes:
                 resolve_take_amounts(payment_amount, selected_takes)
                 selected_takes.sort(key=attrgetter('member'))
-                n_periods = payment_amount / tip.periodic_amount
+                n_periods = payment_amount / tip.periodic_amount.convert(currency)
                 return [
                     ProtoTransfer(
                         t.resolved_amount,

--- a/liberapay/payin/common.py
+++ b/liberapay/payin/common.py
@@ -237,7 +237,7 @@ def adjust_payin_transfers(db, payin, net_amount):
                             updates.append((d.amount, pt.id))
                     n_periods = prorated_amount / tip.periodic_amount.convert(prorated_amount.currency)
                     for d in team_donations.values():
-                        unit_amount = (d.amount / n_periods).round_up()
+                        unit_amount = (d.amount / n_periods).round(allow_zero=False)
                         prepare_payin_transfer(
                             db, payin, d.recipient, d.destination, 'team-donation',
                             d.amount, unit_amount, tip.period,
@@ -448,7 +448,7 @@ def resolve_team_donation(
                         db.Participant.from_id(t.member),
                         sepa_accounts[t.member],
                         'team-donation',
-                        (t.resolved_amount / n_periods).round_up(),
+                        (t.resolved_amount / n_periods).round(allow_zero=False),
                         tip.period,
                         team.id,
                     )

--- a/liberapay/testing/__init__.py
+++ b/liberapay/testing/__init__.py
@@ -275,7 +275,7 @@ class Harness(unittest.TestCase):
         remote_id='fake', pt_extra={},
     ):
         payin, payin_transfers = self.make_payin_and_transfers(
-            route, amount, [(tippee, amount, pt_extra)],
+            route, amount, [(tippee, amount - (fee or 0), pt_extra)],
             status=status, error=error, payer_country=payer_country, fee=fee,
             remote_id=remote_id,
         )
@@ -292,7 +292,9 @@ class Harness(unittest.TestCase):
         payer = route.participant
         provider = route.network.split('-', 1)[0]
         proto_transfers = []
+        net_amount = 0
         for tippee, pt_amount, opt in transfers:
+            net_amount += pt_amount
             tip = opt.get('tip')
             if tip:
                 assert tip.tipper == payer.id
@@ -323,7 +325,6 @@ class Harness(unittest.TestCase):
         payin, payin_transfers = prepare_payin(self.db, payer, amount, route, proto_transfers)
         del proto_transfers
         payin = update_payin(self.db, payin.id, remote_id, status, error, fee=fee)
-        net_amount = payin.amount - (fee or 0)
         if len(payin_transfers) > 1:
             adjust_payin_transfers(self.db, payin, net_amount)
         else:

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -144,11 +144,11 @@ class TestResolveTeamDonation(Harness):
         assert len(payin_transfers) == 2
         assert payin_transfers[0].amount == EUR('5.43')
         assert payin_transfers[0].destination == stripe_account_bob.pk
-        assert payin_transfers[0].unit_amount == EUR('0.82')
+        assert payin_transfers[0].unit_amount == EUR('0.87')
         assert payin_transfers[0].n_units == 6
         assert payin_transfers[1].amount == EUR('0.87')
         assert payin_transfers[1].destination == stripe_account_carl.pk
-        assert payin_transfers[1].unit_amount == EUR('0.19')
+        assert payin_transfers[1].unit_amount == EUR('0.14')
         assert payin_transfers[1].n_units == 6
         # Check that this donation has balanced the takes.
         takes = {t.member: t for t in self.db.all("""
@@ -171,6 +171,16 @@ class TestResolveTeamDonation(Harness):
         assert payin_transfers[0].amount == EUR('1.00')
         assert payin_transfers[0].destination == stripe_account_bob.pk
         assert payin_transfers[1].amount == EUR('2.00')
+        assert payin_transfers[1].destination == stripe_account_carl.pk
+
+        # Test with a transfer currency different than the tip currency
+        payin, payin_transfers = self.make_payin_and_transfers(
+            alice_card, EUR('10.00'), [(team, USD('12.00'), {})],
+        )
+        assert len(payin_transfers) == 2
+        assert payin_transfers[0].amount == USD('4.01')
+        assert payin_transfers[0].destination == stripe_account_bob.pk
+        assert payin_transfers[1].amount == USD('7.99')
         assert payin_transfers[1].destination == stripe_account_carl.pk
 
 

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -144,7 +144,7 @@ class TestResolveTeamDonation(Harness):
         assert len(payin_transfers) == 2
         assert payin_transfers[0].amount == EUR('5.43')
         assert payin_transfers[0].destination == stripe_account_bob.pk
-        assert payin_transfers[0].unit_amount == EUR('0.87')
+        assert payin_transfers[0].unit_amount == EUR('0.86')
         assert payin_transfers[0].n_units == 6
         assert payin_transfers[1].amount == EUR('0.87')
         assert payin_transfers[1].destination == stripe_account_carl.pk

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -107,6 +107,11 @@ class TestResolveTeamDonation(Harness):
         account = self.resolve(team, 'paypal', alice, 'BR', EUR('5'))
         assert account == paypal_account_carl
 
+        # Test that self donation is avoided when there are two members
+        carl.set_tip_to(team, EUR('17.89'))
+        account = self.resolve(team, 'stripe', carl, 'FR', EUR('71.56'))
+        assert account == stripe_account_bob
+
         # Test with a suspended member
         self.db.run("UPDATE participants SET is_suspended = true WHERE id = %s", (carl.id,))
         account = self.resolve(team, 'stripe', alice, 'RU', EUR('7.70'))


### PR DESCRIPTION
This branch fixes a regression caused by #2056, and a small rounding mistake that probably dates back to the initial implementation of donating in advance through a team.