### PR TITLE
add last and next payday dates to table

### DIFF
--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -28,13 +28,7 @@ class Website(_Website):
     def compute_previous_and_next_payday_dates(self):
         today = utcnow().date()
         days_till_wednesday = (3 - today.isoweekday()) % 7
-        last_payday = self.db.one("""
-            SELECT ts_end::date
-              FROM paydays
-             WHERE ts_end > ts_start
-          ORDER BY ts_end DESC
-             LIMIT 1
-        """)
+        last_payday = self.db.one("SELECT max(ts_end)::date FROM paydays")
         if days_till_wednesday == 0 and last_payday == today:
             days_till_wednesday = 7
         next_payday = today + timedelta(days=days_till_wednesday)

--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -28,18 +28,17 @@ class Website(_Website):
     def compute_previous_and_next_payday_dates(self):
         today = pando.utils.utcnow().date()
         days_till_wednesday = (3 - today.isoweekday()) % 7
-        last_payday = website.db.one("""
+        last_payday = self.db.one("""
             SELECT ts_end::date
               FROM paydays
              WHERE ts_end > ts_start
           ORDER BY ts_end DESC
              LIMIT 1
-        """, (today,))
+        """)
         if last_payday == today:
             days_till_wednesday = 7
         next_payday = today + timedelta(days=days_till_wednesday)
-        paydays = {"last_payday": last_payday, "next_payday": next_payday}
-        return paydays
+        return last_payday, next_payday
 
     def link(self, path, text):
         return self._html_link % (path, text)

--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -35,7 +35,7 @@ class Website(_Website):
           ORDER BY ts_end DESC
              LIMIT 1
         """)
-        if last_payday == today:
+        if days_till_wednesday == 0 and last_payday == today:
             days_till_wednesday = 7
         next_payday = today + timedelta(days=days_till_wednesday)
         return last_payday, next_payday

--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -11,7 +11,7 @@ import os
 from cached_property import cached_property
 from environment import Environment, is_yesish
 from markupsafe import Markup
-import pando.utils
+from pando.utils import utcnow
 from pando.website import Website as _Website
 
 
@@ -26,7 +26,7 @@ class Website(_Website):
         )
 
     def compute_previous_and_next_payday_dates(self):
-        today = pando.utils.utcnow().date()
+        today = utcnow().date()
         days_till_wednesday = (3 - today.isoweekday()) % 7
         last_payday = self.db.one("""
             SELECT ts_end::date

--- a/liberapay/website.py
+++ b/liberapay/website.py
@@ -30,10 +30,10 @@ class Website(_Website):
         days_till_wednesday = (3 - today.isoweekday()) % 7
         last_payday = website.db.one("""
             SELECT ts_end::date
-            FROM paydays
-            WHERE ts_end > ts_start
-            ORDER BY ts_end DESC
-            LIMIT 1
+              FROM paydays
+             WHERE ts_end > ts_start
+          ORDER BY ts_end DESC
+             LIMIT 1
         """, (today,))
         if last_payday == today:
             days_till_wednesday = 7

--- a/templates/macros/team-members.html
+++ b/templates/macros/team-members.html
@@ -21,8 +21,8 @@
       <thead>
         <tr>
           <th></th>
-          <th>{{ _("Last Payday") }}<br>({{ locale.format_date(last_payday) if last_payday else _("n/a") }})</th>
-          <th colspan=2>{{ _("Next Payday") }}<br>({{ locale.format_date(next_payday) }})</th>
+          <th>{{ _("Last Payday") }}<br><small>({{ locale.format_date(last_payday) if last_payday else _("n/a") }})</small></th>
+          <th colspan=2>{{ _("Next Payday") }}<br><small>({{ locale.format_date(next_payday) }})</small></th>
         </tr>
         <tr>
           <th>{{ _("Member") }}</th>

--- a/templates/macros/team-members.html
+++ b/templates/macros/team-members.html
@@ -7,6 +7,7 @@
 
 % macro team_takes_table(team, cls='')
     % set members = team.get_members()
+    % set paydays = website.compute_previous_and_next_payday_dates()
     % if user.id in members and members[user.id]['max_this_week']
         <p>{{ _(
             "Your nominal take from the {0} team is limited to {1} this week. "
@@ -20,8 +21,8 @@
       <thead>
         <tr>
           <th></th>
-          <th>{{ _("Last Payday") }}</th>
-          <th colspan=2>{{ _("Next Payday") }}</th>
+          <th>{{ _("Last Payday") }} ({{ paydays.last_payday }})</th>
+          <th colspan=2>{{ _("Next Payday") }} ({{ paydays.next_payday }})</th>
         </tr>
         <tr>
           <th>{{ _("Member") }}</th>

--- a/templates/macros/team-members.html
+++ b/templates/macros/team-members.html
@@ -7,7 +7,7 @@
 
 % macro team_takes_table(team, cls='')
     % set members = team.get_members()
-    % set paydays = website.compute_previous_and_next_payday_dates()
+    % set last_payday, next_payday = website.compute_previous_and_next_payday_dates()
     % if user.id in members and members[user.id]['max_this_week']
         <p>{{ _(
             "Your nominal take from the {0} team is limited to {1} this week. "
@@ -21,8 +21,8 @@
       <thead>
         <tr>
           <th></th>
-          <th>{{ _("Last Payday") }} ({{ locale.format_date(paydays.last_payday) }})</th>
-          <th colspan=2>{{ _("Next Payday") }} ({{ locale.format_date(paydays.next_payday) }})</th>
+          <th>{{ _("Last Payday") }}<br>({{ locale.format_date(last_payday) if last_payday else _("n/a") }})</th>
+          <th colspan=2>{{ _("Next Payday") }}<br>({{ locale.format_date(next_payday) }})</th>
         </tr>
         <tr>
           <th>{{ _("Member") }}</th>

--- a/templates/macros/team-members.html
+++ b/templates/macros/team-members.html
@@ -21,8 +21,8 @@
       <thead>
         <tr>
           <th></th>
-          <th>{{ _("Last Payday") }} ({{ paydays.last_payday }})</th>
-          <th colspan=2>{{ _("Next Payday") }} ({{ paydays.next_payday }})</th>
+          <th>{{ _("Last Payday") }} ({{ locale.format_date(paydays.last_payday) }})</th>
+          <th colspan=2>{{ _("Next Payday") }} ({{ locale.format_date(paydays.next_payday) }})</th>
         </tr>
         <tr>
           <th>{{ _("Member") }}</th>


### PR DESCRIPTION
@Changaco  Hi, I had a crack at #2119 

In `liberapay/website.py`I made a new method called `compute_previous_and_next_payday_dates` which gets the last payday date, (using `ts_end`, my thinking was that would be the time the payday finished, so it may be more accurate for some edge cases.) and finds out the next payday just by calculating the next Wednesday. Also, I queried the actual date of the last payday just in case it ever changes from Wednesday, not sure if it's necessary though.

In `templates/macros/team-members.html` I input the payday values in the `Last Payday` and `Next Payday` cells, surrounded by parenthesis for better clarity. Maybe they should be styled differently than the preceding text?