### PR TITLE
standalone month format

### DIFF
--- a/www/%username/ledger/index.spt
+++ b/www/%username/ledger/index.spt
@@ -88,7 +88,7 @@ if participant.join_time:
         % if len(total_received_by_month) > 1
         <ul>
         % for month, money_basket in sorted(total_received_by_month.items(), reverse=True)
-            <li>{{ _("{0}: {1}", locale.months['format']['wide'][month], money_basket) }}</li>
+            <li>{{ _("{0}: {1}", locale.months['stand-alone']['wide'][month], money_basket) }}</li>
         % endfor
         </ul>
         % endif
@@ -98,7 +98,7 @@ if participant.join_time:
         % if len(total_sent_by_month) > 1
         <ul>
         % for month, money_basket in sorted(total_sent_by_month.items(), reverse=True)
-            <li>{{ _("{0}: {1}", locale.months['format']['wide'][month], money_basket) }}</li>
+            <li>{{ _("{0}: {1}", locale.months['stand-alone']['wide'][month], money_basket) }}</li>
         % endfor
         </ul>
         % endif


### PR DESCRIPTION
in some languages, month written in date has a different form than it does on itself (e.g. Slovak, Czech)
```
júla: 0,xx €, 0,xx USD a 0,xx GBP
júna: 0,xx € a 0,xx USD
mája: 0,xx € a 0,xx USD
apríla: 0,xx € a 0,xx USD
marca: 0,xx € a 0,xx USD
februára: 0,xx € a 0,xx USD
januára: 0,xx €
```
Which should be:
```
júl: 0,xx €, 0,xx USD a 0,xx GBP
jún: 0,xx € a 0,xx USD
máj: 0,xx € a 0,xx USD
apríl: 0,xx € a 0,xx USD
marec: 0,xx € a 0,xx USD
február: 0,xx € a 0,xx USD
január: 0,xx €
```