### PR TITLE
Fix bogus warnings of incomplete English translation

### DIFF
--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -117,7 +117,7 @@ class Locale(babel.core.Locale):
                 s2 = s2[0]
         if not s2:
             s2 = s
-            if self is not LOCALE_EN:
+            if self.language != 'en':
                 self = LOCALE_EN
                 state['partial_translation'] = True
         if a or kw:
@@ -141,7 +141,7 @@ class Locale(babel.core.Locale):
                 website.tell_sentry(e)
         if not s2:
             s2 = s if n == 1 else p
-            if self is not LOCALE_EN:
+            if self.language != 'en':
                 self = LOCALE_EN
                 state['partial_translation'] = True
         kw['n'] = self.format_decimal(n) or n

--- a/tests/py/test_i18n.py
+++ b/tests/py/test_i18n.py
@@ -73,6 +73,14 @@ class Tests(Harness):
         state = self.client.GET('/', HTTP_ACCEPT_LANGUAGE=b'zh-CN', want='state')
         assert state['locale'] == self.website.locales['zh']
 
+    def test_american_english(self):
+        state = self.client.GET('/', HTTP_ACCEPT_LANGUAGE=b'en-us', want='state')
+        locale = state['locale']
+        assert locale is self.website.locales['en_us']
+        assert locale.format_money(Money('5200.00', 'USD')) == '$5,200.00'
+        assert locale.parse_money_amount('5,200.00', 'USD') == Money('5200.00', 'USD')
+        assert not state.get('partial_translation')
+
     def test_swiss_german(self):
         state = self.client.GET('/', HTTP_ACCEPT_LANGUAGE=b'de-ch', want='state')
         locale = state['locale']


### PR DESCRIPTION
I forgot something in #2068 that is causing a bogus translation warning to be displayed at the top of every page for every visitor with a browser configured to request an English variant (e.g. `en-US`).