### PR TITLE
Hold high risk charges for review

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -213,6 +213,19 @@ Liberapay.forms.jsSubmit = function() {
                             window.location.href = window.location.href;
                             navigating = true;
                         }
+                    } else if (action == "replaceButton") {
+                        var $button = $(button);
+                        var $replacement = $button.siblings('button.hidden');
+                        if ($replacement.length > 0) {
+                            $button.fadeOut(200, function() {
+                                $button.addClass('hidden');
+                                $replacement.removeClass('hidden').hide().fadeIn(200);
+                            });
+                        } else {
+                            console.error("jsSubmit: replacement button not found");
+                            window.location.href = window.location.href;
+                            navigating = true;
+                        }
                     } else {
                         Liberapay.error("invalid value in `data-on-success` attribute");
                     }

--- a/liberapay/models/participant.py
+++ b/liberapay/models/participant.py
@@ -3843,6 +3843,15 @@ class Participant(Model, MixinTeam):
             bool(self.get_email_address())
         )
 
+    @property
+    def marked_since(self):
+        return self.db.one("""
+            SELECT max(e.ts)
+              FROM events e
+             WHERE e.participant = %s
+               AND e.type IN ('is_suspended', 'flags_changed')
+        """, (self.id,))
+
 
 class NeedConfirmation(Exception):
     """Represent the case where we need user confirmation during a merge.

--- a/liberapay/payin/stripe.py
+++ b/liberapay/payin/stripe.py
@@ -65,7 +65,7 @@ def charge(db, payin, payer, route, update_donor=True):
     """
     assert payin.route == route.id
     transfers = db.all("""
-        SELECT pt.id,
+        SELECT pt.*,
                p.marked_as AS recipient_marked_as,
                p.join_time::date::text AS recipient_join_time
           FROM payin_transfers pt
@@ -108,19 +108,13 @@ def charge(db, payin, payer, route, update_donor=True):
                     update_donor=(update_donor and i == len(transfers)),
                 )
             return payin
-    if len(transfers) == 1:
-        payin, charge = destination_charge(
-            db, payin, payer, statement_descriptor=('Liberapay %i' % payin.id),
-            update_donor=update_donor,
-        )
-        if payin.status == 'failed':
-            payin, charge = try_other_destinations(
-                db, payin, payer, charge, update_donor=update_donor,
-            )
-    else:
-        payin, charge = charge_and_transfer(
-            db, payin, payer, statement_descriptor=('Liberapay %i' % payin.id),
-            update_donor=update_donor,
+    payin, charge = create_charge(
+        db, payin, transfers, payer, statement_descriptor=('Liberapay %i' % payin.id),
+        update_donor=update_donor,
+    )
+    if payin.status == 'failed' and len(transfers) == 1:
+        payin, charge = try_other_destinations(
+            db, payin, payer, charge, update_donor=update_donor,
         )
     if charge and charge.status == 'failed' and charge.failure_code == 'expired_card':
         route.update_status('expired')
@@ -178,16 +172,12 @@ def try_other_destinations(db, payin, payer, charge, update_donor=True):
                 db, payer, payin.amount, route, proto_transfers,
                 off_session=payin.off_session,
             )
-            if len(payin_transfers) == 1:
-                payin, charge = destination_charge(
-                    db, payin, payer, statement_descriptor=('Liberapay %i' % payin.id),
-                    update_donor=update_donor,
-                )
-            else:
-                payin, charge = charge_and_transfer(
-                    db, payin, payer, statement_descriptor=('Liberapay %i' % payin.id),
-                    update_donor=update_donor,
-                )
+            payin, charge = create_charge(
+                db, payin, payin_transfers, payer,
+                statement_descriptor=('Liberapay %i' % payin.id),
+                update_donor=update_donor,
+            )
+            del payin_transfers
         except NextAction:
             raise
         except Exception as e:
@@ -203,61 +193,12 @@ def try_other_destinations(db, payin, payer, charge, update_donor=True):
     return payin, charge
 
 
-def charge_and_transfer(
-    db, payin, payer, statement_descriptor, update_donor=True,
+def create_charge(
+    db, payin, payin_transfers, payer, statement_descriptor, update_donor=True,
 ):
-    """Create a standalone Charge then multiple Transfers.
+    """Create a Charge, possibly a Destination Charge if the recipient is outside SEPA.
 
-    Doc: https://stripe.com/docs/connect/charges-transfers
-
-    As of January 2019 this only works if the recipients are in the SEPA.
-
-    """
-    assert payer.id == payin.payer
-    amount = payin.amount
-    route = ExchangeRoute.from_id(payer, payin.route)
-    description = generate_charge_description(payin)
-    try:
-        params = dict(
-            amount=Money_to_int(amount),
-            confirm=True,
-            currency=amount.currency.lower(),
-            customer=route.remote_user_id,
-            description=description,
-            mandate=route.mandate,
-            metadata={'payin_id': payin.id},
-            off_session=payin.off_session,
-            payment_method=route.address,
-            payment_method_types=['sepa_debit' if route.network == 'stripe-sdd' else 'card'],
-            return_url=payer.url('giving/pay/stripe/%i' % payin.id),
-            statement_descriptor=statement_descriptor,
-            idempotency_key='payin_intent_%i' % payin.id,
-        )
-        if not route.mandate and not route.one_off and not payin.off_session:
-            params['setup_future_usage'] = 'off_session'
-        intent = stripe.PaymentIntent.create(**params)
-    except stripe.error.StripeError as e:
-        return abort_payin(db, payin, repr_stripe_error(e)), None
-    except Exception as e:
-        website.tell_sentry(e)
-        return abort_payin(db, payin, str(e)), None
-    if intent.status == 'requires_action':
-        update_payin(db, payin.id, None, 'awaiting_payer_action', None,
-                     intent_id=intent.id)
-        raise NextAction(intent)
-    else:
-        charge = intent.charges.data[0]
-    payin = settle_charge_and_transfers(
-        db, payin, charge, intent_id=intent.id, update_donor=update_donor,
-    )
-    send_payin_notification(db, payin, payer, charge, route)
-    return payin, charge
-
-
-def destination_charge(db, payin, payer, statement_descriptor, update_donor=True):
-    """Create a Destination Charge.
-
-    Doc: https://stripe.com/docs/connect/destination-charges
+    Doc: https://docs.stripe.com/connect/charges
 
     Destination charges don't have built-in support for processing payments
     "at cost", so we (mis)use transfer reversals to recover the exact amount of
@@ -265,23 +206,23 @@ def destination_charge(db, payin, payer, statement_descriptor, update_donor=True
 
     """
     assert payer.id == payin.payer
-    pt = db.one("SELECT * FROM payin_transfers WHERE payin = %s", (payin.id,))
-    destination, country = db.one("""
-        SELECT id, country
-          FROM payment_accounts
-         WHERE pk = %s
-    """, (pt.destination,))
-    if country in SEPA:
-        return charge_and_transfer(
-            db, payin, payer, statement_descriptor=statement_descriptor,
-            update_donor=update_donor,
-        )
     amount = payin.amount
     route = ExchangeRoute.from_id(payer, payin.route)
     description = generate_charge_description(payin)
-    if destination == 'acct_1ChyayFk4eGpfLOC':
-        # Stripe rejects the charge if the destination is our own account
-        destination = None
+    destination = None
+    if len(payin_transfers) == 1:
+        destination, country = db.one("""
+            SELECT id, country
+              FROM payment_accounts
+             WHERE pk = %s
+        """, (payin_transfers[0].destination,))
+        if destination == 'acct_1ChyayFk4eGpfLOC':
+            # Stripe rejects the charge if the destination is our own account
+            destination = None
+        elif country in SEPA:
+            # Don't use destination charges when we can use separate transfers
+            destination = None
+        del country
     try:
         params = dict(
             amount=Money_to_int(amount),
@@ -292,16 +233,17 @@ def destination_charge(db, payin, payer, statement_descriptor, update_donor=True
             mandate=route.mandate,
             metadata={'payin_id': payin.id},
             off_session=payin.off_session,
-            on_behalf_of=destination,
             payment_method=route.address,
             payment_method_types=['sepa_debit' if route.network == 'stripe-sdd' else 'card'],
             return_url=payer.url('giving/pay/stripe/%i' % payin.id),
             statement_descriptor=statement_descriptor,
-            transfer_data={'destination': destination} if destination else None,
             idempotency_key='payin_intent_%i' % payin.id,
         )
         if not route.mandate and not route.one_off and not payin.off_session:
             params['setup_future_usage'] = 'off_session'
+        if destination:
+            params['on_behalf_of'] = destination
+            params['transfer_data'] = {'destination': destination}
         intent = stripe.PaymentIntent.create(**params)
     except stripe.error.StripeError as e:
         return abort_payin(db, payin, repr_stripe_error(e)), None
@@ -312,11 +254,16 @@ def destination_charge(db, payin, payer, statement_descriptor, update_donor=True
         update_payin(db, payin.id, None, 'awaiting_payer_action', None,
                      intent_id=intent.id)
         raise NextAction(intent)
+    charge = intent.charges.data[0]
+    if destination:
+        payin = settle_destination_charge(
+            db, payin, charge, payin_transfers[0],
+            intent_id=intent.id, update_donor=update_donor,
+        )
     else:
-        charge = intent.charges.data[0]
-    payin = settle_destination_charge(
-        db, payin, charge, pt, intent_id=intent.id, update_donor=update_donor,
-    )
+        payin = settle_charge_and_transfers(
+            db, payin, charge, intent_id=intent.id, update_donor=update_donor,
+        )
     send_payin_notification(db, payin, payer, charge, route)
     return payin, charge
 

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,0 +1,4 @@
+ALTER TABLE payins
+    ADD COLUMN allowed_by bigint REFERENCES participants,
+    ADD COLUMN allowed_since timestamptz,
+    ADD CHECK ((allowed_since IS NULL) = (allowed_by IS NULL));

--- a/sql/branch.sql
+++ b/sql/branch.sql
@@ -1,4 +1,8 @@
+BEGIN;
 ALTER TABLE payins
     ADD COLUMN allowed_by bigint REFERENCES participants,
     ADD COLUMN allowed_since timestamptz,
     ADD CHECK ((allowed_since IS NULL) = (allowed_by IS NULL));
+DROP INDEX events_admin_idx;
+CREATE INDEX events_admin_idx ON events (ts DESC) WHERE type IN ('admin_request', 'flags_changed', 'payin_review');
+END;

--- a/www/admin/admins.spt
+++ b/www/admin/admins.spt
@@ -10,7 +10,7 @@ events = website.db.all("""
       FROM events e
       JOIN participants p ON p.id = e.participant
       JOIN participants admin ON admin.id = e.recorder
-     WHERE e.type IN ('admin_request', 'flags_changed')
+     WHERE e.type IN ('admin_request', 'flags_changed', 'payin_review')
        AND coalesce(e.ts < %s, true)
   ORDER BY e.ts DESC
      LIMIT %s
@@ -41,7 +41,7 @@ title = "Admins Oversight"
     % if e.type == 'admin_request'
         <div class="mb-3">{{ recorder(e) }} modified the account of <a href="/~{{ e.participant }}/">{{ e.username }}</a>:<br>
         <pre>{{ json.dumps(e.payload) }}</pre></div>
-    % elif assert(e.type == 'flags_changed', "unexpected event type: " + e.type)
+    % elif e.type == 'flags_changed'
         % set marked_as = e.payload.get('marked_as', '')
         % if marked_as is None
             <p>{{ recorder(e) }} unmarked the profile <a href="/~{{ e.participant }}/">{{ e.username }}</a>.</p>
@@ -49,6 +49,12 @@ title = "Admins Oversight"
             <p>{{ recorder(e) }} marked the profile <a href="/~{{ e.participant }}/">{{ e.username }}</a> as <code>{{ e.payload }}</code>.</p>
         % else
             <p>{{ recorder(e) }} marked the profile <a href="/~{{ e.participant }}/">{{ e.username }}</a> as <span class="{{ constants.ACCOUNT_MARK_CLASSES.get(marked_as, 'text-muted') }}">{{ marked_as }}</span>.</p>
+        % endif
+    % elif assert(e.type == 'payin_review', "unexpected event type: " + e.type)
+        % if e.payload.allowed
+            <p>{{ recorder(e) }} allowed <a href="/admin/payments?before={{ e.payload.payin_id + 1 }}">payin {{ e.payload.payin_id }}</a>.</p>
+        % else
+            <p>{{ recorder(e) }} disallowed <a href="/admin/payments?before={{ e.payload.payin_id + 1 }}">payin {{ e.payload.payin_id }}</a>.</p>
         % endif
     % endif
     % endfor

--- a/www/admin/payments.spt
+++ b/www/admin/payments.spt
@@ -1,7 +1,7 @@
 from operator import itemgetter
 
 from liberapay.i18n.base import LOCALE_EN as locale, MoneyBasket
-from liberapay.utils import group_by, render_postal_address
+from liberapay.utils import form_post_success, group_by, render_postal_address
 
 PAGE_SIZE = 50
 STATUS_MAP = {
@@ -15,6 +15,37 @@ STATUS_MAP = {
 [---]
 
 user.require_active_privilege('admin')
+
+if request.method == 'POST':
+    if 'allow' in request.body:
+        payin_id = request.body.get_int('allow')
+        payin = website.db.one("""
+            UPDATE payins
+               SET allowed_since = coalesce(allowed_since, current_timestamp)
+                 , allowed_by = coalesce(allowed_by, %s)
+             WHERE id = %s
+               AND status = 'awaiting_review'
+         RETURNING *
+        """, (user.id, payin_id))
+        if not payin:
+            raise response.error(400, f"payin {payin_id} isn't awaiting review")
+        del payin
+    elif 'disallow' in request.body:
+        payin_id = request.body.get_int('disallow')
+        payin = website.db.one("""
+            UPDATE payins
+               SET allowed_since = null
+                 , allowed_by = null
+             WHERE id = %s
+               AND status = 'awaiting_review'
+         RETURNING *
+        """, (payin_id,))
+        if not payin:
+            raise response.error(400, f"payin {payin_id} isn't awaiting review")
+        del payin
+    else:
+        raise response.error(400)
+    form_post_success(state)
 
 before = request.qs.get_int('before', default=None)
 status = request.qs.get('status')
@@ -111,6 +142,9 @@ title = "Payments Admin"
 <br><br>
 
 % if payins
+<form action="javascript:/admin/payments" method="POST" class="js-submit"
+      data-on-success="replaceButton">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     <table class="table">
     <thead>
         <tr>
@@ -184,7 +218,14 @@ title = "Payments Admin"
                 <code>{{ pi.transfers }}</code>
             % endif
             </td>
-            <td class="text-{{ STATUS_MAP.get(pi.status, 'info') }}">{{ pi.status }}</td>
+            % set allowed = bool(pi.allowed_by)
+            <td class="text-{{ STATUS_MAP.get(pi.status, 'info') }}">
+                <p>{{ pi.status }}</p>
+                % if pi.status == 'awaiting_review'
+                    <button class="btn btn-warning btn-sm {{ 'hidden' if allowed else '' }}" name="allow" value="{{ pi.id }}">Allow</button>
+                    <button class="btn btn-default btn-sm {{ '' if allowed else 'hidden' }}" name="disallow" value="{{ pi.id }}">Disallow</button>
+                % endif
+            </td>
         </tr>
         % if pi.error
         <tr class="subrow">
@@ -195,6 +236,7 @@ title = "Payments Admin"
     % endfor
     </tbody>
     </table>
+</form>
     % if len(payins) == PAGE_SIZE
         <a class="btn btn-primary" href="{{ request.qs.derive(before=payins[-1].id) }}">Next page →</a>
     % endif

--- a/www/admin/payments.spt
+++ b/www/admin/payments.spt
@@ -19,29 +19,37 @@ user.require_active_privilege('admin')
 if request.method == 'POST':
     if 'allow' in request.body:
         payin_id = request.body.get_int('allow')
-        payin = website.db.one("""
-            UPDATE payins
-               SET allowed_since = coalesce(allowed_since, current_timestamp)
-                 , allowed_by = coalesce(allowed_by, %s)
-             WHERE id = %s
-               AND status = 'awaiting_review'
-         RETURNING *
-        """, (user.id, payin_id))
-        if not payin:
-            raise response.error(400, f"payin {payin_id} isn't awaiting review")
+        with website.db.get_cursor() as cursor:
+            payin = cursor.one("""
+                UPDATE payins
+                   SET allowed_since = coalesce(allowed_since, current_timestamp)
+                     , allowed_by = coalesce(allowed_by, %s)
+                 WHERE id = %s
+                   AND status = 'awaiting_review'
+             RETURNING *
+            """, (user.id, payin_id))
+            if not payin:
+                raise response.error(400, f"payin {payin_id} isn't awaiting review")
+            website.db.Participant.from_id(payin.payer).add_event(
+                cursor, 'payin_review', {'allowed': True, 'payin_id': payin_id}
+            )
         del payin
     elif 'disallow' in request.body:
         payin_id = request.body.get_int('disallow')
-        payin = website.db.one("""
-            UPDATE payins
-               SET allowed_since = null
-                 , allowed_by = null
-             WHERE id = %s
-               AND status = 'awaiting_review'
-         RETURNING *
-        """, (payin_id,))
-        if not payin:
-            raise response.error(400, f"payin {payin_id} isn't awaiting review")
+        with website.db.get_cursor() as cursor:
+            payin = cursor.one("""
+                UPDATE payins
+                   SET allowed_since = null
+                     , allowed_by = null
+                 WHERE id = %s
+                   AND status = 'awaiting_review'
+             RETURNING *
+            """, (payin_id,))
+            if not payin:
+                raise response.error(400, f"payin {payin_id} isn't awaiting review")
+            website.db.Participant.from_id(payin.payer).add_event(
+                cursor, 'payin_review', {'allowed': None, 'payin_id': payin_id}
+            )
         del payin
     else:
         raise response.error(400)


### PR DESCRIPTION
This branch changes the way Liberapay submits card charges to Stripe. It separates the authorization and capture steps. That enables checking the risk level that Stripe computes during the first step before initiating the second step. The goal is to reduce the number of fraudulent charges that go through, and consequently the number of refunds we have to do and the amount of money we lose on those.