### PR TITLE
change GitLab display name to GitLab.com

### DIFF
--- a/liberapay/elsewhere/gitlab.py
+++ b/liberapay/elsewhere/gitlab.py
@@ -7,7 +7,7 @@ class GitLab(PlatformOAuth2):
 
     # Platform attributes
     name = 'gitlab'
-    display_name = 'GitLab'
+    display_name = 'GitLab.com'
     fontawesome_name = name
     account_url = 'https://gitlab.com/{user_name}'
     repo_url = 'https://gitlab.com/{slug}'


### PR DESCRIPTION
This is corresponding to issue #2148 

I just changed the `display_name` of the `GitLab` class to `GitLab.com`