### PR TITLE
Update Mastodon brand color

### DIFF
--- a/style/base/icons.scss
+++ b/style/base/icons.scss
@@ -4,7 +4,7 @@
     &.fa-facebook-square { color: #3c5598; }
     &.fa-github { color: #24292e; }
     &.fa-gitlab { color: #fca326; }
-    &.fa-mastodon { color: #3088d4; }
+    &.fa-mastodon { color: #6364ff; }
     &.fa-pleroma { color: #fba457; }
     &.fa-twitch { color: #6441a5; }
     &.fa-twitter { color: #1da1f2; }


### PR DESCRIPTION
Closes #2211 

Taken from Brand Toolkit: https://joinmastodon.org/branding and confirmed via their sass variable: https://github.com/mastodon/mastodon/blob/main/app/javascript/styles/mastodon/variables.scss#L15