### PR TITLE
[Language fix] Add commas after dependent clause (if)

### DIFF
--- a/emails/once/mangopay-exodus.spt
+++ b/emails/once/mangopay-exodus.spt
@@ -10,11 +10,11 @@ If you use Liberapay as a donor the first choice is recommended, especially if y
 
 For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.
 
-Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.
+Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.
 
 The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.
 
-If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.
+If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.
 
 We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.
 

--- a/emails/payin_sdd_created.spt
+++ b/emails/payin_sdd_created.spt
@@ -29,7 +29,7 @@
 ) }}</p>
 
 <p>{{ _(
-    "If you did not authorize this payment please let us know, we will refund it."
+    "If you did not authorize this payment, please let us know, we will refund it."
 ) }}</p>
 
 % if statement_descriptor is defined

--- a/i18n/core/ar.po
+++ b/i18n/core/ar.po
@@ -353,11 +353,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -517,7 +517,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1184,7 +1184,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2301,7 +2301,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3941,7 +3941,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4320,7 +4320,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5250,7 +5250,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5288,7 +5288,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ca.po
+++ b/i18n/core/ca.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Hem iniciat un càrrec per domiciliació de {money_amount} des del vostr
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Aquesta operació s'ha fet d'acord amb el {link_start}manament {mandate_id}{link_end} que vau signar en data {acceptance_date}, autoritzant al Liberapay (creditor SEPA {creditor_identifier}) a enviar instruccions al vostre banc per a carregar-vos al compte, i al vostre banc per a carregar al vostre compte segons aquestes instruccions."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Si no heu autoritzat aquest pagament, feu-nos-ho saber, i us el reemborsarem."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Ha fallat l'intent de distribuir tot els diners la vostra cartera ha fallat: {money_amount} romanent."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "L'intent d'enviar un correu a {email_address} ha fallat. Comproveu que l'adreça és vàlida i torneu a intentar-ho. Si el problema persisteix, contacteu amb support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "El document núm. {id} s'ha validat."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "S'ha rebutjat el document núm. {id}: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Si us cal assistència, podeu enviar un correu a support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Acceptar divises estrangeres pot augmentar els ingressos en convèncer persones d'altres països de fer-vos donatius, però els pagaments internacionals habitualment tenen un comissions més altes, i les fluctuacions en els tipus de canvi poden reduir l'estabilitat dels vostres ingressos."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe automàticament converteix els fons en la vostra divisa principal, però de forma predeterminada PayPal reté els pagaments en divises estrangeres, fins que indiqueu què ha de fer. Si teniu un compte Business de PayPal, podeu optar per convertir automàticament tots els pagaments en divises estrangeres a la vostra divisa principal. Aquesta opció es troba actualment en la pàgina «{link_open}Preferències per a rebre pagaments{link_close}»."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Retirada de diners"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "S'han pres {0} de la vostra cartera de Liberapay. Si la transferència es realitza correctament, arribaran {1} en el vostre compte bancari i es pagaran {2} en comissions."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "De forma predeterminada, les quantitats totals que doneu i que rebeu són públiques (podeu optar per deixar de compartir aquesta informació)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay és un projecte obert, podeu ajudar-nos {1}traduint-lo{0}, {2}millorant-ne el codi{0} i {3}administrant la seva entitat legal{0}. Si ho feu, podreu unir-vos a {4}l'equip Liberapay{0} i rebre una participació dels diners que els nostres usuaris reben per a mantenir el funcionament del servei."
 
 msgid "Why should you donate?"
@@ -5004,7 +5004,7 @@ msgid "Log In"
 msgstr "Inicia sessió"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "La recuperació de dades del vostre compte de {platform} ha fallat (codi d'error {x}). Si el problema persisteix, contacteu amb support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5041,7 +5041,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "donatius en curs (si el beneficiari encara no s'ha unit a Liberapay, es crearà un compromís)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "comptes d'altres llocs (p. ex. si el vostre compte de Twitter està connectat amb el compte de {platform}, també s'enllaçarà en Liberapay)"
 
 #, python-brace-format
@@ -5067,7 +5067,7 @@ msgstr "Introduïu una adreça de correu electrònic (el vostre compte de {platf
 msgid "Does this existing account belong to you?"
 msgstr "Aquest compte us pertany realment?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Si aquesta adreça us pertany, inicieu sessió abans de continuar:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/cs.po
+++ b/i18n/core/cs.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -496,7 +496,7 @@ msgstr "Z vašeho účtu ({partial_account_number}) jsme zahájili inkaso {money
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Pokud jste tuto platbu neautorizovali, dejte nám prosím vědět, vrátíme ji."
 
 #, python-brace-format
@@ -1151,7 +1151,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1989,7 +1989,7 @@ msgstr "Dokument #{id} byl ověřen."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} byl zamítnut: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Pokud potřebujete pomoc, můžete poslat e-mail na support@liberapay.com."
 
 msgid "Income Range"
@@ -2240,7 +2240,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3827,7 +3827,7 @@ msgid "Withdrawing Money"
 msgstr "Vybrat peníze"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} bylo převedeno z peněženky Liberapay. Pokud bude převod úspěšný, dostanete {1} na váš bankovní účet a {2} zaplatíte na poplatcích."
 
 #, python-brace-format
@@ -4201,7 +4201,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay je otevřený projekt, můžete nám pomoci {1}s překladem{0}, {2}vylepšit jeho kód{0} a {3}spravovat naši právní entitu{0}. Pokud tak učiníte, bude se moci přidat do týmu {4}Liberapay{0} a získat podíl z peněz, které naši uživatelé přispěli, aby služba běžela."
 
 msgid "Why should you donate?"
@@ -5052,7 +5052,7 @@ msgid "Log In"
 msgstr "Přihlásit se"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5089,7 +5089,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr "Patří vám tento existující účet?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/da.po
+++ b/i18n/core/da.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Vi har indledt en direkte debitering af {money_amount} fra din bankkonto
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Denne handling udføres baseret på {link_start}mandatet{mandate_id}{link_end} som du underskrev {acceptance_date}, og derved godkendte Liberapay (SEPA kreditor {creditor_identifier}) til at sende instruktioner til din bank for at debitere din konto og din bank at debitere din konto i overensstemmelse med disse instruktioner."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Hvis du ikke autoriserede denne betaling, så kontakt os og vi refunderer det."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Forsøget på at fordele alle pengene i din tegnebog mislykkedes: {money_amount} er tilbage."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Forsøget på at sende en email til {email_address} mislykkedes. Kontroller, at adressen er gyldig, og prøv igen. Hvis problemet fortsætter kontakt venligst support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokument #{id} er blevet valideret."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} er blevet afvist: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Hvis du har brug for hjælp, kan du sende en email til support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "At acceptere udenlandske valutaer kan øge din indkomst ved at overbevise folk i andre lande om at donere til dig, men internationale betalinger medfører normalt en højere procentdel af gebyrer, og svingninger i valutakurser kan mindske stabiliteten af din indkomst."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe konverterer automatisk penge til din hovedvaluta, men som standard tilbageholder PayPal betalinger i fremmed valuta, indtil du fortæller dem hvad der skal gøre. Hvis du har en PayPal-konto, kan du vælge at automatisk konvertere alle indgående betalinger i fremmed valuta til din hovedvaluta. Denne indstilling findes i øjeblikket på siden “{link_open}Præferencer for modtagelse af betalinger {link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Træk Penge Ud"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} er blevet hævet fra din Liberapay tegnebog. Hvis transaktionen er en succes vil {1} blive sat ind på din bankkonto og {2} vil blive betalt i gebyrer."
 
 #, python-brace-format
@@ -4179,7 +4179,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Som standard er det samlede beløb, du giver, og det samlede beløb, du modtager, offentligt (du kan vælge ikke at dele denne information)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay er et åbent projekt. Du kan hjælpe os med at {1}oversætte det{0}, {2}forbedre koden{0} og {3}hjælpe med det juridiske arbejde{0}. Hvis du gør det kan du deltage på {4}Liberapay teamet{0} og modtage en del af de penge, som vores brugere donerer for at holde tjenesten kørende."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Log ind"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Hentningen af dine konto data fra {platform} fejlede (fejl kode {x}). Hvis problemet fortsætter med at være der, kontakt support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "igangværende donationer (hvis donoren ikke har tilsluttet sig Liberapay, vil et donationstilbud i stedet blive oprettet)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "andre kontoer (d.v.s. hvis din Twitter-konto er forbundet til din {platform}-konto, vil den også blive linket til på Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Indsæt venligst en e-mail-adresse (din {platform}-konto har ikke en pri
 msgid "Does this existing account belong to you?"
 msgstr "Tilhører denne eksisterende konto dig?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Hvis denne adresse tilhører dig, skal du logge ind, inden du fortsætter:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/de.po
+++ b/i18n/core/de.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Wir haben eine direkte Abbuchung über {money_amount} von Ihrem Konto {p
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Diese Transaktion wird auf der Grundlage {link_start}des Mandats {mandate_id}{link_end} ausgeführt, das Sie am {acceptance_date} bestätigt haben. Dieses berechtigt Liberapay (SEPA-Gläubiger {creditor_identifier}) Ihr Konto mit Lastschriften gemäß diesen Anweisungen zu belasten."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Falls Sie diese Zahlung nicht veranlasst haben, lassen Sie es uns wissen. Wir werden sie zurückerstatten."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Der Versuch, Ihr gesamtes Guthaben in Ihrer Brieftasche zu verteilen, ist gescheitert: {money_amount} verbleiben."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Der Versuch, eine E-Mail an {email_address} zu senden, scheiterte. Überprüfen Sie, ob die Adresse stimmt und versuchen es erneut. Wenn das Problem weiterhin besteht, kontaktieren Sie bitte support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokument #{id} wurde bestätigt."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} wurde abgelehnt: {refused_reason_type} – {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Falls Sie Hilfe benötigen, schreiben Sie eine E-Mail an support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Wenn Sie ausländische Währungen akzeptieren, kann das Ihr Spendenaufkommen erhöhen, da Sie Menschen aus anderen Ländern überzeugen können, für Sie zu spenden. Jedoch führen internationale Zahlungen für gewöhnlich zu höheren Gebühren, und Wechselkursschwankungen können die Stabilität Ihres Spendenaufkommen verringern."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe wechselt Zahlung automatisch in Ihre Hauptwährung. PayPal behält Zahlungen in Fremdwährungen ein, bis Sie entscheiden, was mit diesen zu tun ist. Wenn Sie ein Geschäftskonto bei PayPal besitzen, dann werden eingehende Zahlungen automatisch getauscht. Die Einstellung befindet sich in der Seite „{link_open}Einstellungen zum Empfangen von Zahlungen{link_close}“."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3809,7 +3809,7 @@ msgid "Withdrawing Money"
 msgstr "Geld abheben"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} wurden aus Ihrer Liberapay-Brieftasche genommen. Wenn die Übertragung erfolgreich ist, werden davon {1} auf Ihrem Bankkonto landen, die restlichen {2} werden als Gebühren bezahlt."
 
 #, python-brace-format
@@ -4181,7 +4181,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Der gesamte Betrag, den Sie erhalten und spenden, wird unter der Standardeinstellung öffentlich angezeigt. Sie können diese Einstellung allerdings anpassen."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay ist ein offenes Projekt. Sie können uns helfen, es {1}zu übersetzen{0}, {2}seinen Code zu verbessern{0} oder {3}es zu verwalten{0}. Wenn Sie das tun, können Sie dem {4}Liberapay-Team{0} beitreten und erhalten einen Anteil des Geldes, das unsere Nutzer uns spenden, um den Service am Laufen zu halten."
 
 msgid "Why should you donate?"
@@ -5005,7 +5005,7 @@ msgid "Log In"
 msgstr "Anmelden"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Das Abholen Ihrer Accountdaten von {platform} ist fehlgeschlagen (Fehlercode {x}). Sollte das Problem weiterhin bestehen, wenden Sie sich bitte an support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5042,7 +5042,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "laufende Spenden (wenn der Spender noch nicht bei Liberapay registriert ist, wird stattdessen ein Versprechen erstellt)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "andere Accounts (z. B. wenn Ihr Twitter-Account mit Ihrem {platform} Account verbunden ist, wird dieser auch bei Liberapay verlinkt)"
 
 #, python-brace-format
@@ -5068,7 +5068,7 @@ msgstr "Bitte geben Sie eine E-Mail-Adresse an (Ihr {platform} Account hat keine
 msgid "Does this existing account belong to you?"
 msgstr "Gehört dieses Konto zu Ihnen?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Wenn diese Adresse zu Ihnen gehört, loggen Sie sich bitte ein, bevor Sie fortfahren:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/el.po
+++ b/i18n/core/el.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Έχουμε ξεκινήσει μια άμεση χρέωση των {m
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Αυτή η ενέργεια πραγματοποιείται με βάση την {link_start}εντολή {mandate_id}{link_end} που υπογράψατε την {acceptance_date}, επιτρέποντας στο Liberapay (πιστωτικό φορέα SEPA {creditor_identifier}) να στείλει οδηγίες στην τράπεζά σας για να χρεώσει το λογαριασμό σας και την τράπεζά σας να χρεώσει τον λογαριασμό σας σύμφωνα με αυτές τις οδηγίες."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Αν δεν εξουσιοδοτήσατε αυτήν την πληρωμή, παρακαλούμε να μας το πείτε, θα σας τα επιστρέψουμε."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Απέτυχε η προσπάθεια να κατανείμουμε όλα τα χρήματα στο πορτοφόλι σας: {money_amount} παραμένουν."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Απέτυχε η προσπάθεια για να στείλετε ένα μήνυμα ηλεκτρονικού ταχυδρομείου σε {email_address}. Παρακαλώ ελέγξτε ότι η διεύθυνση είναι έγκυρη και προσπαθήστε ξανά. Εάν το πρόβλημα παραμένει επικοινωνήστε με support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Το αρχείο #{id} έχει επικυρωθεί."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Το αρχείο #{id} έχει απορριφθεί: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Αν χρειάζεστε βοήθεια μπορείτε να στείλετε email στο support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Η αποδοχή ξένων νομισμάτων μπορεί να αυξήσει το εισόδημά σας πείθοντας ανθρώπους σε άλλες χώρες να σας κάνουν δωρεές, αλλά οι διεθνείς πληρωμές συνήθως συνεπάγονται υψηλότερο ποσοστό τελών και οι διακυμάνσεις στις συναλλαγματικές ισοτιμίες μπορούν να μειώσουν τη σταθερότητα του εισοδήματός σας."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Το Stripe μετατρέπει αυτόματα τα χρήματα στο κύριο συνάλλαγμά σας, αλλά από προεπιλογή το PayPal κρατά τις πληρωμές σε ξένα συναλλάγματα έως ότου το πείτε τι να κάνετε. Εάν έχετε λογαριασμό Business PayPal, μπορείτε να επιλέξετε να μετατρέπετε αυτόματα όλες τις εισερχόμενες πληρωμές σε ξένα συναλλάγματα στο κύριο συνάλλαγμά σας. Αυτή η επιλογή βρίσκεται επί του παρόντος στη σελίδα \"{link_open} Προτιμήσεις για τη λήψη πληρωμών {link_close}\"."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Απόσυρση χρημάτων"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4179,7 +4179,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5001,7 +5001,7 @@ msgid "Log In"
 msgstr "Σύνδεση"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Η ανάκτηση των δεδομένων του λογαριασμού σας από το {platform} απέτυχε (κωδικός σφάλματος {x}). Εάν το πρόβλημα εξακολουθεί να υφίσταται, επικοινωνήστε με το support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5038,7 +5038,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "συνεχείς δωρεές (αν ο δικαιούχος δεν έχει ενταχθεί ακόμα στο Liberapay, θα δημιουργηθεί μια υπόσχεση)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "λογαριασμούς αλλού (π.χ. αν ο λογαριασμός σας στο Twitter είναι συνδεδεμένος με τον {platform} λογαριασμό σας, θα είναι επίσης συνδεδεμένος στο Liberapay)"
 
 #, python-brace-format
@@ -5064,7 +5064,7 @@ msgstr "Εισαγάγετε μια διεύθυνση ηλεκτρονικού 
 msgid "Does this existing account belong to you?"
 msgstr "Σας ανήκει αυτός ο υπάρχων λογαριασμός;"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Εάν αυτή η διεύθυνση σας ανήκει, παρακαλούμε συνδεθείτε πριν συνεχίσετε:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/eo.po
+++ b/i18n/core/eo.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Ni ekigis rektan debeton de {money_amount} el vi bankokonto ({partial_ac
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Tiu operacio okazas surbaze de {link_start}la mandato {mandate_id}{link_end} kiun vi subskribis je la {acceptance_date}, rajtigante Liberapay (SEPA kreditoro {creditor_identifier}) al via banko sendi komandojn por debeti vian konton kaj rajtigante vian bankon debeti vian konton laŭ tiuj komandoj."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Se vi ne rajtigis ĉi tiun pagon, sciigu tion al ni, ni repagos ĝin."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "La provo distribui ĉian monon en vian monujon malsukcesis: {money_amount} restas."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "La provo sendi retmesaĝon al {email_address} malsukcesis. Bonvolu kontroli, ke la adreso estas valida kaj reprovu. Se la problemo daŭras, bonvolu kontakti support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokumento #{id} estis validigita."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokumento #{id} estis malakceptita: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Se vi bezonas helpon, vi povas sendi retmesaĝon al support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Akcepti fremdlandajn valutojn povas pliigi vian enspezon konvinkante alilandanoj donaci al vi, sed internaciaj pagoj ofte rezultas pli altan peradkoston, kaj ŝanĝoj de la kurzoj povas malstabiligi la stabilecon de via enspezo."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe aŭtomate konvertas monon al via ĉefa valuto, sed implicite PayPal retenas pagojn en fremdaj valutoj ĝis vi decidas kion fari. Se vi havas PayPal-an entreprenan konton vi povas elekti aŭtomate konverti ĉiujn alvenintajn fremdvalutajn pagojn al vi ĉefa valuto. Tiu elekteblo estas nun en la pago “{link_open}Agordoj for ricevi pagoj{link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Retirado de mono"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} estis prenita(j) el via Liberapay-monujo. Se la transdono estas sukcesa {1} iros al via bankokonto kaj {2} estos peradkostoj."
 
 #, python-brace-format
@@ -4179,7 +4179,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Implicite, la totala kvanto kiun vi donacas kaj la totala kvanto kiun vi ricevas estas publikaj (vi povas elekti la malon)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay estas malfermita projekto, vi povas helpi nin {1}traduki ĝin{0}, {2}plibonigi ĝian kodon{0} kaj {3}administri ĝian leĝan enton{0}. Se vi faras tion, vi povos aliĝi al {4}la teamo de Liberapay{0} kaj ricevi parton de la mono, kiun niaj uzantoj donacas por daŭrigi la servon."
 
 msgid "Why should you donate?"
@@ -5002,7 +5002,7 @@ msgid "Log In"
 msgstr "Ensaluti"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "La venigado de viaj kontdatumoj el {platform} malsukcesis (erarkodo {x}). Se la problemo daŭras bonvolu kontakti support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5039,7 +5039,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "nunaj donacadoj (se la ricevanto ankoraŭ ne aliĝis al Liberapay, promeso de donaco estos kreita)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "alilokaj kontoj (ekzemple, se via konto de Twitter estas konektita al via konto de {platform}, ĝi ankaŭ estos ligita en Liberapay)"
 
 #, python-brace-format
@@ -5065,7 +5065,7 @@ msgstr "Enigu retpoŝtadreson (via konto de {platform} ne havas ĉefan):"
 msgid "Does this existing account belong to you?"
 msgstr "Ĉu tiu ekzistanta konto apartenas al vi?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Se tiu adreso apartenas al vi, bonvolu ensaluti antaŭ ol daŭrigi:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/es.po
+++ b/i18n/core/es.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Hemos iniciado un pago domiciliado de {money_amount} desde tu cuenta ban
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Esta operación se está realizando basándose en {link_start}el mandato {mandate_id}{link_end} que firmaste el {acceptance_date}, autorizando a Liberapay (acreedor SEPA {creditor_identifier}) para enviar instrucciones a tu banco para adeudar tu cuenta, y a tu banco para adeudar tu cuenta de acuerdo con esas instrucciones."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Si no autorizaste este pago, háznoslo saber, lo devolveremos."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "El intento de distribuir todo el dinero en tu cartera falló: quedan {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "El intento de enviar un correo a {email_address} falló. Por favor, comprueba que la dirección es válida y vuélvelo a intentar. Si el problema persiste, contacta a support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "El documento n.º {id} ha sido validado."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "El documento n.º {id} ha sido rechazado: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Si necesitas asistencia, puedes mandar un mensaje a support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Aceptar monedas extranjeras puede aumentar tus ingresos al convencer a personas en otros países para que te donen, pero los pagos internacionales normalmente dan lugar a un mayor porcentaje en comisiones, y las fluctuaciones en los tipos de cambio pueden disminuir la estabilidad de tus ingresos."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe convierte automáticamente los fondos a tu moneda principal, pero Paypal mantiene por defecto los pagos en monedas extranjeras hasta que le dices qué hacer. Si tienes una cuenta Business de PayPal, puedes optar por convertir automáticamente todos los pagos entrantes en monedas extranjeras a tu moneda principal. Esta opción se encuentra actualmente en la página «{link_open}Preferencias para recibir pagos{link_close}»."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Retirar dinero"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} han sido tomados de tu cartera de Liberapay. Si la transferencia se realiza correctamente, {1} se ingresarán en tu cuenta bancaria y {2} serán pagados en tasas."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Por defecto, la cantidad total que das y la cantidad total que recibes son públicas (también puedes dejar de compartir esta información)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay es un proyecto abierto. Puedes ayudarnos a {1}traducirlo{0}, a {2}mejorar su código{0} y a {3}administrar su persona jurídica{0}. Si lo haces, podrás unirte al {4}equipo de Liberapay{0} y recibir una parte del dinero que nuestros usuarios donan para mantener el servicio en funcionamiento."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Acceder"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "La retirada de los datos de tu cuenta de {platform} ha fallado (código de error {x}). Si el problema persiste, contacta con support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "donaciones en curso (si el receptor no se ha unido a Liberapay aún, se creará una promesa en su lugar)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "cuentas en otros lugares (p. ej., si tu cuenta de Twitter está conectada a tu cuenta de {platform}, también será enlazada en Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Por favor, introduce una dirección de correo electrónico (tu cuenta de
 msgid "Does this existing account belong to you?"
 msgstr "¿Te pertenece esta cuenta existente?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Si esta dirección te pertenece, inicia sesión antes de continuar:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/et.po
+++ b/i18n/core/et.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -489,7 +489,7 @@ msgstr "Oleme kehtestanud mahaarvestuse summas {money_amount} sinu pangakontole 
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "See toiming põhineb teie poolt {acceptance_date} kuupäeval allkirjastatud {link_start}volikirjal {mandate_id}{link_end}, millega usaldate Librabay esindajat (SEPA võlausaldaja {creditor_identifier}) edastama oma pangale juhiseid enda konto depiteerimiseks ning oma pangale enda konto debiteerimiseks vastavalt samadele juhistele."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1140,7 +1140,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1968,7 +1968,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2218,7 +2218,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3786,7 +3786,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4157,7 +4157,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -4978,7 +4978,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5015,7 +5015,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5041,7 +5041,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/fi.po
+++ b/i18n/core/fi.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Olemme toimeenpanneet {money_amount} suoraveloituksen pankkitililtäsi (
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Tämä toimenpide perustuu {acceptance_date} allekirjoittamaasi {link_start}valtakirjaan {mandate_id}{link_end}, jossa valtuutit Liberapayn (SEPA-velkojatunnus {creditor_identifier}) lähettämään pankillesi toimeksiantoja tilisi veloittamisesta, sekä pankkisi veloittamaan tiliäsi näiden toimeksiantojen mukaan."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Jos et ole antanut lupaa tähän maksuun, kerro meille ja hyvitämme sen."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Yritys jaotella kaikki lompakossasi oleva raha epäonnistui; {money_amount} jäi jäljelle."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Sähköpostiosoite {email_address} ei tunnu toimivan. Tarkista, että osoite on kirjoitettu oikein. Jos ongelma ei selviä, ota yhteyttä: support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokumentti #{id} on hyväksytty."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokumentti #{id} on hylätty: {refused_reason_type} – {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Jos tarvitset apua, lähetä sähköpostia osoitteeseen support@liberapay.com (englanniksi)."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Vieraiden valuuttojen hyväksyminen saattaa lisätä tulojasi, kun muissa maissa asuvat voivat lahjoittaa sinulle, mutta kansainvälisissä lahjoituksissa on usein suuremmat prosentiaaliset kulut. Lisäksi valuuttakurssien heilahtelu voi heikentää tulojesi vakautta."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe muuntaa automaattisesti rahat päävaluutallesi, mutta PayPal oletuksena säilyttää maksut vieraissa valuutoissa siihen asti, kunnes määräät sille mitä tehdä. Jos sinulla on Business-tyyppinen PayPal-tili, voit valita saapuvien maksujen automaattisen muuntamisen päävaluutallesi. Tämä toiminto löytyy tällä hetkellä ”{link_open}Maksujen vastaanottamisen asetukset{link_close}” -sivulta."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Rahan nosto"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "Liberapay-lompakostasi on nostettu {0}. Jos siirto onnistuu, pankkitilillesi tupsahtaa {1} ja kuluihin menee {2}."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Oletuksena lahjoittamasi sekä vastaanottamasi rahasummat yhteensä ovat julkista tietoa, mutta voit muuttaa niiden näkyvyyden halutessasi."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay on avoin projekti. Voit auttaa sen {1}kääntämisessä{0}, {2}koodin parantamisessa{0}, tai {3}oikeushenkilön koordinoinnissa{0}. Jos teet niin, voit liittyä {4}Liberapay-ryhmään{0} ja saada osan rahasta, jota käyttäjämme lahjoittavat pitääkseen palvelun pystyssä."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Kirjaudu sisään"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Tilitietojesi noutaminen {platform}-palvelusta epäonnistui (ivrhekoodi {x}). Jos ongelma toistuu, ota yhteyttä: support@liberapay.com (englanniksi)."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "jatkuvaa lahjoitusta (jos kohde ei ole vielä liittynyt Liberapay-palveluun, tehdään lahjoituslupaus)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "muuta tiliä (esim. jos Twitter-tilisi on kytketty {platform}-tiliisi, se kytketään myös Liberapay-palvelussa)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Syötä sähköpostiosoitteesi (tunnuksesi {platform}-palvelussa ei sis�
 msgid "Does this existing account belong to you?"
 msgstr "Kuuluuko tämä olemassaoleva tili sinulle?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Jos osoite kuuluu sinulle, kirjaudu sisään ennen jatkamista:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/fr.po
+++ b/i18n/core/fr.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Nous avons initié un prélèvement bancaire de {money_amount} à partir
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Cette opération s'effectue sur la base du {link_start}mandat {mandate_id}{link_end} que vous avez signé le {acceptance_date}, autorisant Liberapay (créancier SEPA {creditor_identifier}) à envoyer des instructions à votre banque pour débiter votre compte et votre banque à débiter votre compte conformément à ces instructions."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Si vous n'avez pas autorisé ce paiement, veuillez nous le faire savoir, nous effectuerons un remboursement."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "La tentative de distribuer la totalité de l'argent contenu dans votre portefeuille a échoué : il reste {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "La tentative d'envoi d'un courriel à {email_address} a échoué. Veuillez vérifier que l'adresse est valide et réessayer. Si le problème persiste, veuillez contacter support@liberapay.com ."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Le document n°{id} a été validé."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Le document n°{id} a été rejeté : {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Si vous avez besoin d’aide vous pouvez envoyer un courriel à support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Accepter les devises étrangères peut augmenter votre revenu en convaincant des personnes dans d'autres pays de vous soutenir, cependant les paiements internationaux aboutissent généralement à un pourcentage de frais plus élevé, et les variations des taux de change peuvent diminuer la stabilité de votre revenu."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe convertit automatiquement les fonds reçus vers votre devise principale, mais par défaut PayPal retient les paiements en devises étrangères jusqu'à ce que vous lui indiquiez quoi faire. Si vous disposez d'un compte PayPal professionnel vous pouvez choisir de convertir automatiquement tous les paiements étrangers vers votre devise principale. Cette option se trouve actuellement dans la page « {link_open}Préférences de réception de paiements{link_close} »."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Retrait d'argent"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} ont été retirés de votre portefeuille Liberapay. Si le transfert abouti, {1} arriveront dans votre compte bancaire et {2} seront payés en frais de transaction."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Par défaut, le montant total que vous donnez et le montant total que vous recevez sont public (vous pouvez choisir de garder cette information privée)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay est un projet libre, vous pouvez le {1}traduire{0}, {2}améliorer son code{0}, ou faire partie de {3}son entité légale{0}. Si vous contribuez, vous pourrez rejoindre {4}l'équipe de Liberapay{0} et percevoir une partie de l'argent que nos utilisateurs nous donnent pour maintenir le service."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Se connecter"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "La récupération des informations du compte depuis {platform} a échouée (code d'erreur {x}). Si le problème persiste, merci de contacter support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "les dons en cours (si le bénéficiaire n'a pas encore rejoint Liberapay, une promesse de don sera créée)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "les comptes externes (par exemple si votre compte Twitter est connecté à votre compte {platform} il sera aussi lié dans Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Veuillez entrer une adresse électronique (votre compte {platform} n'a p
 msgid "Does this existing account belong to you?"
 msgstr "Ce compte vous appartient-il ?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Si cette adresse vous appartient, merci de vous connecter avant de continuer :"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/fy.po
+++ b/i18n/core/fy.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -489,7 +489,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1140,7 +1140,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1968,7 +1968,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2218,7 +2218,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3786,7 +3786,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4157,7 +4157,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -4980,7 +4980,7 @@ msgid "Log In"
 msgstr "Log yn"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5017,7 +5017,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5043,7 +5043,7 @@ msgstr "Graach in e-mailadres ynfiere (jo {platform} akkount hat gjin haad e-mai
 msgid "Does this existing account belong to you?"
 msgstr "Is dit besteande akkount fan jo?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "As dit adres fan jo is log dan yn foardat jo fierder geane:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ga.po
+++ b/i18n/core/ga.po
@@ -333,11 +333,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -497,7 +497,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Mura n-údaraigh tú an íocaíocht seo, cuir in iúl dúinn, déanfaimid aisíoc air."
 
 #, python-brace-format
@@ -1152,7 +1152,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2240,7 +2240,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3826,7 +3826,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4199,7 +4199,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5047,7 +5047,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5084,7 +5084,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5110,7 +5110,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/hu.po
+++ b/i18n/core/hu.po
@@ -318,11 +318,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -501,7 +501,7 @@ msgstr "Kezdeményeztünk egy {money_amount} összegű terhelést a bankszámlá
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Ez a művelet a(z) {link_start}{mandate_id} azonosítójú megbízás{link_end} alapján megy végbe, amelyet {acceptance_date} napján jóváhagyott, ezzel felhatalmazva a Liberapayt ({creditor_identifier} azonosítójú SEPA-hitelező) arra, hogy utasításokat küldjön a bankjának, hogy azoknak megfelelően terheljék meg a számláját."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Amennyiben nem Ön kezdeményezte ezt a fizetést, kérjük tudassa velünk, vissza fogjuk téríteni."
 
 #, python-brace-format
@@ -1148,7 +1148,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "A pénztárcájában lévő összes pénz elosztására tett kísérlet meghiúsult: {money_amount} maradt."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Nem sikerült e-mail-t küldeni a {email_address} címre. Ellenőrizze, hogy a cím érvényes-e, és próbálkozzon újra. Ha a probléma továbbra is fennáll, kérjük, hogy vegye fel velünk a kapcsolatot a support@liberapay.com e-mail címen."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1970,7 +1970,7 @@ msgstr "A(z) {id}. dokumentum hitelesítve lett."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "A(z) {id}. dokumentum vissza lett utasítva: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Ha segítségre van szüksége küldhet egy e-mail-t a support@liberapay.com címre."
 
 msgid "Income Range"
@@ -2219,7 +2219,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "A devizák elfogadása növelheti jövedelmét azáltal, hogy meggyőzhet más országokban élőket, hogy adományozzanak Önnek, de a nemzetközi fizetések általában magasabb díjakkal járnak, és az árfolyamok ingadozása csökkentheti a jövedelmének stabilitását."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "A Stripe automatikusan átváltja a pénzeket az Ön fő pénznemére, viszont a PayPal alapértelmezés szerint devizában tartja a befizetéseket, amíg meg nem mondja neki, mit tegyen. Ha rendelkezik üzleti PayPal fiókkal, akkor dönthet úgy, hogy az összes devizában beérkező befizetést automatikusan átváltja az Ön fő pénznemére. Ez a lehetőség jelenleg a „{link_open}Befizetések fogadására vonatkozó beállítások{link_close}” oldalon található."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3770,7 +3770,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4139,7 +4139,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -4933,7 +4933,7 @@ msgid "Log In"
 msgstr "Bejelentkezés"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -4970,7 +4970,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "folyamatban levő adományok (ha az adomány fogadója még nem csatlakozott a Liberapay-hez, akkor egy letét lesz helyette létrehozva)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "más helyeken levő fiókok (például, ha az Ön Twitter fiókja csatlakoztatva van az Ön {platform} fiókjához, akkor az is csatlakoztatva lesz a Liberapay-hez)"
 
 #, python-brace-format
@@ -4996,7 +4996,7 @@ msgstr "Kérjük, hogy adjon meg egy e-mail címet (az Ön {platform} fiókjána
 msgid "Does this existing account belong to you?"
 msgstr "Ez a meglévő fiók Önhöz tartozik?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Ha ez a cím az Öné, kérjük, hogy jelentkezzen be a folytatás előtt:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/id.po
+++ b/i18n/core/id.po
@@ -318,11 +318,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -501,7 +501,7 @@ msgstr "Kami telah memulai debit langsung {money_amount} dari rekening bank Anda
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Operasi ini dilakukan berdasarkan {link_start} mandat {mandate_id} {link_end} 3 yang Anda tanda tangani di {acceptance_date}, otorisasi Liberapay (kreditor SEPA {creditor_identifier}) untuk mengirim instruksi ke bank Anda untuk mendebit rekening Anda dan bank Anda untuk mendebit rekening Anda sesuai dengan instruksi tersebut."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Jika Anda tidak melakukan pembayaran ini tolong beri tahu kami, kami akan mengembalikannya."
 
 #, python-brace-format
@@ -1148,7 +1148,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Upaya untuk mendistribusikan semua uang di dompet anda gagal: {money_amount} tetap ada."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Upaya untuk mengirim email ke {email_address} 1 gagal. Periksa apakah alamatnya benar dan coba lagi. Jika masalah tetap ada, silakan hubungi support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1971,7 +1971,7 @@ msgstr "Dokumen #{id} telah tervalidasi."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokumen #{id} ditolak: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Jika anda membutuhkan bantuan anda dapat mengirim email ke support@liberapay.com."
 
 msgid "Income Range"
@@ -2220,7 +2220,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Menerima/menyetujui mata uang asing dapat meningkatkan penghasilan anda dengan meyakinkan orang-orang di negara lain untuk berdonasi kepada anda, tetapi pembayaran internasional biasanya menghasilkan persentase biaya yang lebih tinggi, dan fluktuasi nilai tukar dapat mengurangi stabilitas penghasilan anda."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe secara otomatis mengkonversi dana ke mata uang utama anda, tetapi secara standar PayPal menahan pembayaran dalam mata uang asing sampai anda memberi tahu apa yang harus dilakukan. Jika anda memiliki akun PayPal Bisnis, Anda dapat memilih untuk secara otomatis mengkonversi semua pembayaran yang masuk dalam mata uang asing ke mata uang utama anda. Opsi ini saat ini terletak di halaman “{link_open}Preferensi untuk menerima pembayaran {link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3772,7 +3772,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4141,7 +4141,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -4936,7 +4936,7 @@ msgid "Log In"
 msgstr "Masuk"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -4973,7 +4973,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/it.po
+++ b/i18n/core/it.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Abbiamo dato il via ad un addebito diretto di {money_amount} dal tuo con
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Questa operazione viene eseguita sulla base {link_start}del mandato{mandate_id}{link_end} che hai firmato il {acceptance_date}, autorizzando Liberapay (creditore SEPA{creditor_identifier}) ad inviare istruzioni alla tua banca per addebitare il tuo conto e alla tua banca di addebitare il tuo conto in base alle istruzioni fornite."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Se non hai autorizzato questo pagamento ti preghiamo di contattarci, ti verrà rimborsato."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Il tentativo di distribuire tutto il denaro nel tuo portafoglio è fallito: rimangono {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Il tentativo di inviare una e-mail a {email_address} è fallito. Per favore controlla che l'indirizzo sia valido e riprova. Se il problema persiste contatta support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Il documento n.{id} è stato validato."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Il documento n.{id} è stato rifiutato: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Se hai bisogno di aiuto puoi scrivere una e-mail a support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Accettare valute estere può aumentare le tue entrate convincendo persone di altri Paesi a donarti denaro, però effettuare pagamenti internazionali spesso richiede una percentuale maggiore di commissioni, e le fluttuazioni dei tassi di cambio possono diminuire la stabilità dei tuoi guadagni."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe converte automaticamente i fondi nella tua valuta principale, ma per impostazione predefinita PayPal effettua i pagamenti nelle valute estere finché non indichi esplicitamente cosa fare. Se possiedi un conto Business di PayPal puoi scegliere di convertire automaticamente tutti i pagamenti in entrata effettuati in valute estere nella tua valuta principale. Questa opzione al momento si trova nella pagina “{link_open}Preferenze di ricezione dei pagamenti{link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Ritira denaro"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "Sono stati prelevati {0} dal tuo conto Liberapay. Se il trasferimento andrà a buon fine {1} arriveranno sul tuo conto bancario e {2} saranno pagati come commissione."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Per impostazione predefinita, le somme totali di quanto doni e quanto ricevi sono pubbliche (puoi decidere di non condividere queste informazioni)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay è un progetto aperto, puoi aiutarci a {1} tradurlo{0}, {2}migliorare il codice sorgente{0} e {3}gestire la sua entità giuridica{0}. Se lo fai potresti unirti {4}alla squadra Liberapay{0} e ricevere una parte del denaro che i nostri utenti donano per mantenere attivo il servizio."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Accedi"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Il recupero dei dati del tuo conto da {platform} non è riuscito (codice errore {x}). Se il problema persiste per favore contatta support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "donazioni in corso (se il/la destinatario/a non si è ancora unito/a a Liberapay, sarà sottoscritto un impegno a donare)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "profili di altro tipo (per esempio se il tuo profilo Twitter è collegato al conto {platform} sarà anch'esso collegato a Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Per favore, inserisci un indirizzo e-mail (il tuo conto {platform} non n
 msgid "Does this existing account belong to you?"
 msgstr "Questo conto esistente ti appartiene?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Se l'indirizzo ti appartiene esegui l'accesso prima di continuare:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ja.po
+++ b/i18n/core/ja.po
@@ -318,11 +318,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -501,7 +501,7 @@ msgstr "お使いの銀行口座（{partial_account_number}）からの {money_a
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "この操作は、あなたが {acceptance_date} にサインした{link_start}委任 {mandate_id}{link_end}にもとづいて実行され、あなたの口座から引き落とす指示をLiberapay（SEPA 債権者 {creditor_identifier}）があなたの銀行に送信すること、その指示に従ってあなたの銀行があなたの口座から引き落とすことを承認します。"
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "この支払いを承認していない場合はお知らせください。返金いたします。"
 
 #, python-brace-format
@@ -1148,7 +1148,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "ウォレットのすべての金銭を分配できませんでした：{money_amount} が残っています。"
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "{email_address} へのメールの送信に失敗しました。メールアドレスが正しいことを確認し、再試行してください。問題が解決しない場合は、support@liberapay.com までお問い合わせください。"
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1970,7 +1970,7 @@ msgstr "ドキュメント #{id} は確認されました。"
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "ドキュメント #{id} は拒否されました：{refused_reason_type} - {refused_reason_message}。"
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "支援が必要な場合は、support@liberapay.com にメールをお送りいただけます。"
 
 msgid "Income Range"
@@ -2219,7 +2219,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "外貨を承認することで、あなたに寄付するよう他国の人々を説得することが容易になり、収入を増やすことができます。ただし、国をまたいだ支払いは手数料が高くなることが多く、また、為替レートの変動はあなたの収入の安定性を低下させる可能性があります。"
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe は自動的にあなたのメインの通貨に資金を両替します。一方、PayPal はデフォルトでは、あなたの指示があるまで、外貨での支払いを保留します。ビジネス PayPal アカウントをお持ちの場合には、外貨でのすべての入金を自動的にメインの通貨に両替することを選択できます。このオプションは現在 {link_open}Preferences for receiving payments{link_close} ページにあります。"
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3773,7 +3773,7 @@ msgid "Withdrawing Money"
 msgstr "出金"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0}がLiberapayウォレットから引き落とされます。成功した場合、{1}は銀行口座に入金され、{2}は手数料として徴収されます。"
 
 #, python-brace-format
@@ -4143,7 +4143,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "デフォルトでは、寄付した合計金額と受け取った合計金額は公開されます（この情報の共有をオプトアウトすることができます）。"
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay はオープンソースのプロジェクトです。誰でも{1}翻訳{0}、{2}コードの向上{0}、{3}法人の管理{0}の手伝いをすることができます。これらの作業をすると、{4}Liberapay チーム{0}に参加して、サービスを維持するためにユーザーの皆さんが寄付してくださったお金の分け前を受け取ることができます。"
 
 msgid "Why should you donate?"
@@ -4940,7 +4940,7 @@ msgid "Log In"
 msgstr "ログイン"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "{platform} からのアカウントデータの取得に失敗しました（エラーコード {x}）。この問題が再発する場合は、support@liberapay.com までお問い合わせください。"
 
 msgid "Migrating from Gratipay"
@@ -4977,7 +4977,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "現在進行中の寄付（受贈者が Liberapay に参加していない場合、代わりに担保が作成されます）"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "その他のアカウント（例えば、お使いの Twitter アカウントが {platform} アカウントと連携されている場合、Liberapay とも連携されます）"
 
 #, python-brace-format
@@ -5003,7 +5003,7 @@ msgstr "メールアドレスを入力してください（お使いの {platfor
 msgid "Does this existing account belong to you?"
 msgstr "この存在するアカウントはあなたのものですか？"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "このアドレスがあなたのものである場合、続行する前にログインしてください："
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ko.po
+++ b/i18n/core/ko.po
@@ -318,11 +318,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -501,7 +501,7 @@ msgstr "귀하의 은행 계좌({partial_account_number})에서 직접 {money_am
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "이 작업은 {acceptance_date} 에 귀하가 Liberapay (SEPA 대행자: {creditor_identifier})가 하기 지시에 따라 귀하의 은행에 자금을 이체하도록 {link_start}허가 {mandate_id}{link_end}한 데 따른 것입니다."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "혹시 이 지불을 승인하지 않았다면 알려 주십시오. 환불해 드리겠습니다."
 
 #, python-brace-format
@@ -1148,7 +1148,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "지갑의 모든 돈을 소비하려는 시도가 실패했습니다: {money_amount} 만큼이 남았습니다."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "{email_address} 로 이메일을 보낼 수 없습니다. 이메일이 유효한 지 다시 확인한 후 다시 시도해 주세요. 문제가 지속된다면 support@liberapay.com 으로 이메일을 보내 주세요."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1968,7 +1968,7 @@ msgstr "문서 #{id} 이(가) 승인되었습니다."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "문서 #{id} 이(가) 거부되었습니다: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "도움이 필요하다면 support@liberapay.com 으로 이메일을 보낼 수 있습니다."
 
 msgid "Income Range"
@@ -2217,7 +2217,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "외환 기부를 승인하면 다른 국가에 거주하는 사람들이 기부할 수 있도록 함으로써 수익을 늘릴 수 있지만, 국제 거래는 일반적으로 수수료가 더 많이 들며, 환율의 변화에 따라 금액이 증감하므로 수입의 안정성이 줄어들 수 있습니다."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe는 외환을 자동적으로 주 화폐로 환전하지만, PayPal은 사용자가 자금을 어떻게 처리할 지 지시할 때까지 지불을 유예합니다. 비즈니스 PayPal 계정을 가지고 있다면 자동적으로 주 화폐로 환전하도록 선택할 수 있습니다. 이 옵션은 현재 \"{link_open}Preferences for receiving payments{link_close}\"에 있습니다."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3768,7 +3768,7 @@ msgid "Withdrawing Money"
 msgstr "자금 인출"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} 만큼이 Liberapay 계좌에서 출금되었습니다. 이체가 성공적이라면 {1} 이(가) 은행 계좌에 도착할 것이고 {2} 은(는) 수수료로 지불될 것입니다."
 
 #, python-brace-format
@@ -4137,7 +4137,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay는 열린 프로젝트이며, {1}번역을 돕거나{0}, {2}코드를 발전시키거나{0}, {3}법인 운영에 참여{0}할 수 있습니다. 이러한 일을 통해 {4}Liberapay 팀에 가입{0}할 수 있으며, 서비스를 운영하기 위해 사용자가 Liberapay에 기부하는 금액의 일부를 수령할 수 있습니다."
 
 msgid "Why should you donate?"
@@ -4931,7 +4931,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -4968,7 +4968,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/lt.po
+++ b/i18n/core/lt.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -496,7 +496,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1151,7 +1151,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2238,7 +2238,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3825,7 +3825,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4198,7 +4198,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5046,7 +5046,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5083,7 +5083,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5109,7 +5109,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/lv.po
+++ b/i18n/core/lv.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -496,7 +496,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1151,7 +1151,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2238,7 +2238,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3824,7 +3824,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4197,7 +4197,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5045,7 +5045,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5082,7 +5082,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5108,7 +5108,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ms.po
+++ b/i18n/core/ms.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Kami telah memulakan debit terus sebanyak {money_amount} daripada akaun 
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Operasi ini sedang dijalankan berdasarkan {link_start}mandat {mandate_id}{link_end} yang anda tandatangan pada {acceptance_date}, membenarkan Liberapay (kreditor SEPA {creditor_identifier}) untuk menghantar arahan kepada bank anda untuk mendebitkan akaun anda dan untuk bank anda mendebitkan akaun anda mengikut arahan tersebut."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Jika anda tidak membenarkan pembayaran ini sila beritahu kami, kami akan memulangkannya semula."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Cubaan untuk mengagihkan kesemua wang dalam dompet anda gagal: kekal {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Cubaan untuk menghantar e-mel ke {email_address} telah gagal. Sila periksa semula dan pastikan ia sah sebelum cuba lagi. Jika masalah berlarutan, sila hubungi support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokumen #{id} telah disahkan."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokumen #{id} telah ditolak: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Jika anda perlukan bantuan anda boleh hantar e-mel ke support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Menerima mata wang asing boleh meningkatkan kemungkinan pendapatan dengan meyakinkan orang di negara lain untuk menderma kepada anda, tetapi pembayaran antarabangsa selalunya menyebabkan caj dengan peratusan yang lebih tinggi, dan perbezaan tukaran mata wang boleh menjejaskan kestabilan pendapatan anda."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe akan menukarkan dana ke dalam mata wang utama anda secara automatik, tetapi PayPal selalunya pegang pembayaran dalam mata wang asing sehingga anda tetapkan apa hendak dibuat. Jika anda ada akaun Business PayPal, anda boleh pilih untuk tukarkan kesemua pembayaran akan datang ke mata wang utama anda secara automatik. Pilihan tersebut berada di halaman “{link_open}Keutamaan penerimaan pembayaran{link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Mengeluarkan Wang"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} telah diambil daripada dompet Liberapay anda. Jika pindahan berjaya, {1} akan masuk ke akaun bank anda dan {2} akan dibayar untuk caj perkhidmatan."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Secara lalainya, jumlah keseluruhan pemberian dan penerimaan anda ditunjukkan kepada orang awam (anda boleh menyembunyikannya)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay ialah projek terbuka, anda boleh membantu kami {1}menterjemahkannya{0}, {2}menambah baik kodnya{0}, dan {3}mengurus entiti sahnya{0}. Jika anda berbuat demikian, anda boleh sertai {4}kumpulan Liberapay{0} dan menerima sebahagian wang yang pengguna kami dermakan untuk mengekalkan perkhidmatan ini."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Log Masuk"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Proses mendapatkan data akaun anda dari {platform} telah gagal (kod ralat {x}). Jika masalah berlarutan sila hubungi support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "derma yang sedang berjalan (jika penerima derma masih belum sertai Liberapay maka perjanjian derma akan dicipta)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "akaun di tempat lain (cth. jika akaun Twitter anda dikaitkan kepada akaun {platform} anda maka ia juga akan dikaitkan di Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Sila masukkan alamat e-mel (akaun {platform} anda masih belum ada e-mel 
 msgid "Does this existing account belong to you?"
 msgstr "Adakah akaun sedia ada ini kepunyaan anda?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Jika alamat ini kepunyaan anda sila log masuk sebelum teruskan:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/nb.po
+++ b/i18n/core/nb.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -509,7 +509,7 @@ msgstr "En direkte debetbetaling på {money_amount} fra din bankkonto ({partial_
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Operasjonen blir utført basert på {link_start}mandatet{mandate_id}{link_end} du signerte {acceptance_date}, noe som lar Liberapay (SEPA-kreditor {creditor_identifier}) å sende instruks til din bank om debitering av din konto og din bank om å debitere din konto i henhold til disse instruksjonene."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Hvis du ikke vedkjenner deg denne betalingen, la det komme oss til kjenne, slik at den kan refunderes."
 
 #, python-brace-format
@@ -1160,7 +1160,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Forsøket på å distribuere alle pengene i lommeboken din mislyktes: {money_amount} gjenstår."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Forsøket på sende en e-post til {email_address} mislyktes. Sjekk adressens gyldighet og prøv igjen. Hvis problemet vedvarer, kontakt support@liberapay.com"
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1992,7 +1992,7 @@ msgstr "Dokument #{id} er bekreftet."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} har blitt avvist: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Hvis du trenger hjelp kan du sende en e-post til support@liberapay.com."
 
 msgid "Income Range"
@@ -2243,7 +2243,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Å akseptere utenlandsk valuta kan øke inntektene dine ved å overbevise folk i andre land til å gi deg, men internasjonale betalinger fører vanligvis til en høyere prosentandel av avgifter, og svingninger i valutakurser kan redusere stabiliteten i inntekten."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe konverterer automatisk midler til din lokale valuta, men som forvalg holder PayPal betalinger i utenlandske valutaer til du forteller dem hva som skal gjøres. Hvis du har en forretnings-PayPal-konto, kan du velge å automatisk konvertere alle innkommende betalinger i utenlandske valutaer til din hovedvaluta. Dette valget finnes for øyeblikket i «{link_open}Innstillinger for mottak av betalinger{link_close}»-siden."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3824,7 +3824,7 @@ msgid "Withdrawing Money"
 msgstr "Uttak av penger"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} ble hevet fra Liberapay-lommeboken din. Hvis transaksjonen lykkes blir {1} satt inn på bankkontoen din og {2} bli betalt i gebyrer."
 
 #, python-brace-format
@@ -4204,7 +4204,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Som forvalg er den totale mengden du gir og får offentlig (du kan derimot velge å ikke dele denne infoen)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay er et åpent prosjekt. Du kan hjelpe til ved å {1}oversette det{0}, {2}forbedre koden{0} og {3}hjelpe det juridiske arbeidet{0}. Hvis du gjør det kan du delta i {4}Liberapay-laget{0} og motta en del av pengene som brukerne donerer for å holde tjenesten i gang."
 
 msgid "Why should you donate?"
@@ -5049,7 +5049,7 @@ msgid "Log In"
 msgstr "Logg inn"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Innhenting av kontodata fra {platform} har mislyktes (feilkode {x}). Hvis problemet vedvarer, kontakt support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5087,7 +5087,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "pågående donasjoner (hvis mottageren ikke har opprettet konto på Liberapay enda, vil et donasjonstilbud bli opprettet i steden for)"
 
 #, fuzzy, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "kontoer annensteds hen (f.eks. hvis din Twitter-konto er tilknyttet din {platform}-konto, vil den også bli sammenlenket på Liberapay)"
 
 #, python-brace-format
@@ -5113,7 +5113,7 @@ msgstr "Oppgi en e-postadresse (din {platform}-konto har ikke en primær e-posta
 msgid "Does this existing account belong to you?"
 msgstr "Tilhører denne eksisterende kontoen deg?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Hvis adressen tilhører deg, logg inn før du fortsetter:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/nl.po
+++ b/i18n/core/nl.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "We hebben een automatische incasso van {money_amount} van uw bankrekenin
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Deze operatie wordt uitgevoerd op basis van {link_start}het mandaat {mandate_id}{link_end} dat u heeft ondertekend op {acceptance_date}, waarbij u Liberapay (SEPA-crediteur {creditor_identifier}) machtigt om instructies naar uw bank te sturen om uw rekening te debiteren en uw bank om uw rekening te debiteren in overeenstemming met deze instructies."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Als u geen toestemming heeft gegeven voor deze betaling, laat het ons weten, zodat wij het kunnen terugstorten."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "De poging om al het geld in uw portemonnee te verdelen mislukte: Er blijft {money_amount} over."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "De poging om een e-mail naar {email_address} te sturen is mislukt. Controleer of het adres geldig is en probeer het opnieuw. Als het probleem aanhoudt, kan u contact opnemen met support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Document #{id} is gevaliceerd."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Document #{id} is afgekeurd: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Als u hulp nodig heeft kan u een email sturen naar support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Het accepteren van vreemde valuta kan je inkomen verhogen door mensen in andere landen ervan te overtuigen om aan je te doneren, maar internationale betalingen resulteren meestal in een hoger percentage van de kosten en schommelingen in de wisselkoersen kunnen de stabiliteit van je inkomen verminderen."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe zet automatisch geld om in uw hoofdvaluta, maar PayPal houdt standaard betalingen in vreemde valuta vast totdat u vertelt wat ze ermee moeten doen. Als u een zakelijk PayPal-account heeft kan u ervoor kiezen om alle inkomende betalingen in vreemde valuta automatisch om te rekenen naar uw hoofdvaluta. Deze optie bevindt zich momenteel in de \"{link_open}Voorkeuren voor het ontvangen van betalingen{link_close}\"-pagina."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Geld opnemen"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} is opgenomen uit uw Liberapay-portemonnee. Als de overschrijving succesvol is zal {1} op uw bankrekening komen en {2} zal worden betaald als provisie."
 
 #, python-brace-format
@@ -4180,7 +4180,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Standaard is het totale bedrag dat je opgeeft en het totale bedrag dat je ontvangt openbaar (je kan je afmelden voor het delen van deze informatie)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay is een open project, u kunt ons helpen met {1}vertalen{0}, {2}verbetering van de code{0} en {3}het beheren van de juridische entiteit{0}. Als u dat doet kunt u deelnemen aan het {4}Liberapay-team{0} en ontvang u een deel van het geld dat onze sponsors doneren om de service in de lucht te houden."
 
 msgid "Why should you donate?"
@@ -5003,7 +5003,7 @@ msgid "Log In"
 msgstr "Log in"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Het ophalen van uw accountgegevens van {platform} is niet gelukt (foutcode {x}). Als het probleem blijft, neem dan contact op met support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5040,7 +5040,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "lopende donaties (indien de maker nog niet op Liberapay zit zal er een donatie toezegging worden gemaakt)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "andere accounts (als u bijvoorbeeld een Twitter-account hebt verbonden aan uw {platform}-account zal het ook worden gekoppeld aan Liberapay)"
 
 #, python-brace-format
@@ -5066,7 +5066,7 @@ msgstr "Vul uw e-mailadres in (uw {platform}-account heeft geen primair e-mailad
 msgid "Does this existing account belong to you?"
 msgstr "Is dit bestaande account van jou?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Als dit adres van jou is log dan eerst in voordat je verder gaat:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/pl.po
+++ b/i18n/core/pl.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -515,7 +515,7 @@ msgstr "Zainicjowaliśmy polecenie zapłaty w wysokości {money_amount} z twojeg
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Ta operacja jest przeprowadzana na podstawie {link_start}mandatu {mandate_id}{link_end} podpisanego w dniu {acceptance_date}, upoważniając Liberapay (wierzyciel SEPA {creditor_identifier}) do wysyłania instrukcji do Twojego banku, aby obciążyć Twoje konto, a Twój bank do obciążenia konta zgodnie z tymi instrukcjami."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Jeśli nie autoryzowałeś(-aś) tej płatności, daj nam znać, zwrócimy ją."
 
 #, python-brace-format
@@ -1170,7 +1170,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Próba rozdzielenia wszystkich pieniędzy z portfela nie powiodła się: pozostaje {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Próba wysłania wiadomości e-mail na adres {email_address} nie powiodła się. Sprawdź, czy adres jest prawidłowy, i spróbuj ponownie. Jeśli problem będzie się powtarzał, skontaktuj się z support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2006,7 +2006,7 @@ msgstr "Dokument o numerze{id} został zweryfikowany."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} został odrzucony: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Jeśli potrzebujesz pomocy, możesz wysłać e-mail na adres: support@liberapay.com."
 
 msgid "Income Range"
@@ -2257,7 +2257,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Przyjmowanie walut obcych może zwiększyć Twoje dochody, przekonując ludzi z innych krajów, by przekazali Ci darowiznę, ale płatności międzynarodowe zazwyczaj powodują wyższy procent opłat, a wahania kursów walut mogą zmniejszyć stabilność Twoich dochodów."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe automatycznie konwertuje środki na główną walutę, ale domyślnie PayPal przechowuje płatności w walutach obcych, dopóki nie powiesz, co robić. Jeśli masz firmowe konto PayPal, możesz automatycznie konwertować wszystkie płatności przychodzące w walutach obcych na swoją główną walutę. Ta opcja znajduje się obecnie na stronie „{link_open}Preferencje dotyczące otrzymywania płatności{link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3846,7 +3846,7 @@ msgid "Withdrawing Money"
 msgstr "Wypłacanie pieniędzy"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} zostało podjęte z Twojego portfela Liberapay. Jeśli transfer się powiedzie wtedy {1} znajdzie się na Twoim koncie bankowym, a {2} pokryje opłatę obsługi transakcji."
 
 #, python-brace-format
@@ -4220,7 +4220,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Domyślnie łączna kwota, którą podajesz i łączna kwota, którą otrzymujesz, są publiczne (możesz zrezygnować z udostępniania tych informacji)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay to otwarty projekt, możesz pomóc nam {1}go tłumaczyć{0}, {2}rozwijać jego kod{0} i {3}zarządzać jego podmiotem prawnym{0}. Jeśli się tym zajmujesz możesz dołączyć do {4}zespołu Liberapay{0} i otrzymywać udział w pieniądzach jakie użytkownicy przekazują nam w darowiznach, by projekt mógł dalej funkcjonować."
 
 msgid "Why should you donate?"
@@ -5070,7 +5070,7 @@ msgid "Log In"
 msgstr "Zaloguj"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Pobieranie danych konta z {platform} nie powiodło się (kod błędu {x}). Jeżeli problem powtarza się, skontaktuj się na support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5107,7 +5107,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "przychodzące darowizny (jeżeli osoba nie dołączyła do Liberapay, wpłata zostanie zastawiona)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "inne konta (np. jeżeli Twoje konto na Twitterze było podłączone z kontem {platform}, będzie ono także połączone z Liberapay)"
 
 #, python-brace-format
@@ -5133,7 +5133,7 @@ msgstr "Prosimy o wprowadzenie adresu e-mail (Twoje konto w serwisie {platform} 
 msgid "Does this existing account belong to you?"
 msgstr "Czy to istniejące konto należy do Ciebie?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Jeżeli ten adres należy do Ciebie, zaloguj się zanim kontynuujesz:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/pt.po
+++ b/i18n/core/pt.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Iniciamos um débito direto de {money_amount} da sua conta bancária ({p
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "A operação está a ser realizada conforme o {link_start}mandato {mandate_id}{link_end} assinado por si em {acceptance_date}, a autorizar a Liberapay (credora SEPA {creditor_identifier}) a enviar instruções ao seu banco para debitar a sua conta."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Se você não autorizou o pagamento, nos avise para que reembolsemos."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Falha ao distribuir os fundos da sua carteira: Sobrou {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Falha ao enviar um e-mail para {email_address}. Verifique se o e-mail é válido e tente novamente. Entre em contato pelo support@liberapay.com se o problema persistir."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1989,7 +1989,7 @@ msgstr "Documento #{id} validado."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Documento #{id} recusado: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Se precisar de ajuda, entre em contato pelo support@liberapay.com."
 
 msgid "Income Range"
@@ -2239,7 +2239,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Aceitar moedas estrangeiras pode aumentar a sua renda ao convencer pessoas de outros países a doar para você, mas pagamentos internacionais geralmente tem uma percentagem maior de taxas, e as flutuações nas taxas de câmbio podem reduzir a estabilidade da sua renda."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe converte tudo para sua moeda principal automaticamente, mas o PayPal, por padrão, mantém os pagamentos em moedas estrangeiras até que você diga o que fazer. Se você tiver uma conta comercial do PayPal, poderá converter automaticamente todos os pagamentos recebidos em moedas estrangeiras para a moeda principal. A opção está na página \"{link_open}Preferências para receber pagamentos{link_close}\"."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3811,7 +3811,7 @@ msgid "Withdrawing Money"
 msgstr "Retirando"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} foram retirados da sua carteira Liberapay. Se a transferência for realizada com sucesso, {1} serão depositados na sua conta bancária e {2} serão pagos em taxas."
 
 #, python-brace-format
@@ -4184,7 +4184,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Por padrão, o total que se doa e recebe são públicos (você pode ocultá-los)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay é um projeto aberto, pode ajudar-no {1}a traduzi-lo{0}, {2}a otimizar o seu código{0} e {3}a gerir a sua entidade jurídica{0}. Se  colaborar, poderá entrar na {4}equipe Liberapay{0} e receber uma parte do que os nossos utilizadores doam para manter o serviço funcionando."
 
 msgid "Why should you donate?"
@@ -5008,7 +5008,7 @@ msgid "Log In"
 msgstr "Entrar"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Falha na descarrega de dados da sua conta do {platform} (código do erro {x}). Entre em contato pelo support@liberapay.com se o problema persistir."
 
 msgid "Migrating from Gratipay"
@@ -5045,7 +5045,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "doações em curso (se o destinatário ainda não entrou no Liberapay, uma promessa de doação será criada)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "contas diversas (por exemplo, se o seu Twitter está vinculado à sua conta {platform}, ele também ficará vinculado ao Liberapay)"
 
 #, python-brace-format
@@ -5071,7 +5071,7 @@ msgstr "Digite um e-mail (a sua conta {platform} não tem um e-mail principal):"
 msgid "Does this existing account belong to you?"
 msgstr "A conta existente é sua?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Se este e-mail é seu, entre antes de continuar:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ro.po
+++ b/i18n/core/ro.po
@@ -333,11 +333,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -497,7 +497,7 @@ msgstr "Am inițializat un debit direct de {money_amount} de la contul bancar al
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1152,7 +1152,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1991,7 +1991,7 @@ msgstr "Documentul nr.{id} a fost validat."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Documentul nr.{id} a fost respins: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Dacă aveți nevoie de asistență puteți trimite un e-mail la support@liberapay.com."
 
 msgid "Income Range"
@@ -2242,7 +2242,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3829,7 +3829,7 @@ msgid "Withdrawing Money"
 msgstr "Extragere fonduri"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} au fost luați din portofelul dumneavoastră Liberapay. Dacă transferul reușește {1} vor ajunge în contul dumneavoastră bancar și {2} vor fi plătiți ca taxe."
 
 #, python-brace-format
@@ -4203,7 +4203,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay este un proiect deschis, puteți să nu ajutați {1}să-l traduceți{0}, {2}să-i îmbunătățiți codul{0}, și {3}să administrați entitatea lui legală{0}. Dacă faceți una dintre acestea vă veți putea altura {4}echipei Liberapay{0} și primi o parte din banii pe care utilizatorii noștri îi donează pentru a menține serviciul."
 
 msgid "Why should you donate?"
@@ -5057,7 +5057,7 @@ msgid "Log In"
 msgstr "Autentificare"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Extragerea datelor de cont de pe {platform} a eșuat (cod de eroare {x}). Dacă problema persistă contactați support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5094,7 +5094,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "donații în curs (dacă beneficiarul nu s-a alăturat la Liberapay un angajament va fi creeat)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "conturi în altă parte (de ex. dacă contul Twitter este conectat la contul de pe {platform} va fi conectat și pe Liberapay)"
 
 #, python-brace-format
@@ -5120,7 +5120,7 @@ msgstr "Introduceți o adresă de e-mail (contul de pe {platform} nu are o adres
 msgid "Does this existing account belong to you?"
 msgstr "Vă aparține acest cont existent?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Dacă această adresă vă aparține autentificați-vă înainte de a continua:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/ru.po
+++ b/i18n/core/ru.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -515,7 +515,7 @@ msgstr "Мы запросили оплату на сумму {money_amount} с �
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Эта операция производится на основании {link_start}полномочия {mandate_id}{link_end}, которое вы подписали {acceptance_date}, давая Liberapay права (кредитор единой зоны платежей в евро {creditor_identifier}) отправлять указания в ваш банк, чтобы списывать средства с вашего счёта, а вашему банку - право списывать деньги с вашего счёта в соответствии с этими инструкциями."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Если Вы не запрашивали этот перевод, пожалуйста, сообщите нам - мы его отменим."
 
 #, python-brace-format
@@ -1170,7 +1170,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Попытка распределить деньги в вашем кошельке не удалась: осталось {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Попытка отправки письма на {email_address} не удалась. Проверьте, что адрес корректен и попробуйте снова. Если проблема остаётся, свяжитесь с support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2007,7 +2007,7 @@ msgstr "Документ #{id} проверен."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Документ #{id} отклонён: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Если вам нужна помощь, отправьте письмо по адресу support@liberapay.com."
 
 msgid "Income Range"
@@ -2258,7 +2258,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Приём иностранных валют может повысить благосклонность пользователей."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe автоматически конвертирует фунты в Вашу основную валюту, PayPal принимает платежи в оригинальной валюте. Если Вы используете PayPal Business, то можете настроить автоматическое конвертирование валюты входящих платежей. Эта опция находится на странице {link_open}Настройки для приема платежей{link_close}."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3847,7 +3847,7 @@ msgid "Withdrawing Money"
 msgstr "Снятие денег"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} было снято с вашего кошелька Liberapay. Если перевод будет успешен, на ваш банковский счёт поступит {1}, а комиссия составит {2}."
 
 #, python-brace-format
@@ -4222,7 +4222,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "По умолчанию общая сумма, которую вы предоставляете, и общая сумма, которую вы получаете, являются общедоступными (вы можете отказаться от предоставления этой информации)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay открытый проект, вы можете помочь нам {1}перевести его{0}, {2}улучшить код{0} или {3}управлять его юридическим лицом{0}. Если вы делаете это, то сможете вступить в {4}команду Liberapay{0} и получать часть денег, которые жертвуют наши пользователи, чтобы сайт продолжал работать."
 
 msgid "Why should you donate?"
@@ -5073,7 +5073,7 @@ msgid "Log In"
 msgstr "Войти"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Получение данных вашего профиля из {platform} не удалось (код ошибки {x}). Если проблема сохраняется, свяжитесь с support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5110,7 +5110,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "будущие пожертвования (если дарополучатель ещё не присоединился к Liberapay, вместо этого будет создан подарок)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "другие аккаунты (например, если ваш Twitter-аккаунт соединён с аккаунтом {platform}, он также будет связан с Liberapay)"
 
 #, python-brace-format
@@ -5136,7 +5136,7 @@ msgstr "Введите адрес электронной почты (у ваше
 msgid "Does this existing account belong to you?"
 msgstr "Этот существующий аккаунт принадлежит вам?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Если этот адрес принадлежит вас, то войдите в систему для продолжения:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/sk.po
+++ b/i18n/core/sk.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -515,7 +515,7 @@ msgstr "Začali sme priamu platbu {money_amount} z vašeho bankového účtu ({p
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Táto akcia je založená na Vašom {link_start} mandáte {mandate_id} {link_end}, podpísanom dňa {acceptance_date}, v ktorom ste autorizovali spoločnosť Liberapay (SEPA kreditor {creditor_identifier}), aby odoslala Vašej banke platobný príkaz na inkaso z Vášho účtu a Vašu banku, inkasovať Váš účet v súlade s týmito pokynmi."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Ak ste nautorizovali túto platbu, dajte nám vedieť, preplatíme ju."
 
 #, python-brace-format
@@ -1170,7 +1170,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Pokus na distribúciu všetkých peňazí z vašej peňaženky zlyhal: {money_amount} ostáva."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Pokus o poslanie emailu na {email_address} zlyhalo. Prosím skontrolujte či je adresa valídna a skúste znova. Ak problém pretrváva kontaktujte support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2006,7 +2006,7 @@ msgstr "Dokument #{id} bol overený."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} bol zamietnutý: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Pokiaľ potrebujete pomoc, môžete poslať email na support@liberapay.com."
 
 msgid "Income Range"
@@ -2257,7 +2257,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Prijímanie cudzích mien môže zvýšiť Váš príjem tým, že presvedčíte ľudí z iných krajín, aby Vám prispievali, medzinárodné platby ale obvykle vedú k vyššiemu percentu poplatkov a kolísanie výmenných kurzov môže znížiť stabilitu Vášho príjmu."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe automaticky konvertuje prostriedky do vašej hlavnej meny, ale PayPal štandardne drží platby v cudzej mene, kým nerozhodnete, čo má v takom prípade robiť. Ak máte Business PayPal účet, môžete si vybrať automatickú konverziu všetkých prichádzajúcich platieb v cudzej mene na hlavnú menu. Táto možnosť sa momentálne nachádza na stránke \"{link_open} Preferencie pre príjem platieb {link_close}\"."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3846,7 +3846,7 @@ msgid "Withdrawing Money"
 msgstr "Vybrať peniaze"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} bolo prevedené z peňaženky Liberapay. Pokiaľ bude prevod úspešný, dostanete {1} na Váš bankový účet a {2} zaplatíte na poplatkoch."
 
 #, python-brace-format
@@ -4219,7 +4219,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Predvolene, čiastka ktorú darujete, a čiastka ktorú dostávate je verejná (môžete obmedziť zobrazenie tejto informácie)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay je otvorený projekt, môžete nám pomôcť {1}s prekladom{0}, {2}vylepšiť jeho kód{0} a {3}spravovať našu právnu entitu{0}. Pokiaľ tak učiníte, budete sa môcť pridať do tímu {4}Liberapay{0} a získať podiel z peňazí, ktoré nám uživatelia prispeli, aby služba bežala."
 
 msgid "Why should you donate?"
@@ -5070,7 +5070,7 @@ msgid "Log In"
 msgstr "Prihlásiť sa"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Získanie vašich dát z {platform} zlyhalo (chybový kód {x}). Ak problém pretrváva prosím kontaktujte support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5107,7 +5107,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "prichádzajúce dary (ak sa ešte obdarovaný neprihlásil na Liberapay bude namiesto neho vytvorený sľub)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "účty inde (napr. ak je Váš Twitter pripojený na {platform}, bude pripojený aj k Liberapay)"
 
 #, python-brace-format
@@ -5133,7 +5133,7 @@ msgstr "Prosím vyplnte emailovú adresu (Váš {platform} účet nemá zvolenú
 msgid "Does this existing account belong to you?"
 msgstr "Patrí vám tento existujúci účet?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Ak táto adresa patrí vám prosím prihláste sa pred pokračovaním:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/sl.po
+++ b/i18n/core/sl.po
@@ -339,11 +339,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -503,7 +503,7 @@ msgstr ""
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr ""
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr ""
 
 #, python-brace-format
@@ -1162,7 +1162,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr ""
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr ""
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr ""
 
 msgid "Income Range"
@@ -2258,7 +2258,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr ""
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr ""
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3862,7 +3862,7 @@ msgid "Withdrawing Money"
 msgstr ""
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr ""
 
 #, python-brace-format
@@ -4237,7 +4237,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr ""
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr ""
 
 msgid "Why should you donate?"
@@ -5112,7 +5112,7 @@ msgid "Log In"
 msgstr ""
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr ""
 
 msgid "Migrating from Gratipay"
@@ -5149,7 +5149,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr ""
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr ""
 
 #, python-brace-format
@@ -5175,7 +5175,7 @@ msgstr ""
 msgid "Does this existing account belong to you?"
 msgstr ""
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr ""
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/sv.po
+++ b/i18n/core/sv.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "Vi har initierat en direktdebitering på {money_amount} från ditt bankk
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Denna operation utförs baserat på det {link_start}mandat {mandate_id}{link_end} som du skrev under {acceptance_date}, vilket auktoriserar Liberapay (SEPA Kreditor {creditor_identifier}) att skicka instruktioner till din bank om att debitera ditt konto i enlighet med de instruktionerna."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Om du inte begärde denna betalning, var god kontakta oss så återbetalar vi den."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Försöket att distribuera alla pengarna i din plånbok misslyckades: {money_amount} är kvar."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Försöket att skicka ett mejl till {email_address} misslyckades. Vänligen kontrollera att adressen är giltig och försök sedan igen. Om problemet kvarstår vänligen kontakta support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Dokument #{id} har blivit validerat."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Dokument #{id} har blivit avvisat: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Om du behöver hjälp kan du skicka ett e-mail till support@liberapay.com."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Om du accepterar utländska valutor kan din inkomst öka genom att övertyga människor från andra länder att donera till dig. Dock så innebär internationella betalningar vanligtvis högre procentuella avgifter samt så kan fluktuationer i växlingskurser minska säkerheten i din inkomst."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe konverterar automatiskt dina tillgångar till din huvudvaluta, men som standard hanterar PayPal betalningar i utländsk valuta tills du berättar för dem vad de ska göra. Om du har ett PayPal-konto för företag kan du välja att automatiskt konvertera alla inkommande betalningar i utländsk valuta till din huvudvaluta. Den inställningen hittar du på sidan \"{link_open}Preferences for receiving payments{link_close}\"."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3810,7 +3810,7 @@ msgid "Withdrawing Money"
 msgstr "Uttag av pengar"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} har tagits från din Liberapayplånbok. Om överföringen lyckas kommer {1} att landa på ditt bankkonto och {2} att betalas i avgifter."
 
 #, python-brace-format
@@ -4182,7 +4182,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Som standard är de totala beloppet du ger och det totala beloppet du får offentligt (du kan välja att inte dela denna information)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay tar ingen andel av donationerna. Du kan hjälpa oss genom att {1}översätta{0}, {2}förbättra koden{0} och {3}hjälpa till med det juridiska{0}. Om du gör det så har du möjligheten att gå med i {4}Liberapay gruppen{0} och ta emot en del av de pengar våra användare donerar till oss för att hålla tjänsten levande."
 
 msgid "Why should you donate?"
@@ -5006,7 +5006,7 @@ msgid "Log In"
 msgstr "Logga in"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Hämtningen av kontoinformation från {platform} misslyckades (felkod: {x}). Om problemet kvarstår, var god kontakta support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5043,7 +5043,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "pågående donationer (om givaren inte gått med Liberapay ännu så kommer en utfästelse att skapas istället)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "andra konton (exempelvis om ditt Twitterkonto är anslutet till ditt {platform} konto så kommer även det att bli länkat på Liberapay)"
 
 #, python-brace-format
@@ -5069,7 +5069,7 @@ msgstr "Var god ange en e-postadress (ditt {platform} konto har inte en primär 
 msgid "Does this existing account belong to you?"
 msgstr "Tillhör detta existerande konto dig?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Om denna adress tillhör dig, logga in innan du fortsätter:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/tr.po
+++ b/i18n/core/tr.po
@@ -325,11 +325,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -508,7 +508,7 @@ msgstr "{partial_account_number} hesabınızdan {money_amount} otomatik ödemesi
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Bu işlem Liberapay'e (SEPA alacaklısı {creditor_identifier}), hesabınızdan para çekmek için bankanıza talimat gönderme ve bankanıza bu talimatlara göre hesabınızdan para çekme yetkisi veren {acceptance_date} tarihinde imzaladığınız {link_start}{mandate_id} yetkisine{link_end} dayanarak gerçekleştirilmektedir."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Bu ödemeyi onaylamadıysanız lütfen bize bildirin, geri ödeme yapacağız."
 
 #, python-brace-format
@@ -1159,7 +1159,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Cüzdanınızdaki tüm parayı dağıtma girişimi başarısız oldu:kalanlar {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "{email_address} adresine e-posta gönderme denemesi başarısız oldu. Lütfen adresin geçerli olduğunu denetleyin ve tekrar deneyin. Sorun devam ederse lütfen support@liberapay.com ile iletişime geçin."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1987,7 +1987,7 @@ msgstr "Belge #{id} doğrulandı."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Belge #{id} reddedildi: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Yardıma ihtiyacınız olursa support@liberapay.com adresine e-posta gönderebilirsiniz."
 
 msgid "Income Range"
@@ -2237,7 +2237,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Yabancı para birimlerini kabul etmek, diğer ülkelerdeki insanları size bağış yapmaya ikna ederek gelirinizi artırabilir, ancak uluslararası ödemeler genellikle daha yüksek ücret yüzdesi ile sonuçlanır ve döviz kurlarındaki dalgalanmalar gelirinizin istikrarını azaltabilir."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe, fonları otomatik olarak ana para biriminize dönüştürür; ancak öntanımlı olarak PayPal, siz ne yapacağını söyleyene kadar ödemeleri yabancı para birimlerinde tutar. Bir Ticari PayPal hesabınız varsa, yabancı para birimindeki tüm gelen ödemeleri otomatik olarak ana para biriminize dönüştürebilirsiniz. Bu seçenek şu anda “{link_open}Ödeme alma tercihleri{link_close}” sayfasında bulunmaktadır."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3808,7 +3808,7 @@ msgid "Withdrawing Money"
 msgstr "Para Çek"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} Liberapay cüzdanınızdan alındı. Aktarım başarılı olursa {1} banka hesabınıza girecek ve {2} ücretler için ödenecek."
 
 #, python-brace-format
@@ -4179,7 +4179,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Öntanımlı olarak, verdiğiniz ve aldığınız toplam tutarlar herkese açıktır (bu bilgileri paylaşmayı devre dışı bırakabilirsiniz)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay açık bir projedir, bize {1}onu çevirmede{0}, {2}kodunu iyileştirmede{0} ve {3}tüzel kişiliğini yönetmede{0} yardımcı olabilirsiniz. Bunu yaparsanız, {4}Liberapay takımına{0} katılabileceksiniz ve kullanıcılarımızın hizmetin çalışmaya devam etmesi için bağışladığı paradan bir pay alabileceksiniz."
 
 msgid "Why should you donate?"
@@ -5002,7 +5002,7 @@ msgid "Log In"
 msgstr "Oturum Aç"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "{platform} üzerinden hesap verilerinizi alma başarısız oldu (hata kodu {x}). Sorun devam ederse lütfen support@liberapay.com ile iletişime geçin."
 
 msgid "Migrating from Gratipay"
@@ -5039,7 +5039,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "devam eden bağışlar (bağış alan henüz Liberapay'e katılmadıysa, bunun yerine bir vaat oluşturulacak)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "başka yerlerdeki hesaplar (örneğin, Twitter hesabınız {platform} hesabınıza bağlıysa, Liberapay'e de bağlanacaktır)"
 
 #, python-brace-format
@@ -5065,7 +5065,7 @@ msgstr "Lütfen bir e-posta adresi girin ({platform} hesabında birincil bir adr
 msgid "Does this existing account belong to you?"
 msgstr "Var olan bu hesap size mi ait?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Bu adres size aitse devam etmeden önce lütfen oturum açın:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/uk.po
+++ b/i18n/core/uk.po
@@ -332,11 +332,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -515,7 +515,7 @@ msgstr "Ми зробили запит прямого платежу на сум
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "Ця операція здійснюється на основі {link_start}доручення {mandate_id}{link_end}, який ви підписали {acceptance_date}, дозволивши Liberapay (кредитор SEPA {creditor_identifier}) надіслати настанови до вашого банку на списання коштів з вашого рахунку, а вашому банку для списання коштів з рахунку відповідно до цих настанов."
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "Якщо ви не авторизували цей платіж, будь ласка, повідомте нас, щоб ми повернули кошти."
 
 #, python-brace-format
@@ -1170,7 +1170,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "Спроба надіслати всі гроші з вашого гаманця не вдалася: залишилося {money_amount}."
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "Не вдалося надіслати повідомлення до електронної скриньки {email_address}. Перевірте, чи адресу є дійсною і повторіть спробу. Якщо проблема не зникне, зверніться до support@liberapay.com."
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -2006,7 +2006,7 @@ msgstr "Документ #{id} перевірено."
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "Документ #{id} відхилено: {refused_reason_type} - {refused_reason_message}."
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "Якщо вам потрібна допомога, надішліть листа на адресу support@liberapay.com."
 
 msgid "Income Range"
@@ -2257,7 +2257,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "Приймання іноземних валют може збільшити ваші надходження, переконавши людей в інших країнах допомагати вам, але міжнародні платежі зазвичай призводять до вищого відсотка зборів, а коливання курсів валют можуть зменшити стабільність ваших надходжень."
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe автоматично конвертує кошти у вашу основну валюту, але PayPal типово утримує платежі в іноземній валюті, поки ви не скажете, що робити. Якщо у вас є бізнес-рахунок PayPal, ви можете дозволити автоматично конвертувати всі вхідні платежі в іноземній валюті у свою основну валюту. Наразі цей параметр розташовано на сторінці “{link_open}Налаштування отримання платежів {link_close}”."
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3846,7 +3846,7 @@ msgid "Withdrawing Money"
 msgstr "Виведення грошей"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "{0} було виведено з вашого гаманця Liberapay. Якщо переказ буде успішним, на ваш банківський рахунок надійде {1}, а комісія становитиме {2}."
 
 #, python-brace-format
@@ -4220,7 +4220,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "Типово, загальна сума, яку ви надаєте, і загальна сума, яку ви отримуєте, є загальнодоступною (ви можете приховати ці дані)."
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay відкритий проєкт, ви можете допомогти нам {1}перекласти його{0}, {2}вдосконалити код{0} або {3}керувати його юридичною особою{0}. Якщо ви зробите це, то зможете вступити до {4}команди Liberapay{0} та отримати частину внесків від наших користувачів для продовження роботи служби."
 
 msgid "Why should you donate?"
@@ -5070,7 +5070,7 @@ msgid "Log In"
 msgstr "Увійти"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "Не вдалося отримати дані вашого облікового запису з {platform} (код помилки {x}). Якщо проблема не зникне, зв'яжіться з support@liberapay.com."
 
 msgid "Migrating from Gratipay"
@@ -5107,7 +5107,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "майбутні внески (якщо отримувач внесків ще не долучився до Liberapay, буде створено зобов'язання натомість)"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "інші облікові записи (наприклад, якщо ваш обліковий запис Twitter з'єднано з обліковим записом {platform}, його також буде з'єднано з Liberapay)"
 
 #, python-brace-format
@@ -5133,7 +5133,7 @@ msgstr "Введіть адресу електронної пошти (у ваш
 msgid "Does this existing account belong to you?"
 msgstr "Цей обліковий запис, що вже існує, належить вам?"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "Якщо ця адреса належить вам, то увійдіть в систему для продовження:"
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/i18n/core/zh_Hant.po
+++ b/i18n/core/zh_Hant.po
@@ -319,11 +319,11 @@ msgid ""
 "\n"
 "For example, if you’re donating $1 per week to 2 creators, and you have $40 in your wallet, then each creator will receive $20, and 20 weeks from now you’ll receive our usual email reminding you that it’s time to add money again.\n"
 "\n"
-"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.” then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
+"Please note that the disbursement may fail for various reasons. If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”, then the problem is probably on the recipient side, for example someone who hasn’t filled the identity form or a team that hasn’t defined how the income should be split between the members.\n"
 "\n"
 "The other option is to get your money back, if possible through a refund, otherwise by withdrawing it to your bank account.\n"
 "\n"
-"If you receive donations on Liberapay you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
+"If you receive donations on Liberapay, you may want to wait a week before withdrawing your income in order to give your patrons a chance to transfer the remaining of their donations from their wallets to yours.\n"
 "\n"
 "We’ll inform you as soon as the integration of a new payment processor is complete, and tell you if there’s anything you need to do to start receiving donations on Liberapay again.\n"
 "\n"
@@ -502,7 +502,7 @@ msgstr "我們自您的銀行帳戶{partial_account_number}直接扣貸了{money
 msgid "This operation is being carried out based on {link_start}the mandate {mandate_id}{link_end} that you signed on {acceptance_date}, authorizing Liberapay (SEPA creditor {creditor_identifier}) to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions."
 msgstr "本操作的執行乃基於您在{acceptance_date} 簽署的 {link_start}義務{mandate_id}{link_end}，同意授權 Liberapay (SEPA creditor{creditor_identifier})傳送指示給銀行可自您的帳戶扣款。"
 
-msgid "If you did not authorize this payment please let us know, we will refund it."
+msgid "If you did not authorize this payment, please let us know, we will refund it."
 msgstr "若您未授權此次付款請即通知失我方，我們會退回它。"
 
 #, python-brace-format
@@ -1149,7 +1149,7 @@ msgid "The attempt to distribute all the money in your wallet failed: {money_amo
 msgstr "钱包余额分配失败：{money_amount}仍在您的钱包中。"
 
 #, python-brace-format
-msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists please contact support@liberapay.com."
+msgid "The attempt to send an email to {email_address} failed. Please check that the address is valid and retry. If the problem persists, please contact support@liberapay.com."
 msgstr "無法送信到{email_address}，請檢查該地址是否有效後重試。如果該問題無法解決，請聯絡 support@liberapay.com。"
 
 msgid "This payment method is currently unavailable. We apologize for the inconvenience."
@@ -1971,7 +1971,7 @@ msgstr "文件#{id}正在被確認。"
 msgid "Document #{id} has been rejected: {refused_reason_type} - {refused_reason_message}."
 msgstr "文件#{id}已被拒絕：{refused_reason_type} - {refused_reason_message}。"
 
-msgid "If you need assistance you can send an email to support@liberapay.com."
+msgid "If you need assistance, you can send an email to support@liberapay.com."
 msgstr "若需要幫助，請聯繫 support@liberapay.com。"
 
 msgid "Income Range"
@@ -2220,7 +2220,7 @@ msgid "Accepting foreign currencies can increase your income by convincing peopl
 msgstr "接受外幣可以提高收入說服其它國家的人捐款支助，不過國際支付通常會有較高的手續費且滙率波動會減少您的收入。"
 
 #, python-brace-format
-msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
+msgid "Stripe automatically converts funds into your main currency, but by default PayPal holds payments in foreign currencies until you tell it what to do. If you have a Business PayPal account, you can choose to automatically convert all incoming payments in foreign currencies to your main currency. This option is currently located in the “{link_open}Preferences for receiving payments{link_close}” page."
 msgstr "Stripe 可自動將基金轉成您主動使用的貨幣，而 PayPal 除非有明白告之則預設為外幣支付。如果是商務級 PayPal 帳戶則可選擇自動將收入支付的外幣轉成主要使用貨幣。此選項目前放在{link_open}收款頁的偏好設定{link_close}之下。"
 
 msgid "Connecting the accounts you own on other platforms makes your Liberapay profile easier to find, and helps to demonstrate that you are who you claim to be."
@@ -3774,7 +3774,7 @@ msgid "Withdrawing Money"
 msgstr "取領錢款"
 
 #, python-brace-format
-msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful {1} will land in your bank account and {2} will be paid in fees."
+msgid "{0} have been taken from your Liberapay wallet. If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees."
 msgstr "你的 Liberapay 錢包被取走了{0}元。如果滙款成功，將有 {1} 會轉入到你的銀行戶頭，而手續費則為 {2} 。"
 
 #, python-brace-format
@@ -4144,7 +4144,7 @@ msgid "By default, the total amount you give and the total amount you receive ar
 msgstr "默認情況下，您捐輸的數額與收取的金額為公開資訊(可選擇不要公開此資訊)。"
 
 #, python-brace-format
-msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
+msgid "Liberapay is an open project, you can help us {1}translate it{0}, {2}improve its code{0}, and {3}manage its legal entity{0}. If you do so, you'll be able to join {4}the Liberapay team{0} and receive a share of the money that our users donate to keep the service running."
 msgstr "Liberapay 是一個開放專案，你可以協助我們：{1}翻譯{0}，{2}改善程式碼{0}，以及 {3}管理它的法律實體{0}。如果符合這三點，你可以加入 {4} Liberapay 團隊{0} 並收取用戶捐助給我們的捐款以維持本服務繼續運作。"
 
 msgid "Why should you donate?"
@@ -4942,7 +4942,7 @@ msgid "Log In"
 msgstr "登入"
 
 #, python-brace-format
-msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists please contact support@liberapay.com."
+msgid "Fetching your account data from {platform} has failed (error code {x}). If the problem persists, please contact support@liberapay.com."
 msgstr "無法從{platform}獲取你的帳戶信息（錯誤代碼{x}）。若該問題仍舊存在請聯繫support@liberapay.com。"
 
 msgid "Migrating from Gratipay"
@@ -4979,7 +4979,7 @@ msgid "ongoing donations (if the donee hasn't joined Liberapay yet a pledge will
 msgstr "目前的捐款（若收款方未加入Liberapay我們會為你創建一個承諾）"
 
 #, python-brace-format
-msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)"
+msgid "elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)"
 msgstr "其他帳號（若你的Twitter等帳號已經連結到你的{platform}帳號，它也會被連結到Liberapay帳號）"
 
 #, python-brace-format
@@ -5005,7 +5005,7 @@ msgstr "請輸入一個電子郵件 (你的 {platform} 帳號未有主要電郵)
 msgid "Does this existing account belong to you?"
 msgstr "這個已註冊的帳號是你的嗎？"
 
-msgid "If this address belongs to you please log in before continuing:"
+msgid "If this address belongs to you, please log in before continuing:"
 msgstr "若該地址是你的請登入以繼續："
 
 msgid "Otherwise please input an email address which does belong to you:"

--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -592,7 +592,7 @@ class UnableToSendEmail(LazyResponseXXX):
     def msg(self, _):
         return _(
             "The attempt to send an email to {email_address} failed. Please "
-            "check that the address is valid and retry. If the problem persists "
+            "check that the address is valid and retry. If the problem persists, "
             "please contact support@liberapay.com.", email_address=self.args[0]
         )
 

--- a/templates/mangopay/identity-form-2.html
+++ b/templates/mangopay/identity-form-2.html
@@ -27,7 +27,7 @@
         % endfor
         </p>
         % if docs[0].status == 'REFUSED'
-            <p>{{ _("If you need assistance you can send an email to support@liberapay.com.") }}</p>
+            <p>{{ _("If you need assistance, you can send an email to support@liberapay.com.") }}</p>
         % endif
     % endif
 % endmacro

--- a/www/%username/edit/currencies.spt
+++ b/www/%username/edit/currencies.spt
@@ -103,7 +103,7 @@ subhead = _("Currencies")
     <p class="text-warning">{{ glyphicon('info-sign') }} {{ _(
         "Stripe automatically converts funds into your main currency, but by "
         "default PayPal holds payments in foreign currencies until you tell it "
-        "what to do. If you have a Business PayPal account you can choose to "
+        "what to do. If you have a Business PayPal account, you can choose to "
         "automatically convert all incoming payments in foreign currencies to "
         "your main currency. This option is currently located in the "
         "“{link_open}Preferences for receiving payments{link_close}” page.",

--- a/www/%username/wallet/payout/%back_to.spt
+++ b/www/%username/wallet/payout/%back_to.spt
@@ -113,7 +113,7 @@ title = _("Withdrawing Money")
     % if exchange
         <div class="alert alert-{{ 'success' if success else 'danger' }}">{{
             _("{0} have been taken from your Liberapay wallet. "
-              "If the transfer is successful {1} will land in your bank account and {2} will be paid in fees.",
+              "If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees.",
               -exchange.amount + exchange.fee, -exchange.amount, exchange.fee) if success else
             _("The attempt to send {0} to your bank account has failed. Error message: {1}", -exchange.amount, exchange.note)
         }}</div>

--- a/www/about/index.spt
+++ b/www/about/index.spt
@@ -34,7 +34,7 @@ title = _("Introduction")
     <p>{{ _(
         "Liberapay is an open project, you can help us {1}translate it{0}, "
         "{2}improve its code{0}, and {3}manage its legal entity{0}. If you do "
-        "so you'll be able to join {4}the Liberapay team{0} and receive a "
+        "so, you'll be able to join {4}the Liberapay team{0} and receive a "
         "share of the money that our users donate to keep the service running.",
         '</a>'|safe,
         '<a href="https://hosted.weblate.org/engage/liberapay/">'|safe,

--- a/www/migrate.spt
+++ b/www/migrate.spt
@@ -56,7 +56,7 @@ elif step == '2':
             if r.status_code != 200:
                 raise response.error(502, _(
                     "Fetching your account data from {platform} has failed (error code {x}). "
-                    "If the problem persists please contact support@liberapay.com."
+                    "If the problem persists, please contact support@liberapay.com."
                     , platform=platform, x=r.status_code
                 ))
             data = r.json()
@@ -309,8 +309,8 @@ title = _("Migrating from Gratipay")
                 <li>{{ _("basic account data (username, avatar, some privacy settings, etc.)") }}</li>
                 <li>{{ _("profile descriptions") }}</li>
                 <li>{{ _("teams (we will create them for you)") }}</li>
-                <li>{{ _("ongoing donations (if the donee hasn't joined Liberapay yet a pledge will be created instead)") }}</li>
-                <li>{{ _("elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account it will also be linked on Liberapay)", platform=platform) }}</li>
+                <li>{{ _("ongoing donations (if the donee hasn't joined Liberapay yet, a pledge will be created instead)") }}</li>
+                <li>{{ _("elsewhere accounts (e.g. if your Twitter account is connected to your {platform} account, it will also be linked on Liberapay)", platform=platform) }}</li>
                 <li>{{ _("email addresses (we won't ask you to prove ownership when it's already been verified by {platform})", platform=platform) }}</li>
             </ul>
             <p>{{ _("and what we cannot import:") }}</p>
@@ -360,7 +360,7 @@ title = _("Migrating from Gratipay")
                     "{0} is already connected to a different Liberapay account.",
                     existing_account.email
                 ) }}</div>
-                <p>{{ _("If this address belongs to you please log in before continuing:") }}</p>
+                <p>{{ _("If this address belongs, to you please log in before continuing:") }}</p>
                 <button class="btn btn-default"
                         name="log-in.id" value="{{ existing_account.email }}"
                         >{{ _("Log in") }}</button>

--- a/www/migrate.spt
+++ b/www/migrate.spt
@@ -360,7 +360,7 @@ title = _("Migrating from Gratipay")
                     "{0} is already connected to a different Liberapay account.",
                     existing_account.email
                 ) }}</div>
-                <p>{{ _("If this address belongs, to you please log in before continuing:") }}</p>
+                <p>{{ _("If this address belongs to you, please log in before continuing:") }}</p>
                 <button class="btn btn-default"
                         name="log-in.id" value="{{ existing_account.email }}"
                         >{{ _("Log in") }}</button>


### PR DESCRIPTION
It fixes #959.

We don't need to update the translations, as translators should know the comma rules of their own languages, and the sentences aren't ambiguous. That's why I also updated the '`msgid`s of the `.po` files with the following commands (I got it from the Bash command `history`):
 
```
 2027  find . -name *.po -exec sed -i 's/If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”/If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”,/g' {} \;
 2028  find . -name "*.po" -exec sed -i 's/If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”/If you get an error message like “The attempt to distribute all the money in your wallet failed: XX.XX remains.”,/g' {} \;
 2029  git diff
 2030  git diff --word-diff
 2031  find . -name "*.po" -exec sed -i 's/If you receive donations on Liberapay you may want to wait/If you receive donations on Liberapay, you may want to wait/g' {} \;
 2032  find . -name "*.po" -exec sed -i 's/If you did not authorize this payment please let us know/If you did not authorize this payment, please let us know/g' {} \;
 2033  find . -name "*.po" -exec sed -i 's/If the problem persists please/If the problem persists, please/g' {} \;
 2034  find . -name "*.po" -exec sed -i 's/If you need assistance you/If you need assistance, you/g' {} \;
 2035* 
 2036  find . -name "*.po" -exec sed -i 's/If the transfer is successful {1} will land in your bank account and {2} will be paid in fees./If the transfer is successful, {1} will land in your bank account, and {2} will be paid in fees./g' {} \;
 2037  find . -name "*.po" -exec sed -i 's/If you do so you/If you do so, you/g' {} \;
 2038  find . -name "*.po" -exec sed -i 's/If the problem persists please/If the problem persists, please/g' {} \;
 2039  find . -name "*.po" -exec sed -i 's/if your Twitter account is connected to your {platform} account it will also be linked/if your Twitter account is connected to your {platform} account, it will also be linked/g' {} \;
 2040  find . -name "*.po" -exec sed -i 's/If this address belongs to you please log in before continuing/If this address belongs to you, please log in before continuing/g' {} \;
```

> If the transfer is successful {1} will land in your bank account and {2} will be paid in fees.

Here, in addition to adding a comma after the dependent clause, I also added a comma before "and", as these are two independent clauses.

See https://en.wikipedia.org/wiki/Comma#Separation_of_clauses and https://www.grammarly.com/blog/comma-before-and/, for more information on comma usage. 