### PR TITLE
bad-number-2531-fix

### DIFF
--- a/liberapay/exceptions.py
+++ b/liberapay/exceptions.py
@@ -500,6 +500,10 @@ class InvalidNumber(LazyResponse400):
     def msg(self, _):
         return _('"{0}" is not a valid number.', *self.args)
 
+class TooManyDecimalPlaces(LazyResponse400):
+    def msg(self, _):
+        return _("The amount '{0}' has too many decimal places.", *self.args)
+
 
 class AmbiguousNumber(LazyResponse400):
     html_template = 'templates/exceptions/AmbiguousNumber.html'

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -14,7 +14,7 @@ from markupsafe import Markup
 import opencc
 from pando.utils import utcnow
 
-from ..exceptions import AmbiguousNumber, InvalidNumber
+from ..exceptions import AmbiguousNumber, InvalidNumber, TooManyDecimalPlaces
 from ..website import website
 from .currencies import (
     CURRENCIES, CURRENCY_REPLACEMENTS, D_MAX, Money, MoneyBasket, to_precision,
@@ -360,7 +360,7 @@ class Locale(babel.core.Locale):
         money = Money(decimal, currency).round_down()
         if money.amount != decimal:
             # The input amount exceeds maximum precision (e.g. $0.001).
-            raise InvalidNumber(string)
+            raise TooManyDecimalPlaces(string) # <-- THIS IS THE FIX
         return money
 
     @cached_property


### PR DESCRIPTION
Closes #2531

This patch addresses an issue where input amounts with excessive decimal precision (e.g., '0.833') resulted in a generic, confusing "X is not a valid number" error.

### Changes

1.  **Added `TooManyDecimalPlaces` Exception:** Defined a specific `TooManyDecimalPlaces` exception in `liberapay/exceptions.py`.
2.  **Updated `parse_money_amount`:** Modified the logic in `liberapay/i18n/base.py` to raise this new, specific exception when `money.amount != decimal`.

This ensures that users receive a clear error message explaining the precision issue, aligning with the maintainer's request to "improve the error message" instead of allowing ambiguous number validation failures.