### PR TITLE
make width of search div that of search input

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -357,6 +357,10 @@ ul.memberships {
     }
 }
 
+div[role=search] {
+    width: max-content;
+}
+
 input.search {
     width: 250px;
 }

--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -357,12 +357,8 @@ ul.memberships {
     }
 }
 
-div[role=search] {
-    width: max-content;
-}
-
 input.search {
-    width: 250px;
+    min-width: 250px;
 }
 
 .search-result {


### PR DESCRIPTION
Inspired by #2174, I tried to fix the issue where the search input element's width was too small to show the entire placeholder. I made the containing div fit the input's width.

I messed up the previous PR for this. I closed that and this is the correct one.