### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/sql/app-conf-defaults.sql
+++ b/sql/app-conf-defaults.sql
@@ -26,7 +26,7 @@ INSERT INTO app_conf (key, value) VALUES
     ('linuxfr_secret', '"8c518595790487015cd0c33be2d04939946f99aad33c86a6af20a99bc749fb3b"'::jsonb),
     ('log_emails', 'true'::jsonb),
     ('openstreetmap_api_url', '"https://api.openstreetmap.org/api/0.6"'::jsonb),
-    ('openstreetmap_auth_url', '"http://www.openstreetmap.org"'::jsonb),
+    ('openstreetmap_auth_url', '"https://www.openstreetmap.org"'::jsonb),
     ('openstreetmap_callback', '"http://127.0.0.1:8339/on/openstreetmap/associate"'::jsonb),
     ('openstreetmap_id', '"w4eQbkobmMzpkJFwS4tM16a3lq9AFbcoNCKNcGBE"'::jsonb),
     ('openstreetmap_secret', '"W08UgEhxQnh7nMzB7GfSFcqcwPnZMmKMNyxWdcw4"'::jsonb),

--- a/sql/app-conf-defaults.sql
+++ b/sql/app-conf-defaults.sql
@@ -25,7 +25,7 @@ INSERT INTO app_conf (key, value) VALUES
     ('linuxfr_id', '"c574b5f45ce054a0750a3764b3ff8ff2c9f88fe36611272a0bf5e4e07bd3c0bf"'::jsonb),
     ('linuxfr_secret', '"8c518595790487015cd0c33be2d04939946f99aad33c86a6af20a99bc749fb3b"'::jsonb),
     ('log_emails', 'true'::jsonb),
-    ('openstreetmap_api_url', '"http://www.openstreetmap.org/api/0.6"'::jsonb),
+    ('openstreetmap_api_url', '"https://api.openstreetmap.org/api/0.6"'::jsonb),
     ('openstreetmap_auth_url', '"http://www.openstreetmap.org"'::jsonb),
     ('openstreetmap_callback', '"http://127.0.0.1:8339/on/openstreetmap/associate"'::jsonb),
     ('openstreetmap_id', '"w4eQbkobmMzpkJFwS4tM16a3lq9AFbcoNCKNcGBE"'::jsonb),

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,2 @@
+UPDATE app_conf SET value = '"https://api.openstreetmap.org/api/0.6"'::jsonb WHERE key = 'openstreetmap_api_url';
+UPDATE app_conf SET value = '"https://www.openstreetmap.org"'::jsonb WHERE key = 'openstreetmap_auth_url';


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)