### PR TITLE
Bump cryptography to 46.0.6

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -539,7 +539,7 @@ cbor2==5.3.0 \
     --hash=sha256:f0058d33b5eaffb176d6190d175a5391f13362f165881deea2b99e63b66ecf55 \
     --hash=sha256:f5df0ad8c16f7992bf24e5c9a53f03a11a990fd18253c3c335315bd25a34f832
 
-cryptography==46.0.5 \
+cryptography==46.0.6
     --hash=sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72 \
     --hash=sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235 \
     --hash=sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9 \


### PR DESCRIPTION
Noticed some outdated dependencies with known CVEs:

- `cryptography` 46.0.5 -> 46.0.6 (CVE-2026-34073)

Bumped each one to the minimum safe version.