### PR TITLE
Stop rejecting user-input money amounts which contain matching currency signs

### DIFF
--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -274,7 +274,7 @@ class Locale(babel.core.Locale):
         decimal_symbol = self.number_symbols['decimal']
         # If first character is relavent currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
-        if string[0] == get_currency_symbol(currency):
+        if string.startswith(self.currency_symbols.get(currency, currency)):
             string = string [1:]
         try:
             decimal = Decimal(

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -7,7 +7,7 @@ from unicodedata import combining, normalize
 import babel.core
 from babel.dates import format_date, format_datetime, format_time, format_timedelta
 from babel.messages.pofile import Catalog
-from babel.numbers import parse_pattern
+from babel.numbers import parse_pattern, get_currency_symbol
 from cached_property import cached_property
 from markupsafe import Markup
 import opencc
@@ -272,6 +272,10 @@ class Locale(babel.core.Locale):
     def parse_money_amount(self, string, currency, maximum=D_MAX):
         group_symbol = self.number_symbols['group']
         decimal_symbol = self.number_symbols['decimal']
+        # If first character is relavent currency symbol, remove it and pass only numeric string
+        # InvalidNumber will catch error if using the wrong currency symbol
+        if string[0] == get_currency_symbol(currency):
+            string = string [1:]
         try:
             decimal = Decimal(
                 string.replace(group_symbol, '').replace(decimal_symbol, '.')

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -7,7 +7,7 @@ from unicodedata import combining, normalize
 import babel.core
 from babel.dates import format_date, format_datetime, format_time, format_timedelta
 from babel.messages.pofile import Catalog
-from babel.numbers import parse_pattern, get_currency_symbol
+from babel.numbers import parse_pattern
 from cached_property import cached_property
 from markupsafe import Markup
 import opencc

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -275,7 +275,7 @@ class Locale(babel.core.Locale):
         # If first character is relavent currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
         if string.startswith(self.currency_symbols.get(currency, currency)):
-            string = string [1:]
+            string = string[1:]
         try:
             decimal = Decimal(
                 string.replace(group_symbol, '').replace(decimal_symbol, '.')

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -287,6 +287,8 @@ class Locale(babel.core.Locale):
         # then an `InvalidNumber` exception is raised.
         try:
             decimal = Decimal(
+                ''.join(string.split()).replace(decimal_symbol, '.')
+                if group_symbol.isspace() else
                 string.replace(group_symbol, '').replace(decimal_symbol, '.')
             )
         except (InvalidOperation, ValueError):

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -275,10 +275,11 @@ class Locale(babel.core.Locale):
         # If string begins or ends with relevant currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
         string = string.strip()
-        currency_length = len(self.currency_symbols.get(currency, currency))
-        if string.startswith(self.currency_symbols.get(currency, currency)):
+        currency_symbol = self.currency_symbols.get(currency, currency)
+        currency_length = len(currency_symbol)
+        if string.startswith(currency_symbol):
             string = string[currency_length:]
-        elif string.endswith(self.currency_symbols.get(currency, currency)):
+        elif string.endswith(currency_symbol):
             string = string[0:-currency_length]
         string = string.strip()
         try:

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -272,10 +272,15 @@ class Locale(babel.core.Locale):
     def parse_money_amount(self, string, currency, maximum=D_MAX):
         group_symbol = self.number_symbols['group']
         decimal_symbol = self.number_symbols['decimal']
-        # If first character is relavent currency symbol, remove it and pass only numeric string
+        # If string begins or ends with relavent currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
+        string = string.strip()
+        currency_length = len(self.currency_symbols.get(currency, currency))
         if string.startswith(self.currency_symbols.get(currency, currency)):
-            string = string[1:]
+            string = string[currency_length:]
+        elif string.endswith(self.currency_symbols.get(currency, currency)):
+            string = string[0:-currency_length]
+        string = string.strip()
         try:
             decimal = Decimal(
                 string.replace(group_symbol, '').replace(decimal_symbol, '.')

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -275,13 +275,14 @@ class Locale(babel.core.Locale):
         # If string begins or ends with relevant currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
         string = string.strip()
-        currency_symbol = self.currency_symbols.get(currency, currency)
-        currency_length = len(currency_symbol)
-        if string.startswith(currency_symbol):
-            string = string[currency_length:]
-        elif string.endswith(currency_symbol):
-            string = string[0:-currency_length]
-        string = string.strip()
+        currency_symbol = self.currency_symbols.get(currency)
+        if currency_symbol:
+            symbol_length = len(currency_symbol)
+            if string.startswith(currency_symbol):
+                string = string[symbol_length:]
+            elif string.endswith(currency_symbol):
+                string = string[:-symbol_length]
+            string = string.strip()
         try:
             decimal = Decimal(
                 string.replace(group_symbol, '').replace(decimal_symbol, '.')

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -272,7 +272,7 @@ class Locale(babel.core.Locale):
     def parse_money_amount(self, string, currency, maximum=D_MAX):
         group_symbol = self.number_symbols['group']
         decimal_symbol = self.number_symbols['decimal']
-        # If string begins or ends with relavent currency symbol, remove it and pass only numeric string
+        # If string begins or ends with relevant currency symbol, remove it and pass only numeric string
         # InvalidNumber will catch error if using the wrong currency symbol
         string = string.strip()
         currency_length = len(self.currency_symbols.get(currency, currency))

--- a/tests/py/test_i18n.py
+++ b/tests/py/test_i18n.py
@@ -65,6 +65,15 @@ class Tests(Harness):
         with self.assertRaises(AmbiguousNumber):
             LOCALE_EN.parse_money_amount("10,00", 'EUR')
 
+    def test_parse_money_amount_tolerates_spaces_and_matching_currency_symbols(self):
+        assert LOCALE_EN.parse_money_amount("$1", 'USD')
+        assert LOCALE_EN.parse_money_amount(" € 2,000.22 ", 'EUR')
+        assert LOCALE_EN.parse_money_amount("3€", 'EUR')
+        locale_fr = self.website.locales['fr-fr']
+        assert locale_fr.parse_money_amount("  4 000,99  €  ", 'EUR')
+        with self.assertRaises(InvalidNumber):
+            LOCALE_EN.parse_money_amount("$100", 'EUR')
+
     def test_chinese_visitor_gets_chinese_locale(self):
         state = self.client.GET('/', HTTP_ACCEPT_LANGUAGE=b'zh', want='state')
         assert state['locale'] is self.website.locales['zh-hans']


### PR DESCRIPTION
…t result in an error

I added the `get_currency_symbol` function from babel.

This PR is for issue #2134 