### PR TITLE
Fix donation form

### DIFF
--- a/liberapay/utils/emails.py
+++ b/liberapay/utils/emails.py
@@ -13,7 +13,6 @@ from aspen_jinja2_renderer import SimplateLoader
 import boto3
 from dns.exception import DNSException
 from dns.resolver import Cache, NXDOMAIN, Resolver
-from jinja2 import Environment
 from pando import Response
 from pando.utils import utcnow
 
@@ -23,7 +22,7 @@ from liberapay.exceptions import (
     EmailAddressError, EmailAddressIsBlacklisted, EmailDomainIsBlacklisted,
     InvalidEmailDomain, NonEmailDomain, EmailAddressRejected, TooManyAttempts,
 )
-from liberapay.renderers.jinja2 import JINJA_ENV_COMMON
+from liberapay.renderers.jinja2 import Environment
 from liberapay.utils import deserialize
 from liberapay.website import website
 
@@ -36,11 +35,8 @@ class EmailVerificationResult(Enum):
     SUCCEEDED = auto()
 
 
-jinja_env = Environment(**JINJA_ENV_COMMON)
-jinja_env_html = Environment(**dict(
-    JINJA_ENV_COMMON,
-    autoescape=True,
-))
+jinja_env = Environment()
+jinja_env_html = Environment(autoescape=True)
 
 def compile_email_spt(fpath):
     """Compile an email simplate.

--- a/templates/macros/your-tip.html
+++ b/templates/macros/your-tip.html
@@ -266,7 +266,7 @@
         "{username} has chosen not to see who their patrons are, so your donation will be secret.",
         username=tippee_name
     ) }}</p>
-    % elif patron_visibilities == 2 or paypal_only and patron_visibilities is None
+    % elif patron_visibilities == 2 or paypal_only and not patron_visibilities
     <p class="text-info">{{ glyphicon('info-sign') }} {{ _(
         "This donation won't be secret, you will appear in {username}'s private list of patrons.",
         username=tippee_name

--- a/tests/py/test_donating.py
+++ b/tests/py/test_donating.py
@@ -35,6 +35,21 @@ class TestDonating(Harness):
         assert tip.renewal_mode == 2
         assert tip.visibility == 3
 
+    def test_donation_form_v2_for_paypal_only_recipient(self):
+        creator = self.make_participant(
+            'creator', accepted_currencies=None, email='creator@liberapay.com',
+        )
+        self.add_payment_account(creator, 'paypal')
+        assert creator.payment_providers == 2
+        assert creator.recipient_settings.patron_visibilities == 0
+        r = self.client.GET('/creator/donate')
+        assert r.code == 200
+        assert "This donation won&#39;t be secret, " in r.text, r.text
+        creator.update_recipient_settings(patron_visibilities=7)
+        assert creator.recipient_settings.patron_visibilities == 7
+        r = self.client.GET('/creator/donate')
+        assert r.code == 200
+
     def test_donation_form_v2_does_not_overwrite_visibility(self):
         creator = self.make_participant(
             'creator', accepted_currencies=None, email='creator@liberapay.com',


### PR DESCRIPTION
#2226 contained a mistake which resulted in user-visible failures when attempting to view some `/~/donate` pages. I pushed a quick&dirty fix in production yesterday. This branch is the proper fix, with a regression test and a change to prevent similar failures in the future.