### PR TITLE
autofill elsewhere if we have a query

### DIFF
--- a/templates/macros/elsewhere.html
+++ b/templates/macros/elsewhere.html
@@ -61,7 +61,7 @@
 % macro user_lookup_form()
     <form action="/on/" class="form-group">
     <div class="form-inline">
-        <input name="user_name" placeholder="{{ _('username') }}" autocorrect="off"
+        <input name="user_name" placeholder="{{ _('username') }}" value="{{ query or '' }}" autocorrect="off"
                spellcheck="false" size="12" type="text" class="form-control">
         <select class="form-control" name="platform">
             % for platform in website.platforms.hasattr('x_user_name')


### PR DESCRIPTION
I just noticed that on the Search page, the query does not get repeated in the "Didn't find who you were looking for?" part, so you have to copy-paste it again.

This is a quick untested fix based on what I saw in the code base.

Could someone check it quickly?