### PR TITLE
Add Croatia, Gibraltar and Liechtenstein to the list of countries supported by Stripe

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -299,8 +299,8 @@ PAYOUT_COUNTRIES = {
     """.split()),  # https://www.paypal.com/us/webapps/mpp/country-worldwide
 
     'stripe': set("""
-        AT AU BE BG CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IT JP LT LU LV
-        MT MX MY NL NO NZ PL PT RO SE SG SI SK US
+        AT AU BE BG CA CH CY CZ DE DK EE ES FI FR GB GI GR HK HR HU IE IT JP LI
+        LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US
         PR
     """.split()),  # https://stripe.com/global
 }


### PR DESCRIPTION
Liberapay is now fully available in the entire European Union, as Croatia was the last unsupported EU country.