### PR TITLE
Fix nav overflow

### DIFF
--- a/style/base/navs.scss
+++ b/style/base/navs.scss
@@ -9,6 +9,7 @@
     & > .nav-col {
         flex-shrink: 0;
         max-width: 180px;
+        hyphens: auto;
         & > label {
             background-color: #f5f5f5;
             border-radius: 6px;


### PR DESCRIPTION
For to long Strings (e.g. translated) it's possible to overflow (at least) the left navigation. This proposed Pull request should fix that.

| before | after |
| -------- | ------ |
| ![grafik](https://user-images.githubusercontent.com/109021367/184642637-b83d2d08-5691-4362-8b90-7b5374ca6b55.png) | ![grafik](https://user-images.githubusercontent.com/109021367/184642514-07262755-8aa3-4983-a9cd-b363eb653456.png) |