### PR TITLE
Handle invalid custom donation amounts inline

### DIFF
--- a/templates/macros/your-tip.html
+++ b/templates/macros/your-tip.html
@@ -1,14 +1,18 @@
 % from "templates/macros/icons.html" import icon with context
 % from "templates/macros/payment-methods.html" import payment_methods_icons with context
 
-% macro tip_form(tippee, tip=None, disabled='')
+% macro tip_form(tippee, tip=None, disabled='', form_error=None, form_currency=None,
+                 period=None, periodic_amount=None, renewal_mode=None, visibility=None)
     % set tippee_is_stub = tippee.__class__.__name__ == 'AccountElsewhere'
     % set tippee_p = tippee.participant if tippee_is_stub else tippee
     % set pledging = tippee_p.payment_providers == 0 or not tippee_p.accepts_tips
     % set tippee_name = tippee.friendly_name if tippee_is_stub else tippee.username
-    % set tip = tip or user.get_tip_to(tippee_p, currency)
+    % set tip = tip or user.get_tip_to(tippee_p, form_currency or currency)
     % set tip_currency = tip.amount.currency
     % set new_currency, accepted_currencies = user.get_currencies_for(tippee, tip)
+    % if form_currency in accepted_currencies
+        % set new_currency = form_currency
+    % endif
     % if not tippee_is_stub
         % set patron_countries = tippee.recipient_settings.patron_countries
         % set source_country = request.source_country
@@ -59,8 +63,12 @@
     <form action="/~{{ assert(tip.tippee) }}/tip" method="POST" class="your-tip">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <input type="hidden" name="currency" value="{{ new_currency }}" />
+        % if form_error
+            <p class="alert alert-danger">{{ form_error }}</p>
+        % endif
         <div class="form-group">
-            {{ tip_select(tip, new_currency, tippee, disabled) }}
+            {{ tip_select(tip, new_currency, tippee, disabled, period, periodic_amount,
+                          renewal_mode, visibility) }}
         </div>
     </form>
     % if len(accepted_currencies) > 1
@@ -103,7 +111,7 @@
                    class="amount form-control"
                    data-required-if-checked="#custom-amount-radio"
                    value="{{ locale.format_money(periodic_amount, format='amount_only')
-                             if periodic_amount else '' }}"
+                             if periodic_amount is not none else '' }}"
                    {{ disabled }} />
         </div>
         % set period = request.qs.get('period') or period or 'weekly'
@@ -123,12 +131,17 @@
     </div>
 % endmacro
 
-% macro tip_select(tip, new_currency, tippee, disabled='')
+% macro tip_select(tip, new_currency, tippee, disabled='', period=None, periodic_amount=None,
+                   renewal_mode=None, visibility=None)
     % set tippee_is_stub = tippee.__class__.__name__ == 'AccountElsewhere'
     % set tippee_p = tippee.participant if tippee_is_stub else tippee
     % set pledging = tippee_p.payment_providers == 0 or not tippee_p.accepts_tips
     % set tippee_name = tippee.friendly_name if tippee_is_stub else tippee.username
     % set tip_is_standard = []
+    % set has_custom_amount = periodic_amount is not none
+    % if renewal_mode is none
+        % set renewal_mode = tip.renewal_mode
+    % endif
     <ul class="list-group radio-group">
     % set tip_amount_in_new_currency = tip.amount.convert(new_currency)
     % for std_tip in constants.STANDARD_TIPS[new_currency]
@@ -140,7 +153,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="selected_amount" value="{{ std_tip.weekly.amount }}"
-                   {{ 'checked' if amount_is_a_match }} />
+                   {{ 'checked' if amount_is_a_match and not has_custom_amount }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _(std_tip.label) }}</h5>
                 <p class="list-group-item-text">{{ _(
@@ -153,20 +166,22 @@
         </label>
         </li>
     % endfor
-        % set period = request.qs.get('period') or tip.period
+        % set period = period or request.qs.get('period') or tip.period
         % set querystring_amount = (
             request.qs.get_money_amount('amount', new_currency, default=None)
             if new_currency == request.qs.get('currency') else
             None
         )
         % set periodic_amount = (
-            None if tip_is_standard else
-            tip.periodic_amount.convert(new_currency) or querystring_amount
+            periodic_amount if has_custom_amount else (
+                None if tip_is_standard else
+                tip.periodic_amount.convert(new_currency) or querystring_amount
+            )
         )
         <li class="list-group-item">
         <label>
             <input type="radio" id="custom-amount-radio" name="selected_amount" value="custom" required
-                   {{ 'checked' if periodic_amount else '' }} />
+                   {{ 'checked' if periodic_amount is not none else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Custom") }}</h5>
                 {{ tip_input(new_currency, period, periodic_amount, disabled) }}
@@ -182,7 +197,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="renewal_mode" value="2" required
-                   {{ 'checked' if tip.renewal_mode == 2 else '' }} />
+                   {{ 'checked' if renewal_mode == 2 else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Automatic renewal") }}</h5>
                 <p class="list-group-item-text">{{ _(
@@ -194,7 +209,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="renewal_mode" value="1" required
-                   {{ 'checked' if tip.renewal_mode == 1 else '' }} />
+                   {{ 'checked' if renewal_mode == 1 else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Manual renewal") }}</h5>
                 <p class="list-group-item-text">{{ _(
@@ -208,7 +223,8 @@
         tippee_name,
         tippee_p.recipient_settings.patron_visibilities,
         tippee_p.payment_providers,
-        tip
+        tip,
+        visibility
     ) }}
     <br>
     <button class="btn btn-primary btn-lg btn-block" {{ disabled }}>{{
@@ -233,7 +249,10 @@
     % endif
 % endmacro
 
-% macro tip_visibility_choice(tippee_name, patron_visibilities, payment_providers, tip)
+% macro tip_visibility_choice(tippee_name, patron_visibilities, payment_providers, tip, visibility=None)
+    % if visibility is none
+        % set visibility = tip.visibility
+    % endif
     % set paypal_only = payment_providers == 2
     % if paypal_only
         % if not patron_visibilities
@@ -267,7 +286,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="visibility" value="1" required
-                   {{ 'checked' if tip.visibility == 1 else '' }} />
+                   {{ 'checked' if visibility == 1 else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Secret donation") }}</h5>
                 <p class="list-group-item-text">{{ _(
@@ -282,7 +301,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="visibility" value="2" required
-                   {{ 'checked' if tip.visibility == 2 else '' }} />
+                   {{ 'checked' if visibility == 2 else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Private donation") }}</h5>
                 <p class="list-group-item-text">{{ _(
@@ -297,7 +316,7 @@
         <li class="list-group-item">
         <label>
             <input type="radio" name="visibility" value="3" required
-                   {{ 'checked' if tip.visibility == 3 else '' }} />
+                   {{ 'checked' if visibility == 3 else '' }} />
             <div class="radio-label">
                 <h5 class="list-group-item-heading">{{ _("Public donation") }}</h5>
                 <p class="list-group-item-text">{{ _(

--- a/tests/py/test_donating.py
+++ b/tests/py/test_donating.py
@@ -76,7 +76,8 @@ class TestDonating(Harness):
         assert tip.visibility == 3
 
     def test_donation_form_v2_enforces_amount_limits(self):
-        self.make_participant('creator', accepted_currencies=None)
+        creator = self.make_participant('creator', accepted_currencies=None)
+        creator.update_recipient_settings(patron_visibilities=7)
         donor = self.make_participant('donor')
         r = self.client.PxST(
             '/creator/tip',
@@ -113,3 +114,129 @@ class TestDonating(Harness):
         )
         assert r.code == 400
         assert r.__class__.__name__ == 'InvalidNumber'
+
+        r = self.client.PxST(
+            '/creator/tip.json',
+            {
+                'currency': 'USD',
+                'selected_amount': 'custom',
+                'period': 'monthly',
+                'amount': '1111',
+                'renewal_mode': '1',
+            },
+            auth_as=donor,
+        )
+        assert r.code == 400
+        assert r.__class__.__name__ == 'BadAmount'
+
+        r = self.client.POST(
+            '/creator/tip',
+            {
+                'currency': 'USD',
+                'selected_amount': 'custom',
+                'period': 'monthly',
+                'amount': '1111',
+                'renewal_mode': '1',
+                'visibility': '3',
+            },
+            auth_as=donor,
+        )
+        assert r.code == 400
+        assert '$1,111.00' in r.text
+        assert 'not a valid monthly donation amount' in r.text
+        currency_values = {
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='currency']")
+        }
+        assert currency_values == {'USD'}
+        assert ' name="period" value="monthly" checked' in r.text
+        assert ' value="1,111.00"' in r.text
+        checked_renewal_modes = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='renewal_mode']")
+            if 'checked' in i.attrib
+        ]
+        assert checked_renewal_modes == ['1']
+        checked_visibilities = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='visibility']")
+            if 'checked' in i.attrib
+        ]
+        assert checked_visibilities == ['3']
+
+    def test_donation_form_v2_rejects_custom_amounts_in_unsupported_currency(self):
+        self.make_participant('creator', accepted_currencies='USD')
+        donor = self.make_participant('donor')
+
+        r = self.client.PxST(
+            '/creator/tip',
+            {
+                'currency': 'KRW',
+                'selected_amount': 'custom',
+                'period': 'monthly',
+                'amount': '1111111',
+                'renewal_mode': '1',
+            },
+            auth_as=donor,
+        )
+
+        assert r.code == 400
+        assert r.__class__.__name__ == 'BadAmount'
+
+    def test_donation_form_v2_preserves_hidden_visibility_on_error(self):
+        creator = self.make_participant('creator', accepted_currencies=None)
+        creator.update_recipient_settings(patron_visibilities=2)
+        donor = self.make_participant('donor')
+
+        r = self.client.POST(
+            '/creator/tip',
+            {
+                'currency': 'USD',
+                'selected_amount': 'custom',
+                'period': 'monthly',
+                'amount': '1111',
+                'renewal_mode': '1',
+                'visibility': '3',
+            },
+            auth_as=donor,
+        )
+
+        assert r.code == 400
+        hidden_visibilities = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='visibility']")
+            if i.attrib['type'] == 'hidden'
+        ]
+        assert hidden_visibilities == ['2']
+
+    def test_donation_form_v2_preserves_custom_amount_over_standard_tip_on_error(self):
+        creator = self.make_participant('creator', accepted_currencies=None)
+        creator.update_recipient_settings(patron_visibilities=7)
+        donor = self.make_participant('donor')
+        donor.set_tip_to(creator, USD('1.00'), renewal_mode=1, visibility=2)
+
+        r = self.client.POST(
+            '/creator/tip',
+            {
+                'currency': 'USD',
+                'selected_amount': 'custom',
+                'period': 'monthly',
+                'amount': '1111',
+                'renewal_mode': '2',
+                'visibility': '3',
+            },
+            auth_as=donor,
+        )
+
+        assert r.code == 400
+        checked_amounts = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='selected_amount']")
+            if 'checked' in i.attrib
+        ]
+        assert checked_amounts == ['custom']
+        checked_renewal_modes = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='renewal_mode']")
+            if 'checked' in i.attrib
+        ]
+        assert checked_renewal_modes == ['2']
+        checked_visibilities = [
+            i.attrib['value'] for i in r.html_tree.findall(".//{*}input[@name='visibility']")
+            if 'checked' in i.attrib
+        ]
+        assert checked_visibilities == ['3']

--- a/www/%username/tip.spt
+++ b/www/%username/tip.spt
@@ -2,7 +2,7 @@
 """
 from base64 import b64encode
 
-from liberapay.exceptions import AuthRequired
+from liberapay.exceptions import AuthRequired, BadAmount
 from liberapay.models.participant import Participant
 from liberapay.utils import b64encode_s, get_participant
 
@@ -24,6 +24,12 @@ del _
 [-----------------------------------------------------------------------------]
 
 out = {}
+form_error = None
+form_currency = None
+form_period = None
+form_periodic_amount = None
+form_renewal_mode = None
+form_visibility = None
 
 # Get tipper and tippee.
 # ======================
@@ -54,10 +60,10 @@ if tippee.status == 'stub':
 if request.method == 'POST':
     user.require_write_permission()
     currency = request.body.get_currency('currency', 'EUR')
-    amount = request.body.get('selected_amount')
-    if amount and amount != 'custom':
+    selected_amount = request.body.get('selected_amount')
+    if selected_amount and selected_amount != 'custom':
         period = 'weekly'
-        amount = Money(amount, currency)
+        amount = Money(selected_amount, currency)
     else:
         period = request.body['period']
         if period not in constants.PERIOD_CONVERSION_RATES:
@@ -69,31 +75,45 @@ if request.method == 'POST':
             raise response.error(400, _("The donation amount is missing."))
     renewal_mode = request.body.get_int('renewal_mode', default=1, minimum=1, maximum=2)
     visibility = request.body.get_int('visibility', default=None, minimum=1, maximum=3)
-    out = tipper.set_tip_to(tippee, amount, period, renewal_mode=renewal_mode, visibility=visibility)
-    if not out:
-        raise response.error(400, _("This donation doesn't exist or has already been stopped."))
-    if out['renewal_mode'] == 0:
-        out["msg"] = _("Your donation to {0} has been stopped.", tippee_name)
+    try:
+        out = tipper.set_tip_to(tippee, amount, period, renewal_mode=renewal_mode, visibility=visibility)
+    except BadAmount as e:
+        if (selected_amount != 'custom' or output.media_type == 'application/json' or
+            currency not in tippee.accepted_currencies_set):
+            raise
+        response.code = e.code
+        form_error = e.render_body(state)
+        form_currency = currency
+        form_period = period
+        form_periodic_amount = amount
+        form_renewal_mode = renewal_mode
+        form_visibility = visibility
+        out = tipper.get_tip_to(tippee)
     else:
-        messages = PLEDGE_MESSAGES if out['is_pledge'] else DONATION_MESSAGES
-        msg = messages[out['period']]
-        out["msg"] = _(msg, out['periodic_amount'], tippee_name)
-    if output.media_type != 'application/json':
-        back_to = request.body.get('back_to') or tipper.path('giving/')
-        back_to += '&' if '?' in back_to else '?'
-        back_to += 'success=' + b64encode_s(out["msg"])
-        awaiting_payment = (
-            out['renewal_mode'] > 0 and
-            not out['is_funded'] and
-            not out['is_pledge'] and
-            tippee.accepts_tips and
-            out['pending_payins_count'] == 0
-        )
-        if awaiting_payment:
-            response.redirect(
-                tipper.path('giving/pay/') + '?beneficiary=' + str(tippee.id)
+        if not out:
+            raise response.error(400, _("This donation doesn't exist or has already been stopped."))
+        if out['renewal_mode'] == 0:
+            out["msg"] = _("Your donation to {0} has been stopped.", tippee_name)
+        else:
+            messages = PLEDGE_MESSAGES if out['is_pledge'] else DONATION_MESSAGES
+            msg = messages[out['period']]
+            out["msg"] = _(msg, out['periodic_amount'], tippee_name)
+        if output.media_type != 'application/json':
+            back_to = request.body.get('back_to') or tipper.path('giving/')
+            back_to += '&' if '?' in back_to else '?'
+            back_to += 'success=' + b64encode_s(out["msg"])
+            awaiting_payment = (
+                out['renewal_mode'] > 0 and
+                not out['is_funded'] and
+                not out['is_pledge'] and
+                tippee.accepts_tips and
+                out['pending_payins_count'] == 0
             )
-        response.redirect(back_to, trusted_url=False)
+            if awaiting_payment:
+                response.redirect(
+                    tipper.path('giving/pay/') + '?beneficiary=' + str(tippee.id)
+                )
+            response.redirect(back_to, trusted_url=False)
 else:
     out = tipper.get_tip_to(tippee)
 
@@ -114,7 +134,16 @@ if 'ctime' not in out:
 % extends "templates/layouts/base-thin.html"
 
 % block thin_content
-    <p class="alert alert-danger">These aren't the droids you're looking for.</p>
+    % if form_error
+        % from 'templates/macros/your-tip.html' import tip_form with context
+        <h2>{{ _("Donate to {0}", tippee_name) }}</h2>
+        {{ tip_form(tippee=tippee, tip=out, form_error=form_error,
+                    form_currency=form_currency, period=form_period,
+                    periodic_amount=form_periodic_amount,
+                    renewal_mode=form_renewal_mode, visibility=form_visibility) }}
+    % else
+        <p class="alert alert-danger">These aren't the droids you're looking for.</p>
+    % endif
 % endblock
 
 [---] application/json via json_dump


### PR DESCRIPTION
## Summary
- keep the per-recipient donation cap unchanged while handling invalid custom donation amounts in the form flow
- render the donation form with an inline validation error instead of falling through to the generic Bad Request page
- preserve the submitted custom amount, currency, period, renewal mode, and visibility after validation fails
- avoid checking both a preset amount and the custom amount when an existing donation matches a preset
- keep JSON/tampered preset/unsupported currency submissions on the existing error path instead of rendering the HTML form

## Tests
- `PYTHONTZPATH="$PWD/env/lib/python3.12/site-packages/tzdata/zoneinfo" env/bin/python3.12 cli/run.py -e defaults.env,tests/test.env,tests/local.env -s PYTHONPATH=. env/bin/python3.12 -m pytest -Wd -q tests/py/test_donating.py`
- `PYTHONTZPATH="$PWD/env/lib/python3.12/site-packages/tzdata/zoneinfo" env/bin/python3.12 cli/run.py -e defaults.env,tests/test.env,tests/local.env -s PYTHONPATH=. env/bin/python3.12 -m pytest -Wd -q tests/py/test_pages.py tests/py/test_elsewhere.py tests/py/test_tips_json.py tests/py/test_tip_json.py`
- `env/bin/python3.12 -m ruff check tests/py/test_donating.py`
- `git diff --check`