### PR TITLE
Account closure reason

### DIFF
--- a/liberapay/constants.py
+++ b/liberapay/constants.py
@@ -428,6 +428,7 @@ STANDARD_TIPS = _StandardTips(None, {
 })
 
 SUMMARY_MAX_SIZE = 100
+FEEDBACK_MAX_SIZE = 1000
 
 TAKE_THROTTLING_THRESHOLD = MoneyAutoConvertDict(
     {k: Money('1.00', k) for k in ('EUR', 'USD')}

--- a/liberapay/main.py
+++ b/liberapay/main.py
@@ -181,6 +181,7 @@ if conf:
     cron(Daily(hour=16), fetch_currency_exchange_rates, True)
     cron(Daily(hour=17), paypal.sync_all_pending_payments, True)
     cron(Daily(hour=18), Payday.update_cached_amounts, True)
+    cron(Daily(hour=19), Participant.delete_old_feedback, True)
     cron(intervals.get('notify_patrons', 1200), Participant.notify_patrons, True)
     if conf.ses_feedback_queue_url:
         cron(intervals.get('fetch_email_bounces', 60), handle_email_bounces, True)

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -850,6 +850,20 @@ class Participant(Model, MixinTeam):
         for route in routes:
             route.invalidate()
 
+    def store_feedback(self, feedback):
+        """Store feedback in database if provided by user
+        """
+        feedback = '' if feedback is None else feedback.strip()
+        if feedback:
+            self.db.run("""
+                INSERT INTO feedback
+                            (participant, feedback)
+                     VALUES (%s, %s)
+                ON CONFLICT (participant) DO UPDATE
+                        SET feedback = excluded.feedback
+                          , ctime = excluded.ctime
+            """, (self.id, feedback))
+
     @cached_property
     def closed_time(self):
         return self.db.one("""

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+CREATE TABLE feedback
+( participant   bigint      PRIMARY KEY
+, feedback      text        NOT NULL
+);
+
+END;

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -3,6 +3,7 @@ BEGIN;
 CREATE TABLE feedback
 ( participant   bigint      PRIMARY KEY
 , feedback      text        NOT NULL
+, ctime         timestamptz NOT NULL DEFAULT current_timestamp
 );
 
 END;

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -472,10 +472,6 @@ input.search {
     }
 }
 
-#subnav + p, #subnav + div.paragraph {
-    margin-top: 1.5em;
-}
-
 ul.emails {
     margin: 1em 0;
     max-width: 600px;

--- a/style/base/utils.scss
+++ b/style/base/utils.scss
@@ -31,8 +31,20 @@
     margin-top: 0 !important;
 }
 
-.paragraph {
+.mb-3 {
     margin-bottom: ($line-height-computed / 2);
+}
+
+.mb-4 {
+    margin-bottom: $line-height-computed;
+}
+
+.mt-3 {
+    margin-top: ($line-height-computed / 2);
+}
+
+.mt-4 {
+    margin-bottom: $line-height-computed;
 }
 
 .pre-wrap {

--- a/www/%username/admin.spt
+++ b/www/%username/admin.spt
@@ -18,6 +18,10 @@ events = website.db.all("""
   ORDER BY e.ts DESC, e.id DESC
 """, (participant.id,))
 
+feedback = None if participant.status != 'closed' else website.db.one("""
+    SELECT feedback FROM feedback WHERE participant = %s
+""", (participant.id,))
+
 [---] text/html
 % from 'templates/macros/admin.html' import admin_form with context
 
@@ -28,6 +32,11 @@ events = website.db.all("""
 <h3>Admin flags</h3>
 
 {{ admin_form(participant, reload=True, style='inline-labels') }}
+
+% if feedback
+<h3>Feedback</h3>
+<div class="profile-statement embedded raw">{{ feedback }}</div>
+% endif
 
 <h3>Events</h3>
 

--- a/www/%username/giving/pay/stripe/%payin_id.spt
+++ b/www/%username/giving/pay/stripe/%payin_id.spt
@@ -498,8 +498,8 @@ title = _("Funding your donations")
         <fieldset id="card-form" class="form-group {{ 'hidden' if routes else '' }}">
             <p>{{ _("Please input your name and card number:") }}</p>
             <input name="owner.name" autocomplete="name" required minlength=3
-                   class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
-            <div id="stripe-element" data-type="card" class="form-control paragraph"></div>
+                   class="form-control mb-3" placeholder="{{ _('Jane Doe') }}" />
+            <div id="stripe-element" data-type="card" class="form-control mb-3"></div>
             <span id="stripe-errors" role="alert" class="invalid-msg"></span>
             <p class="help-block">{{ glyphicon('lock') }} {{ _(
                 "This data will be sent directly to the payment processor "
@@ -522,8 +522,8 @@ title = _("Funding your donations")
                 "Please input your name and your IBAN (International Bank Account Number):"
             ) }}</p>
             <input name="owner.name" autocomplete="name" required minlength=3
-                   class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
-            <div id="stripe-element" data-type="iban" class="form-control paragraph"></div>
+                   class="form-control mb-3" placeholder="{{ _('Jane Doe') }}" />
+            <div id="stripe-element" data-type="iban" class="form-control mb-3"></div>
             <span id="stripe-errors" role="alert" class="invalid-msg"></span>
             <p class="help-block">{{ _(
                 "By providing your IBAN and confirming this payment, you are authorizing "

--- a/www/%username/identity.spt
+++ b/www/%username/identity.spt
@@ -74,7 +74,6 @@ else:
 % extends "templates/layouts/settings.html"
 
 % block content
-<div class="paragraph">
 <form action="" method="POST">
 
     % if error
@@ -100,5 +99,4 @@ else:
     <button class="btn btn-primary btn-lg" type="submit">{{ _("Save") }}</button>
 
 </form>
-</div>
 % endblock

--- a/www/%username/index.html.spt
+++ b/www/%username/index.html.spt
@@ -235,7 +235,7 @@ show_income = not participant.hide_receiving and participant.accepts_tips
     <p>{{ ngettext("", "The top {n} patrons are:", len(public_patrons)) }}</p>
     % endif
 
-    <div class="paragraph">
+    <div class="mb-3">
     % for p in public_patrons
         <div class="mini-user">
             <a href="/~{{ p.id }}/">
@@ -273,7 +273,7 @@ show_income = not participant.hide_receiving and participant.accepts_tips
         n=n_public_donees,
     ) }}</p>
 
-    <div class="paragraph">
+    <div class="mb-3">
     % for p in public_donees
         <div class="mini-user">
             <a href="/~{{ p.id }}/">

--- a/www/%username/routes/add.spt
+++ b/www/%username/routes/add.spt
@@ -88,8 +88,8 @@ title = _("Add a payment instrument")
             <p>{{ _("Please input your name and card number:") }}</p>
             <div class="form-group">
                 <input name="owner.name" autocomplete="name" required minlength=3
-                       class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
-                <div id="stripe-element" data-type="card" class="form-control paragraph"></div>
+                       class="form-control mb-3" placeholder="{{ _('Jane Doe') }}" />
+                <div id="stripe-element" data-type="card" class="form-control mb-3"></div>
                 <span id="stripe-errors" role="alert" class="invalid-msg"></span>
             </div>
             <p class="help-block">{{ glyphicon('lock') }} {{ _(
@@ -113,8 +113,8 @@ title = _("Add a payment instrument")
             ) }}</p>
             <div class="form-group">
                 <input name="owner.name" autocomplete="name" required minlength=3
-                       class="form-control paragraph" placeholder="{{ _('Jane Doe') }}" />
-                <div id="stripe-element" data-type="iban" class="form-control paragraph"></div>
+                       class="form-control mb-3" placeholder="{{ _('Jane Doe') }}" />
+                <div id="stripe-element" data-type="iban" class="form-control mb-3"></div>
                 <span id="stripe-errors" role="alert" class="invalid-msg"></span>
             </div>
             <p class="help-block">{{ _(

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -5,6 +5,8 @@ from liberapay.utils import get_participant
 participant = get_participant(state, restrict=True)
 
 if request.method == 'POST':
+    feedback = request.body.get('feedback')
+    participant.store_feedback(feedback)
     participant.close()
     participant.sign_out(response.headers.cookie)
     response.redirect('/%s/' % participant.username)
@@ -51,7 +53,15 @@ subhead = participant.username
             "determine that you've been infringing a trademark)."
         ) }}</p>
         % endif
+        
+        <p>{{ _(
+            "Before you go, would you like to let us know why you're leaving? We can use your feedback to improve Liberapay."
+        ) }}</p>
 
+        <textarea name="feedback" class="form-control"
+                maxlength="{{ constants.FEEDBACK_MAX_SIZE }}"
+                placeholder="{{ _('Reason for closing account') }}">
+        </textarea>
 
         <h3>{{ _("Ready?") }}</h3>
 

--- a/www/%username/settings/close.spt
+++ b/www/%username/settings/close.spt
@@ -53,15 +53,19 @@ subhead = participant.username
             "determine that you've been infringing a trademark)."
         ) }}</p>
         % endif
-        
+
+
+        <h3>{{ _("Feedback") }}</h3>
+
         <p>{{ _(
-            "Before you go, would you like to let us know why you're leaving? We can use your feedback to improve Liberapay."
+            "If you would like to tell us why you're closing your account, you "
+            "can leave a message here:"
         ) }}</p>
 
-        <textarea name="feedback" class="form-control"
-                maxlength="{{ constants.FEEDBACK_MAX_SIZE }}"
-                placeholder="{{ _('Reason for closing account') }}">
-        </textarea>
+        <textarea name="feedback" class="form-control" maxlength="{{ constants.FEEDBACK_MAX_SIZE }}"
+                  rows=3 placeholder="{{ _('Reason for closing account') }}"></textarea>
+        <p class="help-block">{{ _("Maximum length is {0}.", constants.FEEDBACK_MAX_SIZE) }}</p>
+
 
         <h3>{{ _("Ready?") }}</h3>
 

--- a/www/admin/users.spt
+++ b/www/admin/users.spt
@@ -51,6 +51,7 @@ if mode == 'all':
         SELECT p
              , c.name AS c_name
              , c.creator AS c_creator
+             , f.feedback AS feedback
              , ( SELECT json_build_object(
                             'address', e.address,
                             'verified', e.verified,
@@ -108,6 +109,7 @@ if mode == 'all':
                ) AS last_change
           FROM participants p
      LEFT JOIN communities c ON c.participant = p.id
+     LEFT JOIN feedback f ON f.participant = p.id
          WHERE coalesce(p.id < %s, true)
            AND (p.status <> 'stub' OR p.receiving > 0)
       ORDER BY p.id DESC
@@ -353,6 +355,15 @@ title = "Users Admin"
         % endif
         % endif
         % endif
+
+        % if row.feedback
+        <div>
+            <strong>Feedback:</strong>
+            <div class="profile-statement embedded raw">{{ row.feedback }}</div>
+        </div>
+        % elif p.status == 'closed'
+        <p><strong>Feedback:</strong> none.<p>
+        %endif
 
         <div><strong>Profile descriptions:</strong>
         % if p.public_name

--- a/www/admin/users.spt
+++ b/www/admin/users.spt
@@ -356,15 +356,6 @@ title = "Users Admin"
         % endif
         % endif
 
-        % if row.feedback
-        <div>
-            <strong>Feedback:</strong>
-            <div class="profile-statement embedded raw">{{ row.feedback }}</div>
-        </div>
-        % elif p.status == 'closed'
-        <p><strong>Feedback:</strong> none.<p>
-        %endif
-
         <div><strong>Profile descriptions:</strong>
         % if p.public_name
             <br>
@@ -387,6 +378,15 @@ title = "Users Admin"
             none. <span class="text-warning">{{ glyphicon('warning-sign') }}</span>
         % endif
         </div>
+
+        % if row.feedback
+        <div class="mt-3">
+            <strong>Feedback:</strong>
+            <div class="profile-statement embedded raw">{{ row.feedback }}</div>
+        </div>
+        % elif p.status == 'closed'
+        <div class="mt-3"><strong>Feedback:</strong> none.</div>
+        % endif
     % endif
     </div>
     <div class="col-md-4">

--- a/www/on/%platform/index.spt
+++ b/www/on/%platform/index.spt
@@ -59,7 +59,7 @@ if account:
 
 % block subnav
     % from "templates/macros/nav.html" import nav with context
-    <nav class="nav nav-pills">
+    <nav class="nav nav-pills mb-4">
         {{ nav(platforms_nav, base='/on') }}
     </nav>
 % endblock
@@ -67,12 +67,9 @@ if account:
 % block content
 
 % if len(accounts) > 1
-    <br>
-    <nav><ul class="nav nav-pills">{{ querystring_nav('e_user_id', accounts_nav, selected_account_id) }}</ul></nav>
-    <br>
+    <nav class="mb-4"><ul class="nav nav-pills">{{ querystring_nav('e_user_id', accounts_nav, selected_account_id) }}</ul></nav>
 % endif
 
-<div class="paragraph">
 % if user.ANON
     % from "templates/macros/sign-in-link.html" import sign_in_link with context
     {{ sign_in_link() }}<br>
@@ -111,6 +108,5 @@ if account:
 % endif
 
 % endif
-</div>
 
 % endblock

--- a/www/search.spt
+++ b/www/search.spt
@@ -154,7 +154,7 @@ if query:
                         len(repositories)) }}</h3>
         % for repo in repositories
             % set owner = repo.owner
-            <div class="paragraph">
+            <div class="mb-3">
                 <a href="/{{ owner.username }}/" class="avatar-inline">
                     {{ avatar_img(owner, size=28) }}
                 </a>


### PR DESCRIPTION
closes #2144 

It's not completed yet, but I'd like to know if there's anything that could be done better so far and discuss some ideas.

I've basically added the method `store_feedback()` to the `Participant` class, and have it run in the `close()` method.
It store what was written in the feedback text area in `www/%username/settings/close.spt` in the `feedback` table of the database, which I created in the `branch.sql` file.

I made a new `FEEDBACK_MAX_SIZE` variable in `constants.py` which I've set to 300.

I created some new lines of text which I guess would need to be translated if they are kept.

It still needs to display the feedback in the `admin/users` page and to delete the feedback after a year or so. 

For deletion, I'm thinking of adding the date the feedback was created to the database, and then adding a cron job to `libereapay/main.py` to check for feedback over a year old. 