### PR TITLE
Modified the database schema to store polls and votes

### DIFF
--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,26 @@
+CREATE TABLE poll_questions
+( id                    bigserial               PRIMARY KEY
+, body                  text                    
+, created_at            timestamptz             NOT NULL
+, updated_at            timestamptz             DEFAULT NULL
+)
+
+CREATE TABLE poll_answers
+( id                    bigserial               PRIMARY KEY
+, body                  text                    
+, votes                 int                     DEFAULT 0
+, question_id           bigserial               PRIMARY KEY
+, created_at            timestamptz             NOT NULL
+, updated_at            timestamptz             DEFAULT NULL
+, FOREIGN KEY question_id REFERENCES poll_questions(id)
+)
+
+CREATE TABLE poll_voting_history
+( id                    bigserial               PRIMARY KEY
+, question_id           bigserial               UNIQUE KEY
+, answer_id             bigserial               UNIQUE KEY              text                    
+, usr_id                bigserial               UNIQUE KEY
+, created_at            timestamptz             NOT NULL
+, updated_at            timestamptz             DEFAULT NULL
+, FOREIGN KEY question_id REFERENCES poll_questions(id)
+)


### PR DESCRIPTION
Schema includes three tables. One for poll questions, second for poll answers and third for poll voting history.
Table "poll_questions" records each poll.
Table "poll_answers" records all answers to the questions from  "poll_questions" table.
Table "poll_voting_history" stores vote for each user to specific poll.

Attention! Values are indicative and might need a change. 
