### PR TITLE
add automatic retries of PayPal API requests

### DIFF
--- a/liberapay/payin/paypal.py
+++ b/liberapay/payin/paypal.py
@@ -4,7 +4,9 @@ import re
 from time import sleep
 
 import requests
+from requests.adapters import HTTPAdapter
 from pando.utils import utcnow
+from urllib3.util.retry import Retry
 
 from ..exceptions import (
     PaymentError, ProhibitedSourceCountry, UnableToDeterminePayerCountry,
@@ -20,6 +22,9 @@ from .common import (
 logger = logging.getLogger('paypal')
 
 session = requests.Session()
+session.mount('https://', HTTPAdapter(max_retries=Retry(
+    total=2, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504],
+)))
 
 
 def _extract_error_message(response):


### PR DESCRIPTION
Configure the requests.Session used for PayPal API calls with a urllib3 Retry adapter: 2 retries with exponential backoff on 5xx server errors. This matches the Stripe module's retry configuration (stripe.max_network_retries = 2) and prevents some payments from failing due to transient network or hardware issues.

Closes #2731