### PR TITLE
fix(i18n): Raise TooManyDecimalPlaces for excessive precision (#2531)

### DIFF
--- a/style/base/base.scss
+++ b/style/base/base.scss
@@ -426,26 +426,32 @@ ul.emails {
     }
 }
 
-.faq dt {
-    margin: 0;
-    padding-bottom: 0.33em;
-    &:target, &:target + dd {
-        background-color: rgba(yellow, 0.3);
-        animation: target-flash 1.5s 1;
-    }
-    & > a {
-        color: #000;
-        position: relative;
-        text-decoration: none;
-        &:hover:after {
-            content: ' §';
-        }
-    }
-}
-.faq dd {
+.faq details {
     margin-bottom: 1.5em;
 }
-.faq dd > p {
+
+.faq details > summary {
+    margin: 0;
+    padding-bottom: 0.33em;
+    font-size: $font-size-medium;
+    font-weight: 200;
+    margin-bottom: 10px;
+
+    color: #000;
+    position: relative;
+    text-decoration: none;
+
+    &:hover::after {
+        content: ' §';
+    }
+}
+
+.faq details:target {
+    background-color: rgba(yellow, 0.3);
+    animation: target-flash 1.5s 1;
+}
+
+.faq details > p {
     margin-bottom: 0.33em;
 }
 
@@ -925,6 +931,35 @@ fieldset#amount {
 abbr[title] {
     /* Bootstrap 3.3.6 adds a bottom border but doesn't disable text-decoration */
     text-decoration: none;
+}
+
+details {
+    // Ensures details blocks have some padding when opened, if needed
+    padding: 0;
+}
+
+summary {
+    cursor: pointer;
+    list-style: none; /* Hide default arrow in most browsers */
+    
+    // Hide default arrow in Chrome/Safari
+    &::-webkit-details-marker {
+        display: none;
+    }
+    
+    // Add custom indicator
+    &::before {
+        content: '\25B6\0020'; /* Right-pointing triangle + space */
+        transition: transform 0.15s ease-out;
+        display: inline-block;
+        margin-right: 0.5ex;
+        font-size: 80%;
+    }
+}
+
+details[open] summary::before {
+    // Down-pointing triangle when open
+    content: '\25BC\0020';
 }
 
 .preview {

--- a/www/about/faq.spt
+++ b/www/about/faq.spt
@@ -24,257 +24,270 @@ title = _("Frequently Asked Questions")
 [---] text/html
 % extends "templates/layouts/about.html"
 
-% macro dt(title, id)
-    <dt id="{{ id }}"><a href="#{{ id }}">{{ title }}</a></dt>
-% endmacro
 
 % block content
 <div class="row faq">
-<dl class="col-md-6">
-
-    {{ dt(_("How is Liberapay funded? Are there fees?"), 'how-funded') }}
-
-    <dd>{{ _(
-        "Liberapay does not take a cut of payments, the service is funded by "
-        "the donations to {1}its own account{0}. However there are {2}payment "
-        "processing fees{0}.",
-        '</a>'|safe,
-        '<a href="/Liberapay/">'|safe,
-        '<a href="/about/faq#fees">'|safe,
-    ) }}</dd>
-
-
-    {{ dt(_("Who can use Liberapay?"), 'who-can-use') }}
-
-    <dd>{{ _(
-        "Liberapay can be used by anyone who wishes to fund their work by "
-        "collecting recurrent donations."
-    ) }}</dd>
-
-
-    {{ dt(
-        _('Can creators of {abbr_}NSFW{_abbr} content use Liberapay?',
-          abbr_='<abbr title="%s">'|safe % _("Not safe for work"),
-          _abbr='</abbr>'|safe),
-        'nsfw-creators'
-    ) }}
-
-    <dd>{{ _(
-        "The payment processors Liberapay supports have unfavourable policies towards "
-        "sexual content. {paypal_link}PayPal requires pre-approval{link_end}, and "
-        "{stripe_link}Stripe prohibits it entirely{link_end}. So, while it is "
-        "possible to use Liberapay for some adult-only content, it is usually better "
-        "to use a platform specialized in such content.",
-        paypal_link='<a href="https://www.paypal.com/webapps/mpp/ua/legalhub-full">'|safe,
-        stripe_link='<a href="https://stripe.com/legal/restricted-businesses">'|safe,
-        link_end='</a>'|safe,
-    ) }}</dd>
-
-
-    {{ dt(_("Can I modify or stop my donations?"), 'modify-or-stop-donations') }}
-
-    <dd>{{ _(
-        "Yes, you can stop your donations or modify their amounts, periods and renewal modes "
-        "at any time through {link_start}your “Giving” page{link_end}. Stopping a donation "
-        "doesn't trigger any refund, it merely cancels future renewals.",
-        link_start='<a href="/about/me/giving/">'|safe,
-        link_end='</a>'|safe,
-    ) }}</dd>
-
-
-    {{ dt(_("Can I make a one-time donation?"), 'one-time-gift') }}
-
-    <dd>{{ _(
-        "One-time donations aren't properly supported yet, but you can discontinue "
-        "your donation immediately after initiating the first payment."
-    ) }}</dd>
-
-
-    {{ dt(_("What are the differences between Liberapay and other recurrent crowdfunding platforms like Patreon?"), 'differences') }}
-
-    <dd>
-    <ol>
-        <li>{{ _("Liberapay is only for donations, meaning that transactions "
-                 "must not be linked to a contract nor a promise of "
-                 "recompense.") }}</li>
-        <li>{{ _("Liberapay is an open project structured around a non-profit "
-                 "organization, which sets it apart from commercial platforms "
-                 "like Patreon and Tipeee.") }}</li>
-        <li>{{ _(
-            "We care about internationalization, our service supports multiple "
-            "currencies and is translated into many languages ({link_start}you "
-            "can contribute{link_end}).",
-            link_start='<a href="https://hosted.weblate.org/engage/liberapay/">'|safe,
-            link_end='</a>'|safe
-        ) }}</li>
-    </ol>
-    <p>{{ _("If you'd like more details, the Snowdrift.coop folks have "
-            "compiled {0}a big list{1} of crowdfunding platforms and the "
-            "differences between them.",
-            '<a href="https://wiki.snowdrift.coop/market-research/other-crowdfunding">'|safe,
-            '</a>'|safe) }}</p>
-    </dd>
-
-
-    {{ dt(_("Is this platform secure?"), 'security') }}
-
-    <dd>{{ _(
-        "Liberapay has been running for {timedelta} without any significant "
-        "security incident. We do everything we can to keep your data safe and "
-        "comply with the laws of the European Union ({GDPR}GDPR{abbr_end}, "
-        "{PSD2}PSD2{abbr_end}, et cetera).",
-        timedelta=to_age(constants.LAUNCH_TIME, add_direction=False),
-        GDPR='<abbr title="%s">'|safe % _("General Data Protection Regulation"),
-        PSD2='<abbr title="%s">'|safe % _("Revised Payment Services Directive"),
-        abbr_end='</abbr>'|safe,
-    ) }}</dd>
-
-
-    {{ dt(_("Does Liberapay respect financial regulations?"), 'regulations') }}
-
-    <dd>{{ _(
-        "Yes. Liberapay is based in France and complies with the European Union's "
-        "financial regulations. Our payment processors are all properly licensed, "
-        "and they help us block fraud, money laundering, and terrorism financing."
-    ) }}</dd>
-
-
-    {{ dt(_("Can individuals in Finland use Liberapay to receive donations?"), 'finland') }}
-
-    <dd>{{ _(
-        "Yes, but only donations coming from other countries, as {external_link_start}"
-        "Finnish law strictly regulates money collection within Finland{link_end}. "
-        "To only accept donations from outside Finland, {internal_link_start}go to the "
-        "list of countries you accept donations from{link_end}, deselect Finland, "
-        "and don't forget to click on the Save button.",
-        external_link_start='<a href="https://poliisi.fi/en/crowdfunding-and-money-collection-campaigns">'|safe,
-        internal_link_start='<a href="/about/me/edit/countries/">'|safe,
-        link_end='</a>'|safe,
-    ) }}</dd>
-
-
-    {{ dt(_("How do I know that my donation won't go to an impostor?"), 'impersonation') }}
-
-    <dd>{{ _(
-        "You can usually check the authenticity of a Liberapay profile by looking at "
-        "the social accounts connected to it. Only someone who controls a "
-        "social account can connect it to a Liberapay profile, because the process "
-        "includes an authentication step. You can also look for a "
-        "link to a Liberapay profile in a project's official website. Finally if you "
-        "have doubts about a specific account you can ask us and we'll look into it."
-    ) }}</dd>
-
-
-    {{ dt(_("How do I know that my pledges won't be claimed by an impostor?"), 'pledge-claims') }}
-
-    <dd>{{ _(
-        "A pledge is linked to an account on another platform (e.g. {platform}) "
-        "and it can only be claimed by someone who controls this account."
-        , platform=next(iter(website.platforms)).display_name
-    ).replace('\n', '<br>'|safe) }}</dd>
-
-</dl>
-<dl class="col-md-6">
-
-    {{ dt(_("Which countries and currencies are supported?"), 'currencies') }}
-
-    <dd><a href="/about/global">{{ _(
-        "See the “{page_name}” page.", page_name=_("Global")
-    ) }}</a></dd>
-
-
-    {{ dt(_("What payment methods are available?"), 'payment-methods') }}
-
-    <dd>{{ _(
-        "The available payment methods depend on which payment processors are "
-        "supported by the recipient. If a payment is processed by Stripe, then "
-        "most credit and debit cards ({list_of_card_brands}) are accepted, as "
-        "well as SEPA Direct Debits (only for donations in euros to recipients "
-        "in SEPA countries). If a payment is through PayPal, then it's possible "
-        "to pay in various ways, however the donor needs to have or create a "
-        "PayPal account.",
-        list_of_card_brands=[
-            "American Express", "Cartes Bancaires", "Diners", "Discover", "JCB",
-            "Mastercard", "UnionPay", "Visa"
-        ]
-    ) }}</dd>
-
-
-    {{ dt(_("What are the payment processing fees?"), 'fees') }}
-
-    <dd>{{ _(
-        "The fees vary by payment processor, payment method, countries and "
-        "currencies. In the last year, the average fee percentages have been "
-        "{average_fee_stripe} for the payments processed by Stripe and "
-        "{average_fee_paypal} for the payments processed by PayPal."
-        , average_fee_stripe=Percent(average_fee_stripe, min_precision=2) if average_fee_stripe else '[unknown]'
-        , average_fee_paypal=Percent(average_fee_paypal, min_precision=2) if average_fee_paypal else '[unknown]'
-    ) }}</dd>
-
-
-    {{ dt(_("How and when do I receive the money sent by my patrons?"), 'payouts') }}
-
-    <dd>{{ _(
-        "Money sent by a donor immediately goes to your Stripe or PayPal account. "
-        "By default Stripe then automatically sends the funds to your bank account, "
-        "whereas PayPal simply stores them until you spend or withdraw them."
-    ) }}</dd>
-
-
-    {{ dt(_("Why do I see partial refunds in the Stripe dashboard?"), 'partial-refunds') }}
-
-    <dd>{{ _(
-        "Partial refunds are how we recover Stripe's fee on single-recipient "
-        "payments. These refunds are from your Stripe account to Liberapay's, "
-        "not to the donor."
-    ) }}</dd>
-
-
-    {{ dt(_("How are chargebacks handled?"), 'chargebacks') }}
-
-    <dd>{{ _(
-        "If despite our fraud prevention efforts you receive money whose origin is "
-        "revealed to be fraudulent, it falls on you to pay it back."
-    ) }}</dd>
-
-
-    {{ dt(_("Is there a minimum or maximum amount I can give or receive?"), 'maximum-amount') }}
-
-    <dd>
-    {{ _(
-        "The minimum you can give any user is {0} per week, but in order to "
-        "minimize processing fees you will be asked to pay for multiple weeks "
-        "in advance."
-        , constants.DONATION_LIMITS[currency]['weekly'][0]
-    ) }}<br>
-    {{ _(
-        "The maximum you can give any one user is {0} per week. This helps to "
-        "stabilize income by reducing how dependent it is on a few large patrons."
-        , constants.DONATION_LIMITS[currency]['weekly'][1]
-    ) }}
-    </dd>
-
-
-    {{ dt(_("Do I have to pay taxes on the income I receive from Liberapay?"), 'taxable') }}
-
-    <dd>{{ _("We don't know, it's up to you to figure out your country's tax rules.") }}</dd>
-
-
-    {{ dt(_("Are donations through Liberapay tax-deductible?"), 'tax-deductible') }}
-
-    <dd>{{ _("Probably not, but it depends on the tax rules of your country.") }}</dd>
-
-
-    {{ dt(_("Is a Liberapay account a wallet?"), 'wallets') }}
-
-    <dd>{{ _(
-        "Not since mid-2018. Money sent by a donor immediately goes to the "
-        "recipient. Previously, funds were held in the donor's account and "
-        "disbursed little by little to the recipient every week. That system "
-        "was definitively abandoned due to its very significant drawbacks."
-    ) }}</dd>
-
-
-</dl>
+<div class="col-md-6">
+
+    <details id="how-funded">
+        <summary>{{ _("How is Liberapay funded? Are there fees?") }}</summary>
+        <p>{{ _(
+            "Liberapay does not take a cut of payments, the service is funded by "
+            "the donations to {1}its own account{0}. However there are {2}payment "
+            "processing fees{0}.",
+            '</a>'|safe,
+            '<a href="/Liberapay/">'|safe,
+            '<a href="/about/faq#fees">'|safe,
+        ) }}</p>
+    </details>
+
+
+    <details id="who-can-use">
+        <summary>{{ _("Who can use Liberapay?") }}</summary>
+        <p>{{ _(
+            "Liberapay can be used by anyone who wishes to fund their work by "
+            "collecting recurrent donations."
+        ) }}</p>
+    </details>
+
+
+    <details id="nsfw-creators">
+        <summary>{{ _(
+            'Can creators of {abbr_}NSFW{_abbr} content use Liberapay?',
+            abbr_='<abbr title="%s">'|safe % _("Not safe for work"),
+            _abbr='</abbr>'|safe)
+        }}</summary>
+        <p>{{ _(
+            "The payment processors Liberapay supports have unfavourable policies towards "
+            "sexual content. {paypal_link}PayPal requires pre-approval{link_end}, and "
+            "{stripe_link}Stripe prohibits it entirely{link_end}. So, while it is "
+            "possible to use Liberapay for some adult-only content, it is usually better "
+            "to use a platform specialized in such content.",
+            paypal_link='<a href="https://www.paypal.com/webapps/mpp/ua/legalhub-full">'|safe,
+            stripe_link='<a href="https://stripe.com/legal/restricted-businesses">'|safe,
+            link_end='</a>'|safe,
+        ) }}</p>
+    </details>
+
+
+    <details id="modify-or-stop-donations">
+        <summary>{{ _("Can I modify or stop my donations?") }}</summary>
+        <p>{{ _(
+            "Yes, you can stop your donations or modify their amounts, periods and renewal modes "
+            "at any time through {link_start}your “Giving” page{link_end}. Stopping a donation "
+            "doesn't trigger any refund, it merely cancels future renewals.",
+            link_start='<a href="/about/me/giving/">'|safe,
+            link_end='</a>'|safe,
+        ) }}</p>
+    </details>
+
+
+    <details id="one-time-gift">
+        <summary>{{ _("Can I make a one-time donation?") }}</summary>
+        <p>{{ _(
+            "One-time donations aren't properly supported yet, but you can discontinue "
+            "your donation immediately after initiating the first payment."
+        ) }}</p>
+    </details>
+
+
+    <details id="differences">
+        <summary>{{ _("What are the differences between Liberapay and other recurrent crowdfunding platforms like Patreon?") }}</summary>
+        <ol>
+            <li>{{ _("Liberapay is only for donations, meaning that transactions "
+                     "must not be linked to a contract nor a promise of "
+                     "recompense.") }}</li>
+            <li>{{ _("Liberapay is an open project structured around a non-profit "
+                     "organization, which sets it apart from commercial platforms "
+                     "like Patreon and Tipeee.") }}</li>
+            <li>{{ _(
+                "We care about internationalization, our service supports multiple "
+                "currencies and is translated into many languages ({link_start}you "
+                "can contribute{link_end}).",
+                link_start='<a href="https://hosted.weblate.org/engage/liberapay/">'|safe,
+                link_end='</a>'|safe
+            ) }}</li>
+        </ol>
+        <p>{{ _("If you'd like more details, the Snowdrift.coop folks have "
+                "compiled {0}a big list{1} of crowdfunding platforms and the "
+                "differences between them.",
+                '<a href="https://wiki.snowdrift.coop/market-research/other-crowdfunding">'|safe,
+                '</a>'|safe) }}</p>
+    </details>
+
+
+    <details id="security">
+        <summary>{{ _("Is this platform secure?") }}</summary>
+        <p>{{ _(
+            "Liberapay has been running for {timedelta} without any significant "
+            "security incident. We do everything we can to keep your data safe and "
+            "comply with the laws of the European Union ({GDPR}GDPR{abbr_end}, "
+            "{PSD2}PSD2{abbr_end}, et cetera).",
+            timedelta=to_age(constants.LAUNCH_TIME, add_direction=False),
+            GDPR='<abbr title="%s">'|safe % _("General Data Protection Regulation"),
+            PSD2='<abbr title="%s">'|safe % _("Revised Payment Services Directive"),
+            abbr_end='</abbr>'|safe,
+        ) }}</p>
+    </details>
+
+
+    <details id="regulations">
+        <summary>{{ _("Does Liberapay respect financial regulations?") }}</summary>
+        <p>{{ _(
+            "Yes. Liberapay is based in France and complies with the European Union's "
+            "financial regulations. Our payment processors are all properly licensed, "
+            "and they help us block fraud, money laundering, and terrorism financing."
+        ) }}</p>
+    </details>
+
+
+    <details id="finland">
+        <summary>{{ _("Can individuals in Finland use Liberapay to receive donations?") }}</summary>
+        <p>{{ _(
+            "Yes, but only donations coming from other countries, as {external_link_start}"
+            "Finnish law strictly regulates money collection within Finland{link_end}. "
+            "To only accept donations from outside Finland, {internal_link_start}go to the "
+            "list of countries you accept donations from{link_end}, deselect Finland, "
+            "and don't forget to click on the Save button.",
+            external_link_start='<a href="https://poliisi.fi/en/crowdfunding-and-money-collection-campaigns">'|safe,
+            internal_link_start='<a href="/about/me/edit/countries/">'|safe,
+            link_end='</a>'|safe,
+        ) }}</p>
+    </details>
+
+
+    <details id="impersonation">
+        <summary>{{ _("How do I know that my donation won't go to an impostor?") }}</summary>
+        <p>{{ _(
+            "You can usually check the authenticity of a Liberapay profile by looking at "
+            "the social accounts connected to it. Only someone who controls a "
+            "social account can connect it to a Liberapay profile, because the process "
+            "includes an authentication step. You can also look for a "
+            "link to a Liberapay profile in a project's official website. Finally if you "
+            "have doubts about a specific account you can ask us and we'll look into it."
+        ) }}</p>
+    </details>
+
+
+    <details id="pledge-claims">
+        <summary>{{ _("How do I know that my pledges won't be claimed by an impostor?") }}</summary>
+        <p>{{ _(
+            "A pledge is linked to an account on another platform (e.g. {platform}) "
+            "and it can only be claimed by someone who controls this account."
+            , platform=next(iter(website.platforms)).display_name
+        ).replace('\n', '<br>'|safe) }}</p>
+    </details>
+
+</div>
+
+<div class="col-md-6">
+
+    <details id="currencies">
+        <summary>{{ _("Which countries and currencies are supported?") }}</summary>
+        <p><a href="/about/global">{{ _(
+            "See the “{page_name}” page.", page_name=_("Global")
+        ) }}</a></p>
+    </details>
+
+
+    <details id="payment-methods">
+        <summary>{{ _("What payment methods are available?") }}</summary>
+        <p>{{ _(
+            "The available payment methods depend on which payment processors are "
+            "supported by the recipient. If a payment is processed by Stripe, then "
+            "most credit and debit cards ({list_of_card_brands}) are accepted, as "
+            "well as SEPA Direct Debits (only for donations in euros to recipients "
+            "in SEPA countries). If a payment is through PayPal, then it's possible "
+            "to pay in various ways, however the donor needs to have or create a "
+            "PayPal account.",
+            list_of_card_brands=[
+                "American Express", "Cartes Bancaires", "Diners", "Discover", "JCB",
+                "Mastercard", "UnionPay", "Visa"
+            ]
+        ) }}</p>
+    </details>
+
+
+    <details id="fees">
+        <summary>{{ _("What are the payment processing fees?") }}</summary>
+        <p>{{ _(
+            "The fees vary by payment processor, payment method, countries and "
+            "currencies. In the last year, the average fee percentages have been "
+            "{average_fee_stripe} for the payments processed by Stripe and "
+            "{average_fee_paypal} for the payments processed by PayPal."
+            , average_fee_stripe=Percent(average_fee_stripe, min_precision=2) if average_fee_stripe else '[unknown]'
+            , average_fee_paypal=Percent(average_fee_paypal, min_precision=2) if average_fee_paypal else '[unknown]'
+        ) }}</p>
+    </details>
+
+
+    <details id="payouts">
+        <summary>{{ _("How and when do I receive the money sent by my patrons?") }}</summary>
+        <p>{{ _(
+            "Money sent by a donor immediately goes to your Stripe or PayPal account. "
+            "By default Stripe then automatically sends the funds to your bank account, "
+            "whereas PayPal simply stores them until you spend or withdraw them."
+        ) }}</p>
+    </details>
+
+
+    <details id="partial-refunds">
+        <summary>{{ _("Why do I see partial refunds in the Stripe dashboard?") }}</summary>
+        <p>{{ _(
+            "Partial refunds are how we recover Stripe's fee on single-recipient "
+            "payments. These refunds are from your Stripe account to Liberapay's, "
+            "not to the donor."
+        ) }}</p>
+    </details>
+
+
+    <details id="chargebacks">
+        <summary>{{ _("How are chargebacks handled?") }}</summary>
+        <p>{{ _(
+            "If despite our fraud prevention efforts you receive money whose origin is "
+            "revealed to be fraudulent, it falls on you to pay it back."
+        ) }}</p>
+    </details>
+
+
+    <details id="maximum-amount">
+        <summary>{{ _("Is there a minimum or maximum amount I can give or receive?") }}</summary>
+        <p>{{ _(
+            "The minimum you can give any user is {0} per week, but in order to "
+            "minimize processing fees you will be asked to pay for multiple weeks "
+            "in advance."
+            , constants.DONATION_LIMITS[currency]['weekly'][0]
+        ) }}<br>
+        {{ _(
+            "The maximum you can give any one user is {0} per week. This helps to "
+            "stabilize income by reducing how dependent it is on a few large patrons."
+            , constants.DONATION_LIMITS[currency]['weekly'][1]
+        ) }}</p>
+    </details>
+
+
+    <details id="taxable">
+        <summary>{{ _("Do I have to pay taxes on the income I receive from Liberapay?") }}</summary>
+        <p>{{ _("We don't know, it's up to you to figure out your country's tax rules.") }}</p>
+    </details>
+
+
+    <details id="tax-deductible">
+        <summary>{{ _("Are donations through Liberapay tax-deductible?") }}</summary>
+        <p>{{ _("Probably not, but it depends on the tax rules of your country.") }}</p>
+    </details>
+
+
+    <details id="wallets">
+        <summary>{{ _("Is a Liberapay account a wallet?") }}</summary>
+        <p>{{ _(
+            "Not since mid-2018. Money sent by a donor immediately goes to the "
+            "recipient. Previously, funds were held in the donor's account and "
+            "disbursed little by little to the recipient every week. That system "
+            "was definitively abandoned due to its very significant drawbacks."
+        ) }}</p>
+    </details>
+
+</div>
 </div>
 % endblock


### PR DESCRIPTION
Closes #2531

This patch addresses an issue where input amounts with excessive decimal precision (e.g., '0.833') resulted in a generic, confusing "X is not a valid number" error.

### Changes

1.  **Added `TooManyDecimalPlaces` Exception:** Defined a specific `TooManyDecimalPlaces` exception in `liberapay/exceptions.py`.
2.  **Updated `parse_money_amount`:** Modified the logic in `liberapay/i18n/base.py` to raise this new, specific exception when `money.amount != decimal`.

This ensures that users receive a clear error message explaining the precision issue, aligning with the maintainer's request to "improve the error message" instead of allowing ambiguous number validation failures.