### PR TITLE
Fix corner case in payments to teams

### DIFF
--- a/liberapay/models/_mixin_team.py
+++ b/liberapay/models/_mixin_team.py
@@ -202,17 +202,11 @@ class MixinTeam:
     def get_current_takes_for_payment(self, currency, weekly_amount):
         """
         Return the list of current takes with the extra information that the
-        `liberapay.payin.common.resolve_take_amounts` function needs to compute
+        `liberapay.payin.common.resolve_team_donation` function needs to compute
         transfer amounts.
         """
         takes = self.db.all("""
-            SELECT t.member
-                 , t.ctime
-                 , convert(t.amount, %(currency)s) AS amount
-                 , convert(
-                       coalesce_currency_amount(t.paid_in_advance, t.amount::currency),
-                       %(currency)s
-                   ) AS paid_in_advance
+            SELECT t.member, t.ctime, t.amount AS nominal_amount, t.paid_in_advance
                  , p.is_suspended
               FROM current_takes t
               JOIN participants p ON p.id = t.member
@@ -222,8 +216,8 @@ class MixinTeam:
         income_amount = self.receiving.convert(currency) + weekly_amount.convert(currency)
         if income_amount == 0:
             income_amount = Money.MINIMUMS[currency]
-        manual_takes_sum = MoneyBasket(t.amount for t in takes if t.amount > 0)
-        n_auto_takes = sum(1 for t in takes if t.amount < 0) or 1
+        manual_takes_sum = MoneyBasket(t.nominal_amount for t in takes if t.nominal_amount > 0)
+        n_auto_takes = sum(1 for t in takes if t.nominal_amount < 0) or 1
         auto_take = (
             (income_amount - manual_takes_sum.fuzzy_sum(currency)) /
             n_auto_takes
@@ -231,7 +225,9 @@ class MixinTeam:
         if auto_take < 0:
             auto_take = zero
         for t in takes:
-            t.amount = auto_take if t.amount < 0 else t.amount.convert(currency)
+            t.paid_in_advance = (t.paid_in_advance or zero).convert(currency)
+            t.naive_amount = \
+                auto_take if t.nominal_amount < 0 else t.nominal_amount.convert(currency)
         return takes
 
     def recompute_actual_takes(self, cursor, member=None):

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -356,6 +356,11 @@ class TestResolveTeamDonation(Harness):
         assert account == stripe_account_bob
         self.db.run("UPDATE participants SET is_suspended = false WHERE id = %s", (carl.id,))
 
+        # Test when the only member the payment can go to has their take at zero
+        team.set_take_for(bob, EUR('0'), bob)
+        with self.assertRaises(MissingPaymentAccount):
+            self.resolve(team, 'stripe', alice, 'CN', EUR('10'), sepa_only=True)
+
 
 class TestPayinAmountSuggestions(Harness):
 

--- a/tests/py/test_payins.py
+++ b/tests/py/test_payins.py
@@ -135,7 +135,7 @@ class TestResolveAmounts(Harness):
 
 class TestResolveTeamDonation(Harness):
 
-    def resolve(self, team, provider, payer, payer_country, payment_amount):
+    def resolve(self, team, provider, payer, payer_country, payment_amount, sepa_only=False):
         tip = self.db.one("""
             SELECT *
               FROM current_tips
@@ -143,7 +143,8 @@ class TestResolveTeamDonation(Harness):
                AND tippee = %s
         """, (payer.id, team.id))
         donations = resolve_team_donation(
-            self.db, team, provider, payer, payer_country, payment_amount, tip
+            self.db, team, provider, payer, payer_country, payment_amount, tip,
+            sepa_only=sepa_only,
         )
         if len(donations) == 1:
             assert donations[0].amount == payment_amount
@@ -184,8 +185,14 @@ class TestResolveTeamDonation(Harness):
 
         # Test with two members but only one payment account at the requested provider
         paypal_account_carl = self.add_payment_account(carl, 'paypal')
+        team.set_take_for(carl, EUR('200.00'), carl)
         account = self.resolve(team, 'stripe', alice, 'BE', EUR('42'))
         assert account == stripe_account_bob
+        team.set_take_for(carl, EUR('-1'), carl)
+        team.set_take_for(carl, EUR('200.00'), bob)
+        account = self.resolve(team, 'paypal', alice, 'BE', EUR('47'))
+        assert account == paypal_account_carl
+        team.set_take_for(carl, EUR('-1'), bob)
 
         # Test with two members and both takes set to `auto`
         stripe_account_carl = self.add_payment_account(
@@ -292,6 +299,62 @@ class TestResolveTeamDonation(Harness):
         assert payin_transfers[0].destination == stripe_account_bob.pk
         assert payin_transfers[1].amount == USD('8.00')
         assert payin_transfers[1].destination == stripe_account_carl.pk
+
+    def test_resolve_team_donation_sepa_only(self):
+        alice = self.make_participant('alice')
+        bob = self.make_participant('bob')
+        carl = self.make_participant('carl')
+        team = self.make_participant('team', kind='group', accepted_currencies=None)
+        alice.set_tip_to(team, EUR('1.00'))
+
+        # Test without payment account
+        team.add_member(bob)
+        with self.assertRaises(MissingPaymentAccount):
+            self.resolve(team, 'stripe', alice, 'FR', EUR('10'), sepa_only=True)
+
+        # Test with a single member and the take set to `auto`
+        stripe_account_bob = self.add_payment_account(bob, 'stripe', country='FR')
+        account = self.resolve(team, 'stripe', alice, 'GB', EUR('7'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test self donation
+        bob.set_tip_to(team, EUR('0.06'))
+        with self.assertRaises(NoSelfTipping):
+            self.resolve(team, 'stripe', bob, 'FR', EUR('6'), sepa_only=True)
+
+        # Test with two members but only one Stripe account
+        team.add_member(carl)
+        self.add_payment_account(carl, 'paypal')
+        account = self.resolve(team, 'stripe', alice, 'CH', EUR('8'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test with two members and both takes set to `auto`
+        self.add_payment_account(carl, 'stripe', country='JP', default_currency='JPY')
+        account = self.resolve(team, 'stripe', alice, 'PL', EUR('5.46'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test with two members and one non-auto take
+        team.set_take_for(carl, EUR('200.00'), carl)
+        account = self.resolve(team, 'stripe', alice, 'RU', EUR('50.02'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test with two members and two different non-auto takes
+        team.set_take_for(bob, EUR('100.00'), bob)
+        account = self.resolve(team, 'stripe', alice, 'BR', EUR('10'), sepa_only=True)
+        assert account == stripe_account_bob
+        account = self.resolve(team, 'stripe', alice, 'BR', EUR('1'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test that self donation is avoided when there are two members
+        carl.set_tip_to(team, EUR('17.89'))
+        account = self.resolve(team, 'stripe', carl, 'FR', EUR('71.56'), sepa_only=True)
+        assert account == stripe_account_bob
+
+        # Test with a suspended member
+        self.db.run("UPDATE participants SET is_suspended = true WHERE id = %s", (carl.id,))
+        account = self.resolve(team, 'stripe', alice, 'RU', EUR('7.70'), sepa_only=True)
+        assert account == stripe_account_bob
+        self.db.run("UPDATE participants SET is_suspended = false WHERE id = %s", (carl.id,))
 
 
 class TestPayinAmountSuggestions(Harness):


### PR DESCRIPTION
On February 1st, a member of [the Mobian team](https://liberapay.com/mobian/), @a-wai, changed his take from `auto` to €250. Since [manual takes have priority](https://liberapay.com/about/teams), and the team's income is less than €250, this change has redirected all the team's income to him. Unfortunately, the fact that his Stripe account is disabled, combined with the bug fixed by this commit, prevented executing any new grouped payment which included the Mobian team as one of the beneficiaries. This snowballed into unrelated automatic payments not being executed on their scheduled dates (<https://github.com/liberapay/salon/issues/542#issuecomment-1440781746>), because it crashed the daily “cron” job. Finally, this entire problem went undetected for two weeks due to several shortcomings:

- for an as-yet unknown reason, the crashes of the daily cron job appear not to have been sent to, or recorded by, Sentry;
  - this might be due to the fact that we're not using the latest version of the Sentry Python library, so it's possible that a policy of regular updates of dependencies would have avoided this
- the limited amount of information displayed in the `/admin/schedules` page did not enable me to realize that some automatic payments were not being executed
- I have failed to fix in a timely manner a weakness which I had identified (#1656)

I plan to address these shortcomings in subsequent pull requests.