### PR TITLE
Bump pytest to 9.0.3

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,6 @@
 Faker
 html5lib
-pytest
+pytest==9.0.3
 pytest-cache
 pytest-cov
 pytest-profiling


### PR DESCRIPTION
A few dependencies in the requirements file have CVEs fixed in newer versions:

- `pytest` 9.0.2 -> 9.0.3 (CVE-2025-71176)

Bumped each one to the minimum safe version.