### PR TITLE
User descriptions support common URI schemes

### DIFF
--- a/liberapay/utils/markdown.py
+++ b/liberapay/utils/markdown.py
@@ -4,13 +4,13 @@ from markupsafe import Markup
 import misaka as m  # http://misaka.61924.nl/
 
 
-url_re = re.compile(r'^(https?|xmpp):')
+uri_re = re.compile(r'^(https?|xmpp|imap|irc|nntp):')
 
 
 class CustomRenderer(m.SaferHtmlRenderer):
 
     def check_url(self, url, is_image_src=False):
-        return bool(url_re.match(url))
+        return bool(uri_re.match(url))
 
 
 renderer = CustomRenderer()


### PR DESCRIPTION
Hi, this is my first time contributing to liberapay. If there's anything needed, please feel free to point out!

**What's fixed**:
As #2492, some URI schemes are not supported yet. By inspecting, the reason is that the regex in `markdown.py` only matches `http`, `https`, and `xmpp`. Common URI schemes are added to this regex.


**Test string**:
```
[NNTP](nntp://comp.unix.bsd.freebsd.misc), [IRC](irc://network/#channel), [HTTPS](https://test.com/#), [HTTP](http://testhttp.com/#)
```


**Render result before fix**:
![image](https://github.com/user-attachments/assets/8d5c5685-8b18-4f05-b2bf-bf11339d9af8)


**Render result after fix**:
![image](https://github.com/user-attachments/assets/37bdc7f7-76ad-4186-b694-701eace0871b)


For the common URI schemes, I referred to this [list](https://en.wikipedia.org/wiki/List_of_URI_schemes). I only added the most common ones for now since handling other uri such as files or app deeplinks may not be the desired behavior.