### PR TITLE
Bump requests to 2.33.0

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -319,7 +319,7 @@ simplejson==3.20.2 \
     --hash=sha256:fc8da64929ef0ff16448b602394a76fd9968a39afff0692e5ab53669df1f047f \
     --hash=sha256:feed6806f614bdf7f5cb6d0123cb0c1c5f40407ef103aa935cffaa694e2e0c74
 
-requests==2.33.0 \
+requests==2.33.0
     --hash=sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b \
     --hash=sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652
 


### PR DESCRIPTION
These packages have security fixes available:

- `requests` 2.32.5 -> 2.33.0 (CVE-2026-25645)

Bumped each one to the minimum safe version.