### PR TITLE
Use safe parsing function for test fixtures

### DIFF
--- a/liberapay/testing/vcr.py
+++ b/liberapay/testing/vcr.py
@@ -37,7 +37,7 @@ class CustomSerializer:
 
     @staticmethod
     def deserialize(cassette_str):
-        return yaml.load(cassette_str, Loader=yaml.Loader)
+        return yaml.safe_load(cassette_str)
 
 
 vcr = VCR(

--- a/tests/py/fixtures/TestElsewhere.yml
+++ b/tests/py/fixtures/TestElsewhere.yml
@@ -72,7 +72,7 @@ interactions:
     method: GET
     uri: https://bitbucket.org/api/2.0/users/adhsjakdjsdkjsajdhksda
   response:
-    body: {string: !!python/unicode '{"type": "error", "error": {"message": "adhsjakdjsdkjsajdhksda"}}'}
+    body: {string: '{"type": "error", "error": {"message": "adhsjakdjsdkjsajdhksda"}}'}
     headers:
       content-length: ['65']
       content-type: [application/json; charset=utf-8]
@@ -108,7 +108,7 @@ interactions:
     method: GET
     uri: https://gitlab.com/api/v4/users?username=adhsjakdjsdkjsajdhksda
   response:
-    body: {string: !!python/unicode '[]'}
+    body: {string: '[]'}
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-length: ['2']
@@ -126,12 +126,12 @@ interactions:
       vary: [Origin]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode client_secret=o090sc7828d7gljtrqc5n4vcpx3bfx&grant_type=client_credentials&client_id=9ro3g4slh0de5yijy6rqb2p0jgd7hi
+    body: client_secret=o090sc7828d7gljtrqc5n4vcpx3bfx&grant_type=client_credentials&client_id=9ro3g4slh0de5yijy6rqb2p0jgd7hi
     headers: {}
     method: POST
     uri: https://id.twitch.tv/oauth2/token
   response:
-    body: {string: !!python/unicode '{"access_token":"l5v4ham8prjwrvowu1pd1pue81t1qp","expires_in":5281481,"token_type":"bearer"}
+    body: {string: '{"access_token":"l5v4ham8prjwrvowu1pd1pue81t1qp","expires_in":5281481,"token_type":"bearer"}
 
 '}
     headers:
@@ -145,7 +145,7 @@ interactions:
     method: GET
     uri: https://api.twitch.tv/helix/users?login=adhsjakdjsdkjsajdhksda
   response:
-    body: {string: !!python/unicode '{"data":[]}'}
+    body: {string: '{"data":[]}'}
     headers:
       access-control-allow-origin: ['*']
       cache-control: ['no-cache, no-store, must-revalidate, private']
@@ -191,7 +191,7 @@ interactions:
     method: GET
     uri: https://bitbucket.org/api/2.0/users/%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       content-length: ['0']
       content-type: [text/html; charset=utf-8]
@@ -227,7 +227,7 @@ interactions:
     method: GET
     uri: https://gitlab.com/api/v4/users?username=%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
   response:
-    body: {string: !!python/unicode '[]'}
+    body: {string: '[]'}
     headers:
       cache-control: ['max-age=0, private, must-revalidate']
       content-length: ['2']
@@ -250,7 +250,7 @@ interactions:
     method: GET
     uri: https://api.twitch.tv/helix/users?login=%3E%27%3E%22%3E%3Cimg%20src%3Dx%20onerror%3Dalert%280%29%3E
   response:
-    body: {string: !!python/unicode '{"error":"Bad Request","status":400,"message":"Error
+    body: {string: '{"error":"Bad Request","status":400,"message":"Error
         (400): Invalid login parameter requested: \u003e''\u003e\"\u003e\u003cimg
         src=x onerror=alert(0)\u003e"}'}
     headers:

--- a/tests/py/fixtures/TestPayinRefund.yml
+++ b/tests/py/fixtures/TestPayinRefund.yml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: !!python/unicode '{"CreditedWalletId": "43046470", "SecureModeReturnURL":
+    body: '{"CreditedWalletId": "43046470", "SecureModeReturnURL":
       "http://localhost/", "Fees": {"Currency": "EUR", "Amount": 65}, "DebitedFunds":
       {"Currency": "EUR", "Amount": 2065}, "SecureMode": "DEFAULT", "AuthorId": "43046469",
       "Tag": "584343568", "CardId": "43046475"}'
@@ -26,7 +26,7 @@ interactions:
       pragma: [no-cache]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"DebitedFunds": {"Currency": "EUR", "Amount": 2000},
+    body: '{"DebitedFunds": {"Currency": "EUR", "Amount": 2000},
       "Tag": "584343569", "AuthorId": "43046469", "Payin": "43046758", "Fees": {"Currency":
       "EUR", "Amount": 0}}'
     headers: {}

--- a/tests/py/fixtures/TestRoutes.yml
+++ b/tests/py/fixtures/TestRoutes.yml
@@ -5,7 +5,7 @@ interactions:
     method: GET
     uri: https://api.sandbox.mangopay.com/v2.01/liberapay-dev/cards/20717494
   response:
-    body: {string: !!python/unicode '{"ExpirationDate":"1234","Alias":"356999XXXXXX0132","CardType":"CB_VISA_MASTERCARD","CardProvider":"MASTERCARD","Country":"USA","Product":"   ","BankCode":"unknown","Active":true,"Currency":"EUR","Validity":"VALID","UserId":"20717491","Id":"20717494","Tag":null,"CreationDate":1486643837}'}
+    body: {string: '{"ExpirationDate":"1234","Alias":"356999XXXXXX0132","CardType":"CB_VISA_MASTERCARD","CardProvider":"MASTERCARD","Country":"USA","Product":"   ","BankCode":"unknown","Active":true,"Currency":"EUR","Validity":"VALID","UserId":"20717491","Id":"20717494","Tag":null,"CreationDate":1486643837}'}
     headers:
       cache-control: [no-cache]
       content-length: ['288']
@@ -22,7 +22,7 @@ interactions:
     method: PUT
     uri: https://api.sandbox.mangopay.com/v2.01/liberapay-dev/cards/20717494
   response:
-    body: {string: !!python/unicode '{"ExpirationDate":"1234","Alias":"356999XXXXXX0132","CardType":"CB_VISA_MASTERCARD","CardProvider":"MASTERCARD","Country":"USA","Product":"   ","BankCode":"unknown","Active":false,"Currency":"EUR","Validity":"VALID","UserId":"20717491","Id":"20717494","Tag":null,"CreationDate":1486643837}'}
+    body: {string: '{"ExpirationDate":"1234","Alias":"356999XXXXXX0132","CardType":"CB_VISA_MASTERCARD","CardProvider":"MASTERCARD","Country":"USA","Product":"   ","BankCode":"unknown","Active":false,"Currency":"EUR","Validity":"VALID","UserId":"20717491","Id":"20717494","Tag":null,"CreationDate":1486643837}'}
     headers:
       cache-control: [no-cache]
       content-length: ['289']


### PR DESCRIPTION
Resolves <https://hackerone.com/reports/2467232>. The unsafe parsing function is only called on files checked into the repository, so it isn't exactly fed untrusted data. However, I'm willing to consider this a valid vulnerability in light of the recent xz backdoor incident, because the files in question are big and generated automatically, so an attacker might have been able to sneak an exploit in there without me noticing.

Sadly there are other attack vectors, and mitigating them will require significantly more work. [PyPI](https://pypi.org/), the software distribution service used by Liberapay to download its dependencies, is unsafe in its design. Any malicious entity who gains the ability to upload packages to PyPI for one of Liberapay's dependencies would have a good chance of breaching Liberapay completely. Related issue: #1305.