### PR TITLE
Create a notification template for when payment processors change their terms

### DIFF
--- a/emails/payment_account_terms_change.spt
+++ b/emails/payment_account_terms_change.spt
@@ -1,0 +1,22 @@
+[---] -/subject
+{{ _("Payment processor contractual changes") }}
+
+[---] text/html
+<p>{{ _(
+    "{provider} is updating {link_start}its terms of service{link_end}. The changes "
+    "will take effect on {effect_date}. No action is needed from you, but by continuing "
+    "to use {provider}'s services on or after that date, you're agreeing to these "
+    "updated terms."
+    , provider=provider_name
+    , link_start=('<a href="{}">'|safe).format(contract_url)
+    , link_end='</a>'|safe
+    , effect_date=effect_date
+) }}</p>
+
+<p><a href="{{ diff_url|default(contract_url) }}" style="margin: 0 2ex 0.7em 0; {{ button_style('primary') }}">{{ _(
+    "Review the changes"
+) if diff_url|default('') else _(
+    "Review the new terms"
+) }}</a> <a href="{{ participant.url('payment') }}" style="{{ button_style('primary') }}">{{ _(
+    "Manage your payment processors"
+) }}</a></p>

--- a/liberapay/i18n/base.py
+++ b/liberapay/i18n/base.py
@@ -219,7 +219,7 @@ class Locale(babel.core.Locale):
                     if isinstance(o, datetime):
                         o = format_datetime(o, locale=self)
                     else:
-                        o = format_date(o, locale=self)
+                        o = format_date(o, 'long', locale=self)
                 elif isinstance(o, Locale):
                     o = self.languages.get(o.language) or o.language.upper()
                 elif isinstance(o, list):


### PR DESCRIPTION
[Stripe updated its terms on November 18 and expects us to notify the owners of Custom accounts](https://support.stripe.com/questions/stripe-user-terms-update-november-18-2025) (#2324). We currently only have two users with Custom accounts, so it wasn't really necessary to create a new type of notification, but it's likely that we'll have to send such notifications again in the future.