### PR TITLE
Collect postal addresses for some payments

### DIFF
--- a/js/stripe.js
+++ b/js/stripe.js
@@ -64,10 +64,21 @@ Liberapay.stripe_form_init = function($form) {
             $form.submit();
             return;
         }
+        var local_address = $form.find('input[name="postal_address.local_address"]').val();
+        local_address = !!local_address ? local_address.split(/(?:\r\n?|\n)/g) : [null];
+        if (local_address.length === 1) {
+            local_address.push(null);
+        }
         if (element_type == 'iban') {
             var tokenData = {};
             tokenData.currency = 'EUR';
             tokenData.account_holder_name = $form.find('input[name="owner.name"]').val();
+            tokenData.address_country = $form.find('input[name="postal_address.country"]').val();
+            tokenData.address_state = $form.find('input[name="postal_address.region"]').val();
+            tokenData.address_city = $form.find('input[name="postal_address.city"]').val();
+            tokenData.address_zip = $form.find('input[name="postal_address.postal_code"]').val();
+            tokenData.address_line1 = local_address[0];
+            tokenData.address_line2 = local_address[1];
             stripe.createToken(element, tokenData).then(Liberapay.wrap(function(result) {
                 if (result.error) {
                     $errorElement.text(result.error.message);
@@ -85,12 +96,12 @@ Liberapay.stripe_form_init = function($form) {
             var pmData = {
                 billing_details: {
                     address: {
-                        city: $form.find('input[name="owner.address.city"]').val(),
-                        country: $form.find('input[name="owner.address.country"]').val(),
-                        line1: $form.find('input[name="owner.address.line1"]').val(),
-                        line2: $form.find('input[name="owner.address.line2"]').val(),
-                        postal_code: $form.find('input[name="owner.address.postal_code"]').val(),
-                        state: $form.find('input[name="owner.address.state"]').val(),
+                        city: $form.find('input[name="postal_address.city"]').val(),
+                        country: $form.find('input[name="postal_address.country"]').val(),
+                        line1: local_address[0],
+                        line2: local_address[1],
+                        postal_code: $form.find('input[name="postal_address.postal_code"]').val(),
+                        state: $form.find('input[name="postal_address.region"]').val(),
                     },
                     email: $form.find('input[name="owner.email"]').val(),
                     name: $form.find('input[name="owner.name"]').val(),

--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -378,9 +378,6 @@ POSTAL_ADDRESS_KEYS = (
 POSTAL_ADDRESS_KEYS_LIBERAPAY = (
     'country', 'region', 'city', 'postal_code', 'local_address'
 )
-POSTAL_ADDRESS_KEYS_STRIPE = (
-    'line1', 'line2', 'city', 'state', 'postal_code', 'country'
-)
 
 PRIVACY_FIELDS = OrderedDict([
     ('hide_giving', (_("Hide total giving from others."), False)),

--- a/templates/macros/postal-addresses.html
+++ b/templates/macros/postal-addresses.html
@@ -1,6 +1,6 @@
 % from "templates/macros/icons.html" import glyphicon
 
-% macro postal_address_form_v2(prefix='postal_address', saved=None, country=None, required=True)
+% macro postal_address_form_v2(prefix='postal_address', saved=None, required=True)
 
     % set required = 'required' if required else ''
 
@@ -8,7 +8,7 @@
         <span>{{ _("Country") }}</span>
         <select name="{{ prefix }}.country" class="form-control country" {{ required }}>
             <option></option>
-            % set country = country or saved.country
+            % set country = saved.country or request.country
             % for code, name in locale.countries.items()
                 <option value="{{ code }}" {{ 'selected' if code == country }}>{{ name }}</option>
             % endfor

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -15,13 +15,14 @@ from liberapay.payin.prospect import PayinProspect
 from liberapay.payin.stripe import (
     charge, create_source_from_token, repr_stripe_error, settle_payin,
 )
-from liberapay.utils import get_participant
+from liberapay.utils import check_address_v2, get_participant
 
 STRIPE_BIT = 1
 
 [---]
 
 payer = get_participant(state, restrict=True)
+identity = payer.get_current_identity() or {}
 
 del currency
 
@@ -64,17 +65,22 @@ if request.method == 'POST':
             payin_amount, amount_min, amount_max
         ))
 
+    postal_address = {
+        k: body.get('postal_address.' + k) for k in constants.POSTAL_ADDRESS_KEYS_LIBERAPAY
+    }
+    if postal_address.get('local_address'):
+        if check_address_v2(postal_address):
+            if postal_address != identity.get('postal_address'):
+                identity['postal_address'] = postal_address
+                payer.insert_identity(identity)
+    else:
+        postal_address = None
+
     try:
         if 'token' in body:
             return_url = payer.url('giving/pay/stripe/complete')
             one_off = body.get('keep') != 'true'
-            owner_address = {
-                k: body.get('owner.address.' + k) for k in constants.POSTAL_ADDRESS_KEYS_STRIPE
-            }
-            if 'line1' not in owner_address:
-                owner_address = None
             owner_info = {
-                'address': owner_address,
                 'email': payer.get_email_address(),
                 'name': body.get('owner.name'),
             }
@@ -102,6 +108,10 @@ if request.method == 'POST':
         raise response.error(400, _(
             "The payment instrument is invalid, please select or add another one."
         ))
+
+    if postal_address and not (route.get_postal_address() or {}).get('line1'):
+        route.set_postal_address(postal_address)
+
     transfer_amounts = resolve_amounts(
         payin_amount, {tip.id: tip.amount for tip in tips}
     )
@@ -195,6 +205,26 @@ if tippees:
     if len(set(tip.amount.currency for tip in tips)) != 1:
         raise response.invalid_input(tippees, 'beneficiary', 'querystring')
     payment = PayinProspect(payer, tips, 'stripe')
+    postal_address_is_required = (
+        payment_type == 'sdd' or
+        # Note: this isn't really accurate, but it's good enough for now.
+        website.db.one("""
+            SELECT true
+              FROM payment_accounts a
+             WHERE ( a.participant IN %(tippee_ids)s OR
+                     a.participant IN (
+                         SELECT take.member
+                           FROM current_takes take
+                          WHERE take.team IN %(tippee_ids)s
+                            AND take.amount <> 0
+                     )
+                   )
+               AND a.provider = 'stripe'
+               AND a.country = 'IN'
+               AND a.is_current
+             LIMIT 1
+        """, tippee_ids=tuple(tip.tippee for tip in tips))
+    )
     del tips
 
 elif not payin_id:
@@ -213,6 +243,8 @@ response.headers[b'Content-Security-Policy'] = csp
 title = _("Funding your donations")
 
 [---] text/html
+% from "templates/macros/postal-addresses.html" import postal_address_form_v2 with context
+
 % extends "templates/layouts/base-thin.html"
 
 % block thin_content
@@ -467,6 +499,14 @@ title = _("Funding your donations")
             </label>
             <br>
         </fieldset>
+        % endif
+
+        % if postal_address_is_required
+        <p>{{ _("Postal address:") }}</p>
+        <div class="block-labels max-width-500">{{
+            postal_address_form_v2(saved=identity.get('postal_address'))
+        }}</div>
+        <br>
         % endif
 
         <div class="text-info">{{ glyphicon('info-sign') }} {{ _(

--- a/www/%username/identity.spt
+++ b/www/%username/identity.spt
@@ -36,10 +36,6 @@ if request.method == 'POST':
             if v['city'] or v['postal_code'] or v['local_address']:
                 if not check_address_v2(v):
                     error = _("The provided postal address is incomplete.")
-                else:
-                    newlines = v['local_address'].count('\n')
-                    if newlines > 1:
-                        error = "`local_address` value contains too many newlines (%i > %i)" % (newlines, 1)
             for subkey, subvalue in v.items():
                 if len(subvalue) > 200:
                     error = "`%s` value is too long (%i > %i)" % (subkey, len(subvalue), 200)

--- a/www/%username/routes/add.spt
+++ b/www/%username/routes/add.spt
@@ -2,11 +2,12 @@ import stripe
 
 from liberapay.models.exchange_route import ExchangeRoute
 from liberapay.payin.stripe import create_source_from_token, repr_stripe_error
-from liberapay.utils import form_post_success, get_participant
+from liberapay.utils import check_address_v2, form_post_success, get_participant
 
 [---]
 
 participant = get_participant(state, restrict=True)
+identity = participant.get_current_identity() or {}
 
 if request.method == 'POST':
     body = request.body
@@ -14,13 +15,7 @@ if request.method == 'POST':
     return_url = participant.url('routes/')
     try:
         if 'token' in body:
-            owner_address = {
-                k: body.get('owner.address.' + k) for k in constants.POSTAL_ADDRESS_KEYS_STRIPE
-            }
-            if 'line1' not in owner_address:
-                owner_address = None
             owner_info = {
-                'address': owner_address,
                 'email': participant.get_email_address(),
                 'name': body.get('owner.name'),
             }
@@ -49,6 +44,13 @@ if request.method == 'POST':
             "The payment processor {name} returned an error: “{error_message}”.",
             name='Stripe', error_message=repr_stripe_error(e)
         ))
+    postal_address = {
+        k: body.get('postal_address.' + k) for k in constants.POSTAL_ADDRESS_KEYS_LIBERAPAY
+    }
+    if check_address_v2(postal_address):
+        if postal_address != identity.get('postal_address'):
+            identity['postal_address'] = postal_address
+            participant.insert_identity(identity)
     msg = _("The payment instrument has been successfully added.")
     form_post_success(state, redirect_url=participant.path('routes/'), msg=msg)
 
@@ -64,9 +66,10 @@ response.headers[b'Content-Security-Policy'] = csp
 title = _("Add a payment instrument")
 
 [---] text/html
-% extends "templates/layouts/settings.html"
-
 % from "templates/macros/icons.html" import fontawesome
+% from "templates/macros/postal-addresses.html" import postal_address_form_v2 with context
+
+% extends "templates/layouts/settings.html"
 
 % block content
 
@@ -122,6 +125,11 @@ title = _("Add a payment instrument")
             </label>
         </fieldset>
         % endif
+        <p>{{ _("Postal address:") }}</p>
+        <div class="block-labels max-width-500">{{
+            postal_address_form_v2(saved=identity.get('postal_address'))
+        }}</div>
+        <br>
         <button class="btn btn-primary btn-lg">{{ _("Save") }}</button>
     </form>
 


### PR DESCRIPTION
On Monday (November 29) we received an email from Stripe informing us that starting tomorrow (December 6) postal addresses will be required for SEPA Direct Debits from 16 non-EU territories: Andorra, French Polynesia, French Southern Territories, Gibraltar, United Kingdom, Guernsey, Isle of Man, Jersey, Monaco, New Caledonia, Saint Barthelemy, Saint Pierre and Miquelon, San Marino, Switzerland, Wallis and Futuna, Vatican City.

This branch implements collecting postal addresses in a quick-and-dirty way so that it can be deployed tomorrow.