### PR TITLE
Fix parsing of money amounts

### DIFF
--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -336,7 +336,11 @@ class Locale(babel.core.Locale):
         # https://github.com/liberapay/liberapay.com/issues/1066
         if group_symbol in string:
             proper = self.format_decimal(decimal, decimal_quantization=False)
-            if string != proper and string.rstrip('0') != (proper + decimal_symbol):
+            ambiguous = string != proper and (
+                (string + ('' if decimal_symbol in string else decimal_symbol)).rstrip('0') !=
+                (proper + ('' if decimal_symbol in proper else decimal_symbol)).rstrip('0')
+            )
+            if ambiguous:
                 # Irregular number format (e.g. `10.00` in German)
                 try:
                     proper_alt = (

--- a/tests/py/test_i18n.py
+++ b/tests/py/test_i18n.py
@@ -53,6 +53,18 @@ class Tests(Harness):
         msgkey2 = self.website.locales['fr'].catalog['Save'].id
         assert id(msgkey1) == id(msgkey2)
 
+    def test_parse_money_amount_accepts_valid_numbers(self):
+        assert LOCALE_EN.parse_money_amount("3400", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.0", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.00", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.000", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.6", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.60", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.600", 'USD')
+        assert LOCALE_EN.parse_money_amount("3,400.65", 'USD')
+
     def test_parse_money_amount_rejects_overly_precise_numbers(self):
         with self.assertRaises(InvalidNumber):
             LOCALE_EN.parse_money_amount("100.00001", 'EUR')


### PR DESCRIPTION
A bug in my implementation was reported upstream a year and a half ago (<https://github.com/python-babel/babel/issues/928>), but I found out about that only yesterday while reviewing Babel's changelog.