### PR TITLE
Link profile header back to profile page in /income/* subpages

### DIFF
--- a/templates/layouts/profile.html
+++ b/templates/layouts/profile.html
@@ -21,13 +21,14 @@
     <div class="profile-header">
         {{ avatar_img(participant, size=120) }}
         <h1>
-            {% if '/income/' in request.path %}<a href="{{ participant.path('') }}">{% endif %}
+            % set is_subpage = request.path.raw.rstrip('/') > participant.path('').rstrip('/')
+            {% if is_subpage %}<a href="{{ participant.path('') }}">{% endif %}
                 % if participant.public_name
                     {{ participant.public_name }}<br><small>@{{ participant.username }}</small>
                 % else
                     {{ participant.username }}
                 % endif
-            {% if '/income/' in request.path %}</a>{% endif %}
+            {% if is_subpage %}</a>{% endif %}
         </h1>
         <p class="summary" lang="{{ lang|default('', True) }}">{{ summary|default('', True) }}</p>
     </div>


### PR DESCRIPTION
I found it a bit awkward to have to scroll all the way to the end of the Payments and Income Shares pages to be able to navigate to the corresponding profile page. This change makes the profile header into a link, but only in these pages (i.e. the link is not added in the main profile page linking back to itself).

Note: I am not 100% sure the syntax is correct, but hopefully it's close enough :)
